### PR TITLE
[135] Preparations for the Fork Id computation. Moved feeRecipient out of Maru's genesis file

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppCli.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppCli.kt
@@ -22,6 +22,7 @@ import com.sksamuel.hoplite.addFileSource
 import java.io.File
 import java.util.concurrent.Callable
 import maru.config.MaruConfigDtoToml
+import maru.config.QbftOptionsDecoder
 import maru.consensus.config.ForkConfigDecoder
 import maru.consensus.config.JsonFriendlyForksSchedule
 import org.apache.logging.log4j.LogManager
@@ -47,9 +48,9 @@ class MaruAppCli : Callable<Int> {
     inline fun <reified T : Any> loadConfig(configFiles: List<File>): ConfigResult<T> {
       val confBuilder: ConfigLoaderBuilder =
         ConfigLoaderBuilder.Companion
-          .empty()
-          .addDecoder(ForkConfigDecoder())
-          .addDefaults()
+          .default()
+          .addDecoder(QbftOptionsDecoder)
+          .addDecoder(ForkConfigDecoder)
           .withExplicitSealedTypes()
       for (configFile in configFiles.reversed()) {
         // files must be added in reverse order for overriding

--- a/app/src/main/kotlin/maru/app/QbftFollowerFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftFollowerFactory.kt
@@ -15,6 +15,7 @@
  */
 package maru.app
 
+import maru.config.ValidatorElNode
 import maru.consensus.ForkSpec
 import maru.consensus.NewBlockHandler
 import maru.consensus.ProtocolFactory
@@ -37,7 +38,7 @@ class QbftFollowerFactory(
   val p2PNetwork: P2PNetwork,
   val beaconChain: BeaconChain,
   val newBlockHandler: NewBlockHandler<*>,
-  val validatorElNodeConfig: maru.config.ValidatorElNode,
+  val validatorElNodeConfig: ValidatorElNode,
   val beaconChainInitialization: BeaconChainInitialization,
 ) : ProtocolFactory {
   override fun create(forkSpec: ForkSpec): Protocol {

--- a/app/src/test/kotlin/maru/testutils/MaruFactory.kt
+++ b/app/src/test/kotlin/maru/testutils/MaruFactory.kt
@@ -36,6 +36,7 @@ import maru.consensus.ForksSchedule
 import maru.consensus.config.Utils
 import maru.crypto.Crypto
 import maru.extensions.encodeHex
+import maru.extensions.fromHexToByteArray
 import maru.p2p.NoOpP2PNetwork
 import maru.p2p.P2PNetwork
 
@@ -62,13 +63,13 @@ class MaruFactory {
           "type": "qbft",
           "blockTimeSeconds": 1,
           "validatorSet": ["$validatorAddress"],
-          "feeRecipient": "$validatorAddress",
           "elFork": "Prague"
         }
       }
     }
 
     """.trimIndent()
+  private val validatorQbftOptions = QbftOptions(feeRecipient = validatorAddress.fromHexToByteArray())
 
   private val beaconGenesisConfig: ForksSchedule =
     run {
@@ -135,7 +136,7 @@ class MaruFactory {
         ethereumJsonRpcUrl = ethereumJsonRpcUrl,
         engineApiRpc = engineApiRpc,
         dataDir = dataDir,
-        qbftOptions = QbftOptions(),
+        qbftOptions = validatorQbftOptions,
       )
     writeValidatorPrivateKey(config)
     return buildApp(config, p2pNetwork = p2pNetwork)
@@ -156,7 +157,7 @@ class MaruFactory {
         dataDir = dataDir,
         p2pConfig = p2pConfig,
         followers = FollowersConfig(emptyMap()),
-        qbftOptions = QbftOptions(),
+        qbftOptions = validatorQbftOptions,
       )
     writeValidatorPrivateKey(config)
     return buildApp(config = config, p2pNetwork = p2pNetwork)
@@ -210,7 +211,7 @@ class MaruFactory {
         ethereumJsonRpcUrl = ethereumJsonRpcUrl,
         engineApiRpc = engineApiRpc,
         dataDir = dataDir,
-        qbftOptions = QbftOptions(),
+        qbftOptions = validatorQbftOptions,
       )
     writeValidatorPrivateKey(config)
     val genesisContent =

--- a/config/src/main/kotlin/maru.config/Config.kt
+++ b/config/src/main/kotlin/maru.config/Config.kt
@@ -74,7 +74,43 @@ data class QbftOptions(
   val duplicateMessageLimit: Int = 100,
   val futureMessageMaxDistance: Long = 10L,
   val futureMessagesLimit: Long = 1000L,
-)
+  val feeRecipient: ByteArray,
+) {
+  init {
+    require(feeRecipient.size == 20) {
+      "feesRecipient address must be 20 bytes long, " +
+        "but it's ${feeRecipient.size} bytes long!"
+    }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as QbftOptions
+
+    if (messageQueueLimit != other.messageQueueLimit) return false
+    if (duplicateMessageLimit != other.duplicateMessageLimit) return false
+    if (futureMessageMaxDistance != other.futureMessageMaxDistance) return false
+    if (futureMessagesLimit != other.futureMessagesLimit) return false
+    if (minBlockBuildTime != other.minBlockBuildTime) return false
+    if (roundExpiry != other.roundExpiry) return false
+    if (!feeRecipient.contentEquals(other.feeRecipient)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = messageQueueLimit
+    result = 31 * result + duplicateMessageLimit
+    result = 31 * result + futureMessageMaxDistance.hashCode()
+    result = 31 * result + futureMessagesLimit.hashCode()
+    result = 31 * result + minBlockBuildTime.hashCode()
+    result = 31 * result + roundExpiry.hashCode()
+    result = 31 * result + feeRecipient.contentHashCode()
+    return result
+  }
+}
 
 data class MaruConfig(
   val persistence: Persistence,

--- a/config/src/main/kotlin/maru.config/Config.kt
+++ b/config/src/main/kotlin/maru.config/Config.kt
@@ -78,7 +78,7 @@ data class QbftOptions(
 ) {
   init {
     require(feeRecipient.size == 20) {
-      "feesRecipient address must be 20 bytes long, " +
+      "feeRecipient address must be 20 bytes long, " +
         "but it's ${feeRecipient.size} bytes long!"
     }
   }

--- a/config/src/main/kotlin/maru.config/HopliteTomlFriendly.kt
+++ b/config/src/main/kotlin/maru.config/HopliteTomlFriendly.kt
@@ -15,7 +15,21 @@
  */
 package maru.config
 
+import com.sksamuel.hoplite.ConfigFailure
+import com.sksamuel.hoplite.ConfigResult
+import com.sksamuel.hoplite.DecoderContext
+import com.sksamuel.hoplite.Node
+import com.sksamuel.hoplite.decoder.DataClassDecoder
+import com.sksamuel.hoplite.decoder.Decoder
+import com.sksamuel.hoplite.fp.invalid
+import com.sksamuel.hoplite.valueOrNull
 import java.net.URL
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import maru.extensions.fromHexToByteArray
 
 data class PayloadValidatorDto(
   val engineApiEndpoint: ApiEndpointDto,
@@ -33,6 +47,50 @@ data class ApiEndpointDto(
   val jwtSecretPath: String? = null,
 ) {
   fun domainFriendly(): ApiEndpointConfig = ApiEndpointConfig(endpoint = endpoint, jwtSecretPath = jwtSecretPath)
+}
+
+object QbftOptionsDecoder : Decoder<QbftOptions> {
+  // This should be private, but Hoplite won't accept a private data class
+  data class QbftOptionsDtoToml(
+    val minBlockBuildTime: Duration = 500.milliseconds,
+    val messageQueueLimit: Int = 1000,
+    val roundExpiry: Duration = 1.seconds,
+    val duplicateMessageLimit: Int = 100,
+    val futureMessageMaxDistance: Long = 10L,
+    val futureMessagesLimit: Long = 1000L,
+  ) {
+    fun toDomain(feeRecipient: ByteArray): QbftOptions =
+      QbftOptions(
+        minBlockBuildTime = minBlockBuildTime,
+        messageQueueLimit = messageQueueLimit,
+        roundExpiry = roundExpiry,
+        duplicateMessageLimit = duplicateMessageLimit,
+        futureMessageMaxDistance = futureMessageMaxDistance,
+        futureMessagesLimit = futureMessagesLimit,
+        feeRecipient = feeRecipient,
+      )
+  }
+
+  override fun decode(
+    node: Node,
+    type: KType,
+    context: DecoderContext,
+  ): ConfigResult<QbftOptions> {
+    val tomlFriendlyPart = DataClassDecoder().safeDecode(node, QbftOptionsDtoToml::class.createType(), context)
+    val tomlFriendlyPartTyped = tomlFriendlyPart as ConfigResult<QbftOptionsDtoToml>
+    val feeRecipient =
+      try {
+        node.getString("feerecipient").fromHexToByteArray()
+      } catch (throwable: Throwable) {
+        return ConfigFailure.ResolverException("Unable to convert feeRecipient to byteArray!", throwable).invalid()
+      }
+
+    return tomlFriendlyPartTyped.map { it.toDomain(feeRecipient) }
+  }
+
+  private fun Node.getString(key: String): String = this[key].valueOrNull()!!
+
+  override fun supports(type: KType): Boolean = type.classifier == QbftOptions::class
 }
 
 data class MaruConfigDtoToml(

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -22,18 +22,20 @@ import java.net.URI
 import kotlin.io.path.Path
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import maru.extensions.fromHexToByteArray
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalHoplite::class)
 class HopliteFriendlinessTest {
-  private val emptyFollowersConfig =
+  private val emptyFollowersConfigToml =
     """
     [persistence]
     data-path="/some/path"
     private-key-path = "/private-key/path"
 
     [qbft-options]
+    fee-recipient = "0xdead000000000000000000000000000000000000"
 
     [p2p-config]
     port = 3322
@@ -45,199 +47,168 @@ class HopliteFriendlinessTest {
     engine-api-endpoint = { endpoint = "http://localhost:8555", jwt-secret-path = "/secret/path" }
     eth-api-endpoint = { endpoint = "http://localhost:8545" }
     """.trimIndent()
-  private val rawConfig =
+  private val rawConfigToml =
     """
-    $emptyFollowersConfig
+    $emptyFollowersConfigToml
 
     [follower-engine-apis]
     follower1 = { endpoint = "http://localhost:1234", jwt-secret-path = "/secret/path" }
     follower2 = { endpoint = "http://localhost:4321" }
     """.trimIndent()
+  private val dataPath = Path("/some/path")
+  private val privateKeyPath = Path("/private-key/path")
+  private val persistence = Persistence(dataPath, privateKeyPath)
+  private val p2pConfig =
+    P2P(
+      ipAddress = "127.0.0.1",
+      port = 3322u,
+      staticPeers = emptyList(),
+      reconnectDelay = 500.milliseconds,
+    )
+  private val ethApiEndpoint =
+    ApiEndpointConfig(
+      endpoint = URI.create("http://localhost:8545").toURL(),
+    )
+  private val engineApiEndpoint =
+    ApiEndpointConfig(
+      endpoint = URI.create("http://localhost:8555").toURL(),
+      jwtSecretPath = "/secret/path",
+    )
+  private val payloadValidator =
+    PayloadValidatorDto(
+      ethApiEndpoint =
+        ApiEndpointDto(
+          endpoint = URI.create("http://localhost:8545").toURL(),
+        ),
+      engineApiEndpoint =
+        ApiEndpointDto(
+          endpoint = URI.create("http://localhost:8555").toURL(),
+          jwtSecretPath = "/secret/path",
+        ),
+    )
+  private val follower1 =
+    ApiEndpointDto(
+      URI.create("http://localhost:1234").toURL(),
+      jwtSecretPath = "/secret/path",
+    )
+  private val follower2 =
+    ApiEndpointDto(
+      URI.create("http://localhost:4321").toURL(),
+    )
+  private val followersConfig =
+    FollowersConfig(
+      mapOf(
+        "follower1" to ApiEndpointConfig(URI.create("http://localhost:1234").toURL(), "/secret/path"),
+        "follower2" to ApiEndpointConfig(URI.create("http://localhost:4321").toURL()),
+      ),
+    )
+  private val emptyFollowersConfig = FollowersConfig(emptyMap())
+  private val qbftOptions =
+    QbftOptions(
+      minBlockBuildTime = 500.milliseconds,
+      messageQueueLimit = 1000,
+      roundExpiry = 1.seconds,
+      duplicateMessageLimit = 100,
+      futureMessageMaxDistance = 10L,
+      futureMessagesLimit = 1000L,
+      feeRecipient = "0xdead000000000000000000000000000000000000".fromHexToByteArray(),
+    )
 
   @Test
   fun appConfigFileIsParseable() {
-    val config =
-      parseTomlConfig<MaruConfigDtoToml>(rawConfig)
-    assertThat(config)
-      .isEqualTo(
-        MaruConfigDtoToml(
-          persistence = Persistence(dataPath = Path("/some/path"), privateKeyPath = Path("/private-key/path")),
-          qbftOptions =
-            QbftOptions(),
-          p2pConfig =
-            P2P(
-              ipAddress = "127.0.0.1",
-              port = 3322u,
-              staticPeers = emptyList(),
-              reconnectDelay = 500.milliseconds,
-            ),
-          payloadValidator =
-            PayloadValidatorDto(
-              ethApiEndpoint =
-                ApiEndpointDto(
-                  endpoint = URI.create("http://localhost:8545").toURL(),
-                ),
-              engineApiEndpoint =
-                ApiEndpointDto(
-                  endpoint = URI.create("http://localhost:8555").toURL(),
-                  jwtSecretPath = "/secret/path",
-                ),
-            ),
-          followerEngineApis =
-            mapOf(
-              "follower1" to
-                ApiEndpointDto(
-                  URI.create("http://localhost:1234").toURL(),
-                  jwtSecretPath =
-                    "/secret/path",
-                ),
-              "follower2" to ApiEndpointDto(URI.create("http://localhost:4321").toURL()),
-            ),
-        ),
-      )
+    val config = parseTomlConfig<MaruConfigDtoToml>(rawConfigToml)
+    assertThat(config).isEqualTo(
+      MaruConfigDtoToml(
+        persistence = persistence,
+        qbftOptions = qbftOptions,
+        p2pConfig = p2pConfig,
+        payloadValidator = payloadValidator,
+        followerEngineApis = mapOf("follower1" to follower1, "follower2" to follower2),
+      ),
+    )
   }
 
   @Test
   fun supportsEmptyFollowers() {
-    val config =
-      parseTomlConfig<MaruConfigDtoToml>(emptyFollowersConfig)
-    assertThat(config)
-      .isEqualTo(
-        MaruConfigDtoToml(
-          persistence = Persistence(Path("/some/path"), privateKeyPath = Path("/private-key/path")),
-          qbftOptions =
-            QbftOptions(),
-          p2pConfig =
-            P2P(
-              ipAddress = "127.0.0.1",
-              port = 3322u,
-              staticPeers = emptyList(),
-              reconnectDelay = 500.milliseconds,
-            ),
-          payloadValidator =
-            PayloadValidatorDto(
-              ethApiEndpoint =
-                ApiEndpointDto(
-                  endpoint = URI.create("http://localhost:8545").toURL(),
-                ),
-              engineApiEndpoint =
-                ApiEndpointDto(
-                  endpoint = URI.create("http://localhost:8555").toURL(),
-                  jwtSecretPath = "/secret/path",
-                ),
-            ),
-          followerEngineApis = null,
-        ),
-      )
+    val config = parseTomlConfig<MaruConfigDtoToml>(emptyFollowersConfigToml)
+    assertThat(config).isEqualTo(
+      MaruConfigDtoToml(
+        persistence = persistence,
+        qbftOptions = qbftOptions,
+        p2pConfig = p2pConfig,
+        payloadValidator = payloadValidator,
+        followerEngineApis = null,
+      ),
+    )
   }
 
   @Test
   fun appConfigFileIsConvertableToDomain() {
-    val config = parseTomlConfig<MaruConfigDtoToml>(rawConfig)
-    assertThat(config.domainFriendly())
-      .isEqualTo(
-        MaruConfig(
-          persistence = Persistence(Path("/some/path"), privateKeyPath = Path("/private-key/path")),
-          p2pConfig =
-            P2P(
-              ipAddress = "127.0.0.1",
-              port = 3322u,
-              staticPeers = emptyList(),
-              reconnectDelay = 500.milliseconds,
-            ),
-          validatorElNode =
-            ValidatorElNode(
-              engineApiEndpoint =
-                ApiEndpointConfig(
-                  URI.create("http://localhost:8555").toURL(),
-                  jwtSecretPath = "/secret/path",
-                ),
-              ethApiEndpoint =
-                ApiEndpointConfig(
-                  endpoint = URI.create("http://localhost:8545").toURL(),
-                ),
-            ),
-          qbftOptions =
-            QbftOptions(),
-          followers =
-            FollowersConfig(
-              mapOf(
-                "follower1" to ApiEndpointConfig(URI.create("http://localhost:1234").toURL(), "/secret/path"),
-                "follower2" to ApiEndpointConfig(URI.create("http://localhost:4321").toURL()),
-              ),
-            ),
-        ),
-      )
+    val config = parseTomlConfig<MaruConfigDtoToml>(rawConfigToml)
+    assertThat(config.domainFriendly()).isEqualTo(
+      MaruConfig(
+        persistence = persistence,
+        p2pConfig = p2pConfig,
+        validatorElNode =
+          ValidatorElNode(
+            engineApiEndpoint = engineApiEndpoint,
+            ethApiEndpoint = ethApiEndpoint,
+          ),
+        qbftOptions = qbftOptions,
+        followers = followersConfig,
+      ),
+    )
   }
 
   @Test
   fun emptyFollowersAreConvertableToDomain() {
-    val config =
-      parseTomlConfig<MaruConfigDtoToml>(emptyFollowersConfig)
-    assertThat(config.domainFriendly())
-      .isEqualTo(
-        MaruConfig(
-          persistence = Persistence(Path("/some/path"), privateKeyPath = Path("/private-key/path")),
-          qbftOptions =
-            QbftOptions(),
-          p2pConfig =
-            P2P(
-              ipAddress = "127.0.0.1",
-              port = 3322u,
-              staticPeers = emptyList(),
-              reconnectDelay = 500.milliseconds,
-            ),
-          validatorElNode =
-            ValidatorElNode(
-              engineApiEndpoint =
-                ApiEndpointConfig(
-                  URI.create("http://localhost:8555").toURL(),
-                  jwtSecretPath = "/secret/path",
-                ),
-              ethApiEndpoint =
-                ApiEndpointConfig(
-                  endpoint = URI.create("http://localhost:8545").toURL(),
-                ),
-            ),
-          followers =
-            FollowersConfig(
-              emptyMap(),
-            ),
-        ),
-      )
+    val config = parseTomlConfig<MaruConfigDtoToml>(emptyFollowersConfigToml)
+    assertThat(config.domainFriendly()).isEqualTo(
+      MaruConfig(
+        persistence = persistence,
+        qbftOptions = qbftOptions,
+        p2pConfig = p2pConfig,
+        validatorElNode =
+          ValidatorElNode(
+            engineApiEndpoint = engineApiEndpoint,
+            ethApiEndpoint = ethApiEndpoint,
+          ),
+        followers = emptyFollowersConfig,
+      ),
+    )
   }
 
-  private val qbftOptions =
+  private val qbftOptionsToml =
     """
     min-block-build-time=200m
-    data-path="/some/path"
-    message-queue-limit = 1000
-    round-expiry = 1000
-    duplicateMessageLimit = 100
-    future-message-max-distance = 10
-    future-messages-limit = 1000
+    message-queue-limit = 1001
+    round-expiry = 900m
+    duplicateMessageLimit = 99
+    future-message-max-distance = 11
+    future-messages-limit = 100
+    fee-recipient = "0x0000000000000000000000000000000000000001"
     """.trimIndent()
 
   @Test
   fun validatorDutiesAreParseable() {
-    val config =
-      parseTomlConfig<QbftOptions>(qbftOptions)
-    assertThat(config)
-      .isEqualTo(
-        QbftOptions(
-          minBlockBuildTime = 200.milliseconds,
-          messageQueueLimit = 1000,
-          roundExpiry = 1.seconds,
-          duplicateMessageLimit = 100,
-          futureMessageMaxDistance = 10L,
-          futureMessagesLimit = 1000L,
-        ),
-      )
+    val config = parseTomlConfig<QbftOptions>(qbftOptionsToml)
+    assertThat(config).isEqualTo(
+      QbftOptions(
+        minBlockBuildTime = 200.milliseconds,
+        messageQueueLimit = 1001,
+        roundExpiry = 900.milliseconds,
+        duplicateMessageLimit = 99,
+        futureMessageMaxDistance = 11,
+        futureMessagesLimit = 100,
+        feeRecipient = "0x0000000000000000000000000000000000000001".fromHexToByteArray(),
+      ),
+    )
   }
 
   inline fun <reified T : Any> parseTomlConfig(toml: String): T =
     ConfigLoaderBuilder
       .default()
+      .addDecoder(QbftOptionsDecoder)
       .withExplicitSealedTypes()
       .addSource(TomlPropertySource(toml))
       .build()

--- a/consensus/src/main/kotlin/maru/consensus/config/JsonFriendlyForksSchedule.kt
+++ b/consensus/src/main/kotlin/maru/consensus/config/JsonFriendlyForksSchedule.kt
@@ -40,7 +40,7 @@ import maru.consensus.qbft.QbftConsensusConfig
 import maru.core.Validator
 import maru.extensions.fromHexToByteArray
 
-class ForkConfigDecoder : Decoder<JsonFriendlyForksSchedule> {
+object ForkConfigDecoder : Decoder<JsonFriendlyForksSchedule> {
   override fun decode(
     node: Node,
     type: KType,
@@ -78,7 +78,6 @@ class ForkConfigDecoder : Decoder<JsonFriendlyForksSchedule> {
       "delegated" -> ElDelegatedConsensus.ElDelegatedConfig.valid()
       "qbft" ->
         QbftConsensusConfig(
-          feeRecipient = obj.getString("feerecipient").fromHexToByteArray(),
           validatorSet =
             (obj["validatorset"] as ArrayNode)
               .elements

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusConfig.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusConfig.kt
@@ -20,32 +20,6 @@ import maru.consensus.ElFork
 import maru.core.Validator
 
 data class QbftConsensusConfig(
-  val feeRecipient: ByteArray,
   val validatorSet: Set<Validator>,
   val elFork: ElFork,
-) : ConsensusConfig {
-  init {
-    require(feeRecipient.size == 20) {
-      "feesRecipient address must be 20 bytes long, " +
-        "but it's only ${feeRecipient.size} bytes long!"
-    }
-  }
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (javaClass != other?.javaClass) return false
-
-    other as QbftConsensusConfig
-
-    if (!feeRecipient.contentEquals(other.feeRecipient)) return false
-    if (elFork != other.elFork) return false
-
-    return true
-  }
-
-  override fun hashCode(): Int {
-    var result = feeRecipient.contentHashCode()
-    result = 31 * result + elFork.hashCode()
-    return result
-  }
-}
+) : ConsensusConfig

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adapters/ForksScheduleAdapter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adapters/ForksScheduleAdapter.kt
@@ -19,7 +19,6 @@ import java.math.BigInteger
 import java.util.Optional
 import maru.config.QbftOptions
 import maru.consensus.ForkSpec
-import maru.consensus.qbft.QbftConsensusConfig
 import org.apache.tuweni.bytes.Bytes
 import org.hyperledger.besu.config.BftConfigOptions
 import org.hyperledger.besu.datatypes.Address
@@ -63,7 +62,7 @@ class ForksScheduleAdapter(
         override fun getFutureMessagesMaxDistance(): Int = config.futureMessageMaxDistance.toInt()
 
         override fun getMiningBeneficiary(): Optional<Address> =
-          Optional.of(Address.wrap(Bytes.wrap((spec.configuration as QbftConsensusConfig).feeRecipient)))
+          Optional.of(Address.wrap(Bytes.wrap(config.feeRecipient)))
 
         override fun getBlockRewardWei(): BigInteger = BigInteger.ZERO
 

--- a/consensus/src/test/kotlin/maru/consensus/NextBlockTimestampProviderTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/NextBlockTimestampProviderTest.kt
@@ -28,8 +28,8 @@ class NextBlockTimestampProviderTest {
     ForksSchedule(
       chainId,
       listOf(
-        ForkSpec(0, 1, QbftConsensusConfig(ByteArray(20), validatorSet = emptySet(), ElFork.Prague)),
-        ForkSpec(10, 2, QbftConsensusConfig(ByteArray(20), validatorSet = emptySet(), ElFork.Prague)),
+        ForkSpec(0, 1, QbftConsensusConfig(validatorSet = emptySet(), ElFork.Prague)),
+        ForkSpec(10, 2, QbftConsensusConfig(validatorSet = emptySet(), ElFork.Prague)),
       ),
     )
   private val baseLastBlockTimestamp = 9L

--- a/consensus/src/test/kotlin/maru/consensus/config/JsonFriendlyForksScheduleTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/config/JsonFriendlyForksScheduleTest.kt
@@ -22,7 +22,6 @@ import maru.consensus.delegated.ElDelegatedConsensus
 import maru.consensus.qbft.QbftConsensusConfig
 import maru.core.Validator
 import maru.extensions.fromHexToByteArray
-import org.apache.tuweni.bytes.Bytes
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -41,7 +40,6 @@ class JsonFriendlyForksScheduleTest {
           "type": "qbft",
           "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
           "blockTimeSeconds": 6,
-          "feeRecipient": "0x0000000000000000000000000000000000000000",
           "elFork": "Prague"
         }
       }
@@ -69,7 +67,6 @@ class JsonFriendlyForksScheduleTest {
             blockTimeSeconds = 6,
             configuration =
               QbftConsensusConfig(
-                feeRecipient = Bytes.fromHexString("0x0000000000000000000000000000000000000000").toArray(),
                 validatorSet = setOf(Validator("0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0".fromHexToByteArray())),
                 elFork = ElFork.Prague,
               ),
@@ -87,7 +84,6 @@ class JsonFriendlyForksScheduleTest {
         "config": {
           "4": {
             "type": "qbft",
-            "feeRecipient": "0x0000000000000000000000000000000000000000",
             "elFork": "Prague"
           }
         }

--- a/consensus/src/testFixtures/kotlin/maru/consensus/config/Utils.kt
+++ b/consensus/src/testFixtures/kotlin/maru/consensus/config/Utils.kt
@@ -24,7 +24,7 @@ object Utils {
   fun parseBeaconChainConfig(json: String): JsonFriendlyForksSchedule =
     ConfigLoaderBuilder
       .default()
-      .addDecoder(ForkConfigDecoder())
+      .addDecoder(ForkConfigDecoder)
       .withExplicitSealedTypes()
       .addSource(JsonPropertySource(json))
       .build()

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -3,6 +3,7 @@ data-path="/tmp/maru-db"
 private-key-path="/tmp/maru-db/private-key"
 
 [qbft-options]
+fee-recipient = "0x0000000000000000000000000000000000000000"
 
 [p2p-config]
 port = 3322

--- a/docker/maru/genesis.json
+++ b/docker/maru/genesis.json
@@ -3,7 +3,6 @@
     "0": {
       "type": "qbft",
       "blockTimeSeconds": 1,
-      "feeRecipient": "0x0000000000000000000000000000000000000000",
       "elFork": "Prague"
     }
   }

--- a/e2e/src/acceptanceTest/resources/config/clique-to-prague.template
+++ b/e2e/src/acceptanceTest/resources/config/clique-to-prague.template
@@ -9,7 +9,6 @@
       "type": "qbft",
       "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
       "blockTimeSeconds": 7,
-      "feeRecipient": "0x0000000000000000000000000000000000000000",
       "elFork": "Prague"
     }
   }

--- a/e2e/src/acceptanceTest/resources/config/maru.toml
+++ b/e2e/src/acceptanceTest/resources/config/maru.toml
@@ -2,6 +2,7 @@
 data-path="/tmp/maru-db"
 
 [qbft-options]
+fee-recipient="0x0000000000000000000000000000000000000000"
 
 [p2p-config]
 port = 3322


### PR DESCRIPTION
* Moved `feeRecipient` out of Maru's Genesis file
* Used `QbftOptionsDecoder` to decode `feeRecipient` instead of the usual Dto + domain class duo
* Refactored `HopliteFriendlinessTest` so there's less copypaste and more readability