### PR TITLE
Upgrade Besu to 25.3.0

### DIFF
--- a/consensus/src/main/kotlin/maru/consensus/dummy/DummyConsensusEventHandler.kt
+++ b/consensus/src/main/kotlin/maru/consensus/dummy/DummyConsensusEventHandler.kt
@@ -38,6 +38,9 @@ class DummyConsensusEventHandler(
   override fun start() {
   }
 
+  override fun stop() {
+  }
+
   override fun handleMessageEvent(p0: BftReceivedMessageEvent) {
     TODO("Unexpected because there should be no peers yet")
   }

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adaptors/QbftBlockCodecAdaptor.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adaptors/QbftBlockCodecAdaptor.kt
@@ -18,7 +18,6 @@ package maru.consensus.qbft.adaptors
 import maru.serialization.rlp.RLPSerializers.BeaconBlockSerializer
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCodec
-import org.hyperledger.besu.consensus.qbft.core.types.QbftHashMode
 import org.hyperledger.besu.ethereum.rlp.RLPInput
 import org.hyperledger.besu.ethereum.rlp.RLPOutput
 
@@ -26,10 +25,7 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput
  * Adaptor for QBFT block codec, this provides a way to serialize QBFT blocks
  */
 class QbftBlockCodecAdaptor : QbftBlockCodec {
-  override fun readFrom(
-    rlpInput: RLPInput,
-    qbftHashMode: QbftHashMode,
-  ): QbftBlock = QbftBlockAdaptor(BeaconBlockSerializer.readFrom(rlpInput))
+  override fun readFrom(rlpInput: RLPInput): QbftBlock = QbftBlockAdaptor(BeaconBlockSerializer.readFrom(rlpInput))
 
   override fun writeTo(
     qbftBlock: QbftBlock,

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adaptors/QbftBlockInterfaceAdaptor.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adaptors/QbftBlockInterfaceAdaptor.kt
@@ -15,12 +15,9 @@
  */
 package maru.consensus.qbft.adaptors
 
-import maru.consensus.qbft.adaptors.toBeaconBlock
-import maru.consensus.qbft.adaptors.toBeaconBlockHeader
 import maru.core.BeaconBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockInterface
-import org.hyperledger.besu.consensus.qbft.core.types.QbftHashMode
 
 /**
  * Adaptor class for QBFT block interface, this provides a way to replace the round number in a block
@@ -29,7 +26,6 @@ class QbftBlockInterfaceAdaptor : QbftBlockInterface {
   override fun replaceRoundInBlock(
     proposalBlock: QbftBlock,
     roundNumber: Int,
-    hashMode: QbftHashMode,
   ): QbftBlock {
     val beaconBlockHeader = proposalBlock.header.toBeaconBlockHeader()
     val replacedBeaconBlockHeader =

--- a/consensus/src/test/kotlin/maru/consensus/adaptors/QbftBlockCodecAdaptorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/adaptors/QbftBlockCodecAdaptorTest.kt
@@ -19,30 +19,18 @@ import maru.consensus.qbft.adaptors.QbftBlockAdaptor
 import maru.consensus.qbft.adaptors.QbftBlockCodecAdaptor
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat
-import org.hyperledger.besu.consensus.qbft.core.types.QbftHashMode
 import org.hyperledger.besu.ethereum.rlp.RLP
 import org.junit.jupiter.api.Test
 
 class QbftBlockCodecAdaptorTest {
   @Test
-  fun `can encode and decode same value for committed seal`() {
+  fun `can encode and decode same value`() {
     val beaconBlock = DataGenerators.randomBeaconBlock(10U)
     val testValue = QbftBlockAdaptor(beaconBlock)
     val qbftBlockCodecAdaptor = QbftBlockCodecAdaptor()
 
     val encodedData = RLP.encode { rlpOutput -> qbftBlockCodecAdaptor.writeTo(testValue, rlpOutput) }
-    val decodedValue = qbftBlockCodecAdaptor.readFrom(RLP.input(encodedData), QbftHashMode.COMMITTED_SEAL)
-    assertThat(decodedValue).isEqualTo(testValue)
-  }
-
-  @Test
-  fun `can encode and decode same value for onchain`() {
-    val beaconBlock = DataGenerators.randomBeaconBlock(10U)
-    val testValue = QbftBlockAdaptor(beaconBlock)
-    val qbftBlockCodecAdaptor = QbftBlockCodecAdaptor()
-
-    val encodedData = RLP.encode { rlpOutput -> qbftBlockCodecAdaptor.writeTo(testValue, rlpOutput) }
-    val decodedValue = qbftBlockCodecAdaptor.readFrom(RLP.input(encodedData), QbftHashMode.ONCHAIN)
+    val decodedValue = qbftBlockCodecAdaptor.readFrom(RLP.input(encodedData))
     assertThat(decodedValue).isEqualTo(testValue)
   }
 }

--- a/consensus/src/test/kotlin/maru/consensus/adaptors/QbftBlockInterfaceAdaptorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/adaptors/QbftBlockInterfaceAdaptorTest.kt
@@ -20,7 +20,6 @@ import maru.consensus.qbft.adaptors.QbftBlockInterfaceAdaptor
 import maru.consensus.qbft.adaptors.toBeaconBlockHeader
 import maru.core.BeaconBlock
 import maru.core.ext.DataGenerators
-import org.hyperledger.besu.consensus.qbft.core.types.QbftHashMode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -34,7 +33,7 @@ class QbftBlockInterfaceAdaptorTest {
       )
     val qbftBlock = QbftBlockAdaptor(beaconBlock)
     val updatedBlock =
-      QbftBlockInterfaceAdaptor().replaceRoundInBlock(qbftBlock, 20, QbftHashMode.COMMITTED_SEAL)
+      QbftBlockInterfaceAdaptor().replaceRoundInBlock(qbftBlock, 20)
     val updatedBeaconBlockHeader = updatedBlock.header.toBeaconBlockHeader()
     assertEquals(updatedBeaconBlockHeader.round, 20UL)
   }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -140,7 +140,7 @@ dependencyManagement {
       entry 'log4j-slf4j2-impl'
     }
 
-    def besuVersion = "25.2.2"
+    def besuVersion = "25.3.0"
 
     imports {
       mavenBom "org.hyperledger.besu:bom:$besuVersion"


### PR DESCRIPTION
Upgrades Besu to 25.3.0

Most changes don't affect the current code, but there are some changes to
- Remove HashMode from QBFT
- Addition of stop method to BftEventHandler as event handlers can now be started and stopped with Ibft to Qbft migration code