### PR TITLE
Add gradle jvm memory config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ junit.jupiter.execution.parallel.enabled=true
 junit.jupiter.execution.parallel.mode.default=concurrent
 junit.jupiter.execution.parallel.mode.classes.default=concurrent
 
-kotlin.daemon.jvmargs=-Xmx4g
+org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
Set the gradle jvm heap to 4096M which is higher than the default of 512M. This should fix the occasional out of heap space exception.

`kotlin.daemon.jvmargs` is not explicitly needed if `org.gradle.jvmargs` is specified as the [value is inherited](https://kotlinlang.org/docs/gradle-compilation-and-caches.html#gradle-daemon-arguments-inheritance).