### PR TITLE
replace deprecated option --Xbonsai-limit-trie-logs-enabled

### DIFF
--- a/docker/besu-follower/config.toml
+++ b/docker/besu-follower/config.toml
@@ -36,6 +36,6 @@ metrics-port=9545
 
 # database
 data-storage-format="BONSAI"
-Xbonsai-limit-trie-logs-enabled=false
+bonsai-limit-trie-logs-enabled=false
 bonsai-historical-block-limit=1024
 fast-sync-min-peers=1

--- a/docker/sequencer/config.toml
+++ b/docker/sequencer/config.toml
@@ -35,6 +35,6 @@ metrics-port=9545
 
 # database
 data-storage-format="BONSAI"
-Xbonsai-limit-trie-logs-enabled=false
+bonsai-limit-trie-logs-enabled=false
 bonsai-historical-block-limit=1024
 Xsnapsync-server-enabled=true


### PR DESCRIPTION
- `--Xbonsai-limit-trie-logs-enabled` is deprecated, use `--bonsai-limit-trie-logs-enabled` instead.
