### PR TITLE
Setting fixed Geth 1.15 tag, as the latest one doesn't work

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -51,7 +51,7 @@ services:
     depends_on:
       sequencer:
         condition: service_healthy
-    image: ethereum/client-go:release-1.15
+    image: ethereum/client-go:v1.15.7
     restart: always
     entrypoint: [ "sh", "/scripts/node.sh", "1337", "/initialization/genesis-geth.json", "0x0", "0x1C9C380", "/data" ]
     environment:


### PR DESCRIPTION
Since Geth release 1.15.8 E2E tests dont work, because Geth doesn't sync. Setting the image tag to 1.15.7 to fix it