### PR TITLE
Metrics server for serving besu and linea metrics

### DIFF
--- a/app/src/main/kotlin/maru/app/MetricsServer.kt
+++ b/app/src/main/kotlin/maru/app/MetricsServer.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.app
+
+import io.vertx.core.Vertx
+import java.util.Optional
+import net.consensys.linea.async.get
+import net.consensys.linea.metrics.MetricsFacade
+import net.consensys.linea.vertx.ObservabilityServer
+import org.apache.logging.log4j.LogManager
+import org.hyperledger.besu.metrics.MetricsService
+import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration
+import org.hyperledger.besu.plugin.services.MetricsSystem
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory as BesuMetricsCategory
+
+class MetricsServer(
+  val vertx: Vertx,
+  val config: Config,
+  metricsFacade: MetricsFacade,
+  val metricsSystem: MetricsSystem,
+) {
+  data class Config(
+    val portForMetricsFacade: Int,
+    val portForMetricsSystem: Int,
+    val enabledMetricsSystemCategories: Set<BesuMetricsCategory>,
+  )
+
+  private val log = LogManager.getLogger(MetricsServer::class.java)
+
+  private var observabilityServerDeploymentId: String? = null
+  private val observabilityServer =
+    ObservabilityServer(ObservabilityServer.Config(applicationName = "maru", port = config.portForMetricsFacade))
+  private val metricsService: Optional<MetricsService> =
+    MetricsService.create(
+      MetricsConfiguration
+        .builder()
+        .enabled(config.enabledMetricsSystemCategories.isNotEmpty())
+        .port(config.portForMetricsSystem)
+        .metricCategories(config.enabledMetricsSystemCategories)
+        .prometheusJob("maru")
+        .build(),
+      metricsSystem,
+    )
+
+  fun start() {
+    try {
+      observabilityServerDeploymentId = vertx.deployVerticle(observabilityServer).get()
+    } catch (th: Throwable) {
+      log.error("Error while trying to start the observability server", th)
+      throw th
+    }
+    try {
+      metricsService.ifPresent { it.start().get() }
+    } catch (th: Throwable) {
+      log.error("Error while trying to start the metrics service", th)
+      throw th
+    }
+  }
+
+  fun stop() {
+    try {
+      observabilityServerDeploymentId.let { vertx.undeploy(it).get() }
+    } catch (th: Throwable) {
+      log.warn("Error while trying to stop the observability server", th)
+    }
+    try {
+      metricsService.ifPresent { it.stop().get() }
+    } catch (th: Throwable) {
+      log.warn("Error while trying to stop the metrics service", th)
+    }
+  }
+}

--- a/app/src/test/kotlin/maru/testutils/MaruFactory.kt
+++ b/app/src/test/kotlin/maru/testutils/MaruFactory.kt
@@ -39,6 +39,7 @@ import maru.extensions.encodeHex
 import maru.extensions.fromHexToByteArray
 import maru.p2p.NoOpP2PNetwork
 import maru.p2p.P2PNetwork
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem
 
 /**
  * The same MaruFactory should be used per network. Otherwise, validators won't match between Maru instances
@@ -90,7 +91,10 @@ class MaruFactory {
     followers: FollowersConfig = FollowersConfig(emptyMap()),
     qbftOptions: QbftOptions? = null,
     observabilityOptions: ObservabilityOptions =
-      ObservabilityOptions(port = 0u, prometheusMetricsEnabled = true, jvmMetricsEnabled = true),
+      ObservabilityOptions(
+        port = 0u,
+        metricsSystemPort = 0u,
+      ),
     overridingLineaContractClient: LineaRollupSmartContractClientReadOnly? = null,
     apiConfig: ApiConfig = ApiConfig(port = 0u),
     allowEmptyBlocks: Boolean = false,
@@ -138,6 +142,7 @@ class MaruFactory {
       overridingP2PNetwork = overridingP2PNetwork,
       overridingFinalizationProvider = overridingFinalizationProvider,
       overridingLineaContractClient = overridingLineaContractClient,
+      metricsSystem = NoOpMetricsSystem(),
     )
 
   private fun buildP2pConfig(

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -115,8 +115,7 @@ data class QbftOptions(
 
 data class ObservabilityOptions(
   val port: UInt,
-  val prometheusMetricsEnabled: Boolean = true,
-  val jvmMetricsEnabled: Boolean = true,
+  val metricsSystemPort: UInt,
 )
 
 data class LineaConfig(

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -42,6 +42,7 @@ class HopliteFriendlinessTest {
 
     [observability-options]
     port = 9090
+    metrics-system-port = 9091
 
     [api-config]
     port = 8080
@@ -124,7 +125,7 @@ class HopliteFriendlinessTest {
         p2pConfig = p2pConfig,
         payloadValidator = payloadValidator,
         followerEngineApis = mapOf("follower1" to follower1, "follower2" to follower2),
-        observabilityOptions = ObservabilityOptions(port = 9090u),
+        observabilityOptions = ObservabilityOptions(port = 9090u, metricsSystemPort = 9091u),
         apiConfig = ApiConfig(port = 8080u),
       ),
     )
@@ -141,7 +142,7 @@ class HopliteFriendlinessTest {
         p2pConfig = p2pConfig,
         payloadValidator = payloadValidator,
         followerEngineApis = null,
-        observabilityOptions = ObservabilityOptions(port = 9090u),
+        observabilityOptions = ObservabilityOptions(port = 9090u, metricsSystemPort = 9091u),
         apiConfig = ApiConfig(port = 8080u),
       ),
     )
@@ -162,7 +163,7 @@ class HopliteFriendlinessTest {
           ),
         qbftOptions = qbftOptions,
         followers = followersConfig,
-        observabilityOptions = ObservabilityOptions(port = 9090u),
+        observabilityOptions = ObservabilityOptions(port = 9090u, metricsSystemPort = 9091u),
         apiConfig = ApiConfig(port = 8080u),
       ),
     )
@@ -183,7 +184,7 @@ class HopliteFriendlinessTest {
             ethApiEndpoint = ethApiEndpoint,
           ),
         followers = emptyFollowersConfig,
-        observabilityOptions = ObservabilityOptions(port = 9090u),
+        observabilityOptions = ObservabilityOptions(port = 9090u, metricsSystemPort = 9091u),
         apiConfig = ApiConfig(port = 8080u),
       ),
     )
@@ -234,7 +235,7 @@ class HopliteFriendlinessTest {
           p2pConfig = p2pConfig,
           payloadValidator = payloadValidator,
           followerEngineApis = mapOf("follower1" to follower1, "follower2" to follower2),
-          observabilityOptions = ObservabilityOptions(port = 9090u),
+          observabilityOptions = ObservabilityOptions(port = 9090u, metricsSystemPort = 9091u),
           apiConfig = ApiConfig(port = 8080u),
         ),
       )
@@ -252,7 +253,11 @@ class HopliteFriendlinessTest {
             ),
           qbftOptions = qbftOptions,
           followers = followersConfig,
-          observabilityOptions = ObservabilityOptions(port = 9090u),
+          observabilityOptions =
+            ObservabilityOptions(
+              port = 9090u,
+              metricsSystemPort = 9091u,
+            ),
           apiConfig = ApiConfig(port = 8080u),
         ),
       )

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,6 +21,7 @@ plugins {
 dependencies {
   implementation(project(":jvm-libs:extensions"))
   implementation "build.linea.internal:metrics"
+  implementation "org.hyperledger.besu:plugin-api"
 
   testImplementation(project(":serialization"))
   testFixturesImplementation("org.hyperledger.besu.internal:core")

--- a/core/src/main/kotlin/maru/metrics/MaruMetricsCategory.kt
+++ b/core/src/main/kotlin/maru/metrics/MaruMetricsCategory.kt
@@ -8,10 +8,20 @@
  */
 package maru.metrics
 
+import java.util.Optional
 import net.consensys.linea.metrics.MetricsCategory
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory as BesuMetricsCategory
 
 enum class MaruMetricsCategory : MetricsCategory {
   ENGINE_API,
   METADATA,
   P2P_NETWORK,
+}
+
+enum class MaruMetricsSystemCategory : BesuMetricsCategory {
+  STORAGE {
+    override fun getName(): String = "storage"
+
+    override fun getApplicationPrefix(): Optional<String> = Optional.empty()
+  },
 }

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -21,8 +21,7 @@ eth-api-endpoint = { endpoint = "http://sequencer:8545" }
 
 [observability-options]
 port = 9090
-jvm-metrics-enabled = true
-prometheus-metrics-enabled = true
+metrics-system-port = 9091
 
 [api-config]
 port = 8080

--- a/docker/prometheus/prometheus.yaml
+++ b/docker/prometheus/prometheus.yaml
@@ -9,3 +9,4 @@ scrape_configs:
     static_configs:
       - targets:
           - maru:9090
+          - maru:9091

--- a/e2e/src/acceptanceTest/resources/config/maru.toml
+++ b/e2e/src/acceptanceTest/resources/config/maru.toml
@@ -20,8 +20,7 @@ eth-api-endpoint = { endpoint = "http://localhost:8545" }
 
 [observability-options]
 port = 9090
-jvm-metrics-enabled = true
-prometheus-metrics-enabled = true
+metrics-system-port = 9091
 
 [api-config]
 port = 8080

--- a/p2p/src/main/kotlin/maru/p2p/Libp2pNetworkFactory.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Libp2pNetworkFactory.kt
@@ -30,7 +30,7 @@ import kotlin.random.Random
 import maru.core.SealedBeaconBlock
 import maru.p2p.topics.TopicHandlerWithInOrderDelivering
 import org.apache.tuweni.bytes.Bytes
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem
+import org.hyperledger.besu.plugin.services.MetricsSystem
 import pubsub.pb.Rpc
 import tech.pegasys.teku.infrastructure.async.AsyncRunnerFactory
 import tech.pegasys.teku.infrastructure.async.MetricTrackingExecutorFactory
@@ -64,6 +64,7 @@ class Libp2pNetworkFactory(
     sealedBlocksTopicId: String,
     rpcMethods: List<RpcMethod<*, *, *>>,
     maruPeerManager: MaruPeerManager,
+    metricsSystem: MetricsSystem,
   ): TekuLibP2PNetwork {
     val ipv4Address = Multiaddr("/ip4/$ipAddress/tcp/$port")
     val gossipTopicHandlers = GossipTopicHandlers()
@@ -84,7 +85,6 @@ class Libp2pNetworkFactory(
     val pubsubApiImpl = PubsubApiImpl(gossipRouter)
     val gossip = Gossip(gossipRouter, pubsubApiImpl)
 
-    val metricsSystem = NoOpMetricsSystem()
     val publisherApi = gossip.createPublisher(privateKey, Random.nextLong())
     val gossipNetwork = LibP2PGossipNetwork(metricsSystem, gossip, publisherApi, gossipTopicHandlers)
 

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
@@ -25,6 +25,7 @@ import net.consensys.linea.metrics.Tag
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.apache.tuweni.bytes.Bytes
+import org.hyperledger.besu.plugin.services.MetricsSystem
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId
 import tech.pegasys.teku.networking.p2p.libp2p.MultiaddrPeerAddress
@@ -40,6 +41,7 @@ class P2PNetworkImpl(
   private val chainId: UInt,
   private val serDe: SerDe<SealedBeaconBlock>,
   private val metricsFacade: MetricsFacade,
+  private val metricsSystem: MetricsSystem,
   private val statusMessageFactory: StatusMessageFactory,
   nextExpectedBeaconBlockNumber: ULong,
 ) : P2PNetwork {
@@ -64,6 +66,7 @@ class P2PNetworkImpl(
   private fun buildP2PNetwork(
     privateKeyBytes: ByteArray,
     p2pConfig: P2P,
+    metricsSystem: MetricsSystem,
   ): TekuLibP2PNetwork {
     val privateKey = unmarshalPrivateKey(privateKeyBytes)
     val rpcIdGenerator = LineaRpcProtocolIdGenerator(chainId)
@@ -78,12 +81,13 @@ class P2PNetworkImpl(
       port = p2pConfig.port,
       sealedBlocksTopicHandler = sealedBlocksTopicHandler,
       sealedBlocksTopicId = sealedBlocksTopicId,
+      metricsSystem = metricsSystem,
       rpcMethods = rpcMethods.all(),
       maruPeerManager = maruPeerManager,
     )
   }
 
-  private val builtNetwork: TekuLibP2PNetwork = buildP2PNetwork(privateKeyBytes, p2pConfig)
+  private val builtNetwork: TekuLibP2PNetwork = buildP2PNetwork(privateKeyBytes, p2pConfig, metricsSystem)
   internal val p2pNetwork = builtNetwork.p2PNetwork
   private val log: Logger = LogManager.getLogger(this::javaClass)
   private val delayedExecutor =

--- a/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
@@ -31,6 +31,7 @@ import org.apache.tuweni.bytes.Bytes
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.awaitility.Awaitility.await
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
@@ -114,6 +115,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -124,6 +126,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -151,6 +154,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -161,6 +165,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -193,6 +198,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -203,6 +209,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -228,6 +235,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -238,6 +246,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -268,6 +277,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -278,6 +288,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -317,6 +328,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -327,6 +339,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -337,6 +350,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -385,6 +399,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )
@@ -395,6 +410,7 @@ class P2PTest {
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
+        metricsSystem = NoOpMetricsSystem(),
         nextExpectedBeaconBlockNumber = initialExpectedBeaconBlockNumber,
         statusMessageFactory = statusMessageFactory,
       )


### PR DESCRIPTION
#97 

In this PR
- Create a MetricsServer that instantiates two http servers that have metrics endpoints
  - Server#1  is to serve metrics collected by the Linea MetricsFacade
  - Server#2 is to serve metrics collected by the Besu MetricsSystem
- Inject MetricsServer, MetricsSystem and BeaconChain into the MaruApp.
- Inject MetricsSystem to the P2PImpl that can be used to collect metrics from the underlying Teku implementation