### PR TITLE
Removed mergenetsplitblock from Geth and Besu genesis files. Nethermi…

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -71,7 +71,7 @@ jobs:
           java-version: 21
       - name: Run e2e tests
         id: run_e2e_tests
-        timeout-minutes: 6
+        timeout-minutes: 8
         run: |
           make run-e2e-test
       - name: Show e2e tests result

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -40,7 +40,6 @@ services:
       - ./initialization/:/initialization/:ro
     ports:
       - "8545:8545"
-      - "8546:8546"
       - "8550:8550"
       - "8551:8551"
       - "30303:30303"
@@ -63,7 +62,6 @@ services:
       - ./jwt:/jwt:ro
     ports:
       - "8555:8545"
-      - "8556:8546"
       - "8561:8551"
     networks:
       - linea
@@ -88,7 +86,6 @@ services:
       - ./jwt:/jwt:ro
     ports:
       - "8565:8545"
-      - "8566:8546"
       - "8571:8551"
     networks:
       - linea
@@ -118,7 +115,6 @@ services:
       - ./initialization/:/initialization/:ro
     ports:
       - "9545:8545"
-      - "9546:8546"
       - "9550:8550"
       - "9551:8551"
     networks:
@@ -138,7 +134,6 @@ services:
       - ./jwt:/nethermind/keystore/jwt-secret:ro
     ports:
       - "10545:8545"
-      - "10546:8546"
       - "10550:8550"
     networks:
       - linea
@@ -154,7 +149,6 @@ services:
       BOOTNODES: "enode://14408801a444dafc44afbccce2eb755f902aed3b5743fed787b3c790e021fef28b8c827ed896aa4e8fb46e22bd67c39f994a73768b4b382f8597b0d44370e15d@11.11.11.101:30303"
     ports:
       - "11545:8545"
-      - "11546:8546"
       - "11551:8551"
     volumes:
       # It's ok to mount sub-dirs of "datadir" to different drives

--- a/docker/initialization/genesis-besu.json.template
+++ b/docker/initialization/genesis-besu.json.template
@@ -12,7 +12,6 @@
     "istanbulBlock": 0,
     "berlinBlock": 0,
     "londonBlock": 0,
-    "mergenetsplitblock": 6,
     "terminalTotalDifficulty": 10,
     "shanghaiTime": %SWITCH_TIME%,
     "cancunTime": %SWITCH_TIME%,

--- a/docker/initialization/genesis-geth.json.template
+++ b/docker/initialization/genesis-geth.json.template
@@ -14,7 +14,6 @@
     "londonBlock": 0,
     "arrowGlacierBlock": 0,
     "grayGlacierBlock": 0,
-    "MergeNetsplitBlock": 6,
     "terminalTotalDifficulty": 10,
     "shanghaiTime": %SWITCH_TIME%,
     "cancunTime": %SWITCH_TIME%,

--- a/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
+++ b/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
@@ -155,10 +155,19 @@ class CliqueToPosTest {
     restartNodeFromScratch(nodeName, nodeEthereumClient)
     log.info("Container $nodeName restarted")
 
-    await
-      .pollInterval(10.seconds.toJavaDuration())
+    val awaitCondition =
+      if (nodeName.contains("nethermind")) {
+        await
+          .pollInterval(10.seconds.toJavaDuration())
+          .timeout(60.seconds.toJavaDuration())
+      } else {
+        await
+          .pollInterval(1.seconds.toJavaDuration())
+          .timeout(30.seconds.toJavaDuration())
+      }
+
+    awaitCondition
       .ignoreExceptions()
-      .timeout(60.seconds.toJavaDuration())
       .alias(nodeName)
       .untilAsserted {
         if (nodeName.contains("erigon") || nodeName.contains("nethermind")) {

--- a/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
+++ b/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
@@ -115,13 +115,9 @@ class CliqueToPosTest {
 
     @JvmStatic
     fun followerNodes(): List<Arguments> =
-      TestEnvironment.followerExecutionClientsPostMerge
-        .filter {
-          // Doesn't work just yet
-          !it.key.contains("nethermind")
-        }.map {
-          Arguments.of(it.key, it.value)
-        }
+      TestEnvironment.followerExecutionClientsPostMerge.map {
+        Arguments.of(it.key, it.value)
+      }
   }
 
   @Order(1)
@@ -160,12 +156,12 @@ class CliqueToPosTest {
     log.info("Container $nodeName restarted")
 
     await
-      .pollInterval(1.seconds.toJavaDuration())
+      .pollInterval(10.seconds.toJavaDuration())
       .ignoreExceptions()
-      .timeout(20.seconds.toJavaDuration())
+      .timeout(60.seconds.toJavaDuration())
       .alias(nodeName)
       .untilAsserted {
-        if (nodeName.contains("erigon")) {
+        if (nodeName.contains("erigon") || nodeName.contains("nethermind")) {
           // For some reason Erigon needs a restart after PoS transition
           restartNodeKeepingState(nodeName, nodeEthereumClient)
         }
@@ -227,6 +223,7 @@ class CliqueToPosTest {
     val expectedBlockNumber =
       when {
         nodeName.contains("erigon") -> 5L
+        nodeName.contains("nethermind") -> 5L
         else -> 0L
       }
     await


### PR DESCRIPTION
…nd now syncs from scratch.

The issue was that `mergenetsplitblock` field in Geth and Besu genesis configs prevented Nethermind from synching, which needs `MergeForkIdTransition`. So I removed it completely, since it's not necessarily known in advance before the switch. 