### PR TITLE
Implement node apis

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           # force tests to run even if the code is not changed
           # this is to debug flaky tests
-          ./gradlew build --rerun-tasks
+          ./gradlew build --rerun
       - name: Run Jacoco
         run: |
           ./gradlew jacocoAggregatedReport

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           # force tests to run even if the code is not changed
           # this is to debug flaky tests
-          ./gradlew build --rerun
+          ./gradlew build --rerun-tasks
       - name: Run Jacoco
         run: |
           ./gradlew jacocoAggregatedReport

--- a/api/src/main/kotlin/maru/api/HandlerException.kt
+++ b/api/src/main/kotlin/maru/api/HandlerException.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api
+
+import io.javalin.http.Context
+import io.javalin.http.Handler
+
+data class ApiExceptionResponse(
+  val code: Int,
+  val message: String,
+)
+
+class HandlerException(
+  val code: Int,
+  override val message: String,
+) : Exception(message),
+  Handler {
+  override fun handle(ctx: Context) {
+    ctx.status(code).json(ApiExceptionResponse(code, message))
+  }
+}

--- a/api/src/main/kotlin/maru/api/node/Extensions.kt
+++ b/api/src/main/kotlin/maru/api/node/Extensions.kt
@@ -6,12 +6,15 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package maru.p2p
+package maru.api.node
 
-import tech.pegasys.teku.networking.p2p.peer.NodeId
+import maru.p2p.PeerInfo
 
-interface PeerLookup {
-  fun getPeer(nodeId: NodeId): MaruPeer?
-
-  fun getPeers(): List<MaruPeer>
-}
+fun PeerInfo.toPeerData(): PeerData =
+  PeerData(
+    peerId = nodeId,
+    enr = enr,
+    lastSeenP2PAddress = address,
+    state = status.toString().lowercase(),
+    direction = direction.toString().lowercase(),
+  )

--- a/api/src/main/kotlin/maru/api/node/GetHealth.kt
+++ b/api/src/main/kotlin/maru/api/node/GetHealth.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.node
+
+import io.javalin.http.Context
+import io.javalin.http.Handler
+
+class GetHealth : Handler {
+  override fun handle(ctx: Context) {
+    // Placeholder for actual health check logic
+    ctx.status(200).json("Node is ready")
+  }
+
+  companion object {
+    const val ROUTE = "/eth/v1/node/health"
+  }
+}

--- a/api/src/main/kotlin/maru/api/node/GetNetworkIdentity.kt
+++ b/api/src/main/kotlin/maru/api/node/GetNetworkIdentity.kt
@@ -6,18 +6,13 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package maru.api/*
- * Copyright Consensys Software Inc.
- *
- * This file is dual-licensed under either the MIT license or Apache License 2.0.
- * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
- *
- * SPDX-License-Identifier: MIT OR Apache-2.0
- */
+package maru.api.node
+
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.http.HttpStatus
+import maru.api.NetworkDataProvider
 
 /**
  * https://ethereum.github.io/beacon-APIs/#/Node/getNetworkIdentity
@@ -39,11 +34,11 @@ data class NetworkIdentity(
  */
 data class Metadata(
   @JsonProperty("seq_number") val seqNumber: String,
-  val attnets: List<String>,
-  val syncnets: List<String>,
+  val attnets: String,
+  val syncnets: String,
 )
 
-class NodeGetNetworkIdentity(
+class GetNetworkIdentity(
   val networkDataProvider: NetworkDataProvider,
 ) : Handler {
   override fun handle(ctx: Context) {
@@ -56,8 +51,8 @@ class NodeGetNetworkIdentity(
         metadata =
           Metadata(
             seqNumber = "0",
-            attnets = emptyList(),
-            syncnets = emptyList(),
+            attnets = "0x",
+            syncnets = "0x",
           ),
       )
     ctx.status(HttpStatus.OK).json(GetNetworkIdentityResponse(networkIdentity))

--- a/api/src/main/kotlin/maru/api/node/GetPeer.kt
+++ b/api/src/main/kotlin/maru/api/node/GetPeer.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.node
+
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import io.javalin.http.HttpStatus
+import maru.api.HandlerException
+import maru.api.NetworkDataProvider
+
+data class GetPeerResponse(
+  val data: PeerData,
+)
+
+class GetPeer(
+  val networkDataProvider: NetworkDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val peerId = ctx.pathParam(PEER_ID)
+    val peer =
+      try {
+        networkDataProvider.getPeer(peerId)
+      } catch (e: Exception) {
+        if (e.message?.contains("invalid base58 encoded form") == true) {
+          throw HandlerException(400, "Invalid peer ID: $peerId")
+        }
+        throw e
+      }
+    if (peer == null) {
+      throw HandlerException(404, "Peer not found")
+    }
+    val peerData =
+      PeerData(
+        peerId = peer.nodeId,
+        enr = peer.enr,
+        lastSeenP2PAddress = peer.address,
+        state = peer.status.toString().lowercase(),
+        direction = peer.direction.toString().lowercase(),
+      )
+    ctx.status(HttpStatus.OK).json(GetPeerResponse(data = peerData))
+  }
+
+  companion object {
+    const val PEER_ID = "peerId"
+    const val ROUTE = "/eth/v1/node/peers/{$PEER_ID}"
+  }
+}

--- a/api/src/main/kotlin/maru/api/node/GetPeerCount.kt
+++ b/api/src/main/kotlin/maru/api/node/GetPeerCount.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.node
+
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import maru.api.NetworkDataProvider
+import maru.p2p.Peer
+
+data class GetPeerCountResponse(
+  val data: PeerCountData,
+)
+
+data class PeerCountData(
+  val disconnected: String,
+  val connected: String,
+  val connecting: String,
+  val disconnecting: String,
+)
+
+class GetPeerCount(
+  val networkDataProvider: NetworkDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val peerCountMap =
+      networkDataProvider
+        .getPeers()
+        .groupBy { it.status }
+        .mapValues { it.value.size }
+
+    ctx.json(
+      GetPeerCountResponse(
+        data =
+          PeerCountData(
+            disconnected = peerCountMap.getOrDefault(Peer.PeerStatus.DISCONNECTED, 0).toString(),
+            connected = peerCountMap.getOrDefault(Peer.PeerStatus.CONNECTED, 0).toString(),
+            connecting = peerCountMap.getOrDefault(Peer.PeerStatus.CONNECTING, 0).toString(),
+            disconnecting = peerCountMap.getOrDefault(Peer.PeerStatus.DISCONNECTING, 0).toString(),
+          ),
+      ),
+    )
+  }
+
+  companion object {
+    const val ROUTE = "/eth/v1/node/peer_count"
+  }
+}

--- a/api/src/main/kotlin/maru/api/node/GetPeerCount.kt
+++ b/api/src/main/kotlin/maru/api/node/GetPeerCount.kt
@@ -11,7 +11,7 @@ package maru.api.node
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import maru.api.NetworkDataProvider
-import maru.p2p.Peer
+import maru.p2p.PeerInfo
 
 data class GetPeerCountResponse(
   val data: PeerCountData,
@@ -38,10 +38,10 @@ class GetPeerCount(
       GetPeerCountResponse(
         data =
           PeerCountData(
-            disconnected = peerCountMap.getOrDefault(Peer.PeerStatus.DISCONNECTED, 0).toString(),
-            connected = peerCountMap.getOrDefault(Peer.PeerStatus.CONNECTED, 0).toString(),
-            connecting = peerCountMap.getOrDefault(Peer.PeerStatus.CONNECTING, 0).toString(),
-            disconnecting = peerCountMap.getOrDefault(Peer.PeerStatus.DISCONNECTING, 0).toString(),
+            disconnected = peerCountMap.getOrDefault(PeerInfo.PeerStatus.DISCONNECTED, 0).toString(),
+            connected = peerCountMap.getOrDefault(PeerInfo.PeerStatus.CONNECTED, 0).toString(),
+            connecting = peerCountMap.getOrDefault(PeerInfo.PeerStatus.CONNECTING, 0).toString(),
+            disconnecting = peerCountMap.getOrDefault(PeerInfo.PeerStatus.DISCONNECTING, 0).toString(),
           ),
       ),
     )

--- a/api/src/main/kotlin/maru/api/node/GetPeers.kt
+++ b/api/src/main/kotlin/maru/api/node/GetPeers.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.node
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import io.javalin.http.HttpStatus
+import maru.api.NetworkDataProvider
+
+data class GetPeersResponse(
+  val data: List<PeerData>,
+  val meta: PeerMetaData,
+)
+
+data class PeerData(
+  @JsonProperty("peer_id") val peerId: String,
+  val enr: String?,
+  @JsonProperty("last_seen_p2p_address") val lastSeenP2PAddress: String,
+  val state: String,
+  val direction: String,
+)
+
+data class PeerMetaData(
+  val count: Int,
+)
+
+class GetPeers(
+  val networkDataProvider: NetworkDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val peers =
+      networkDataProvider.getPeers().map {
+        PeerData(
+          peerId = it.nodeId,
+          enr = it.enr,
+          lastSeenP2PAddress = it.address,
+          state = it.status.toString().lowercase(),
+          direction = it.direction.toString().lowercase(),
+        )
+      }
+    ctx.json(GetPeersResponse(data = peers, meta = PeerMetaData(count = peers.count())))
+    ctx.status(HttpStatus.OK)
+  }
+
+  companion object {
+    const val ROUTE = "/eth/v1/node/peers"
+  }
+}

--- a/api/src/main/kotlin/maru/api/node/GetPeers.kt
+++ b/api/src/main/kotlin/maru/api/node/GetPeers.kt
@@ -35,16 +35,7 @@ class GetPeers(
   val networkDataProvider: NetworkDataProvider,
 ) : Handler {
   override fun handle(ctx: Context) {
-    val peers =
-      networkDataProvider.getPeers().map {
-        PeerData(
-          peerId = it.nodeId,
-          enr = it.enr,
-          lastSeenP2PAddress = it.address,
-          state = it.status.toString().lowercase(),
-          direction = it.direction.toString().lowercase(),
-        )
-      }
+    val peers = networkDataProvider.getPeers().map { it.toPeerData() }
     ctx.json(GetPeersResponse(data = peers, meta = PeerMetaData(count = peers.count())))
     ctx.status(HttpStatus.OK)
   }

--- a/api/src/main/kotlin/maru/api/node/GetSyncingStatus.kt
+++ b/api/src/main/kotlin/maru/api/node/GetSyncingStatus.kt
@@ -27,6 +27,7 @@ data class SyncingStatusData(
 class GetSyncingStatus : Handler {
   override fun handle(ctx: Context) {
     // This is a placeholder implementation. Replace it with actual logic to retrieve syncing status.
+    // TODO(Implement actual syncing status retrieval logic when we have syncing in place)
     ctx.status(200).json(
       GetSyncingStatusResponse(
         data =

--- a/api/src/main/kotlin/maru/api/node/GetSyncingStatus.kt
+++ b/api/src/main/kotlin/maru/api/node/GetSyncingStatus.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.node
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.javalin.http.Context
+import io.javalin.http.Handler
+
+data class GetSyncingStatusResponse(
+  val data: SyncingStatusData,
+)
+
+data class SyncingStatusData(
+  @JsonProperty("head_slot") val headSlot: String,
+  @JsonProperty("sync_distance") val syncDistance: String,
+  @JsonProperty("is_syncing") val isSyncing: Boolean,
+  @JsonProperty("is_optimistic") val isOptimistic: Boolean,
+  @JsonProperty("el_offline") val elOffline: Boolean,
+)
+
+class GetSyncingStatus : Handler {
+  override fun handle(ctx: Context) {
+    // This is a placeholder implementation. Replace it with actual logic to retrieve syncing status.
+    ctx.status(200).json(
+      GetSyncingStatusResponse(
+        data =
+          SyncingStatusData(
+            headSlot = "12345678",
+            syncDistance = "0",
+            isSyncing = false,
+            isOptimistic = false,
+            elOffline = false,
+          ),
+      ),
+    )
+  }
+
+  companion object {
+    const val ROUTE = "/eth/v1/node/syncing"
+  }
+}

--- a/api/src/main/kotlin/maru/api/node/GetVersion.kt
+++ b/api/src/main/kotlin/maru/api/node/GetVersion.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.node
+
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import maru.VersionProvider
+
+data class GetVersionResponse(
+  val data: VersionData,
+)
+
+data class VersionData(
+  val version: String,
+)
+
+class GetVersion(
+  val versionProvider: VersionProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    ctx.status(200).json(
+      GetVersionResponse(
+        data = VersionData(version = versionProvider.getVersion()),
+      ),
+    )
+  }
+
+  companion object {
+    const val ROUTE = "/eth/v1/node/version"
+  }
+}

--- a/api/src/test/kotlin/maru/api/ApiServerTest.kt
+++ b/api/src/test/kotlin/maru/api/ApiServerTest.kt
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test
 class ApiServerTest {
   private val defaultObjectMapper = jacksonObjectMapper()
 
-  private lateinit var apiServer: ApiServer
+  private lateinit var apiServer: ApiServerImpl
   private lateinit var client: OkHttpClient
   private lateinit var apiServerUrl: String
 
@@ -79,8 +79,8 @@ class ApiServerTest {
   @BeforeEach
   fun beforeEach() {
     apiServer =
-      ApiServer(
-        config = ApiServer.Config(port = 0u),
+      ApiServerImpl(
+        config = ApiServerImpl.Config(port = 0u),
         networkDataProvider = fakeNetworkDataProvider,
         versionProvider = fakeVersionProvider,
       )

--- a/api/src/test/kotlin/maru/api/ApiServerTest.kt
+++ b/api/src/test/kotlin/maru/api/ApiServerTest.kt
@@ -10,6 +10,28 @@ package maru.api
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.util.concurrent.TimeUnit
+import maru.VersionProvider
+import maru.api.node.GetHealth
+import maru.api.node.GetNetworkIdentity
+import maru.api.node.GetNetworkIdentityResponse
+import maru.api.node.GetPeer
+import maru.api.node.GetPeerCount
+import maru.api.node.GetPeerCountResponse
+import maru.api.node.GetPeerResponse
+import maru.api.node.GetPeers
+import maru.api.node.GetPeersResponse
+import maru.api.node.GetSyncingStatus
+import maru.api.node.GetSyncingStatusResponse
+import maru.api.node.GetVersion
+import maru.api.node.GetVersionResponse
+import maru.api.node.Metadata
+import maru.api.node.NetworkIdentity
+import maru.api.node.PeerCountData
+import maru.api.node.PeerData
+import maru.api.node.PeerMetaData
+import maru.api.node.SyncingStatusData
+import maru.api.node.VersionData
+import maru.p2p.Peer
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -34,6 +56,24 @@ class ApiServerTest {
       override fun getNodeAddresses(): List<String> = listOf("TEST_NODE_ADDRESS")
 
       override fun getDiscoveryAddresses(): List<String> = listOf("TEST_DISCOVERY_ADDRESS")
+
+      override fun getPeers(): List<Peer> =
+        listOf(
+          Peer(
+            nodeId = "TEST_PEER_ID",
+            enr = "TEST_PEER_ENR",
+            address = "TEST_PEER_ADDRESS",
+            status = Peer.PeerStatus.CONNECTED,
+            direction = Peer.PeerDirection.OUTBOUND,
+          ),
+        )
+
+      override fun getPeer(peerId: String): Peer? = getPeers().firstOrNull { it.nodeId == peerId }
+    }
+
+  private val fakeVersionProvider =
+    object : VersionProvider {
+      override fun getVersion(): String = "maru/1.0.0-test"
     }
 
   @BeforeEach
@@ -42,6 +82,7 @@ class ApiServerTest {
       ApiServer(
         config = ApiServer.Config(port = 0u),
         networkDataProvider = fakeNetworkDataProvider,
+        versionProvider = fakeVersionProvider,
       )
     apiServer.start()
     apiServerUrl = "http://localhost:${apiServer.port()}"
@@ -54,8 +95,8 @@ class ApiServerTest {
   }
 
   @Test
-  fun `test NodeGetNetworkIdentityV1 method`() {
-    val url = (apiServerUrl + NodeGetNetworkIdentity.ROUTE).toHttpUrl()
+  fun `test GetNetworkIdentity method`() {
+    val url = (apiServerUrl + GetNetworkIdentity.ROUTE).toHttpUrl()
     val request = Request.Builder().url(url).build()
     val networkIdentity =
       NetworkIdentity(
@@ -66,8 +107,8 @@ class ApiServerTest {
         metadata =
           Metadata(
             seqNumber = "0",
-            attnets = emptyList(),
-            syncnets = emptyList(),
+            attnets = "0x",
+            syncnets = "0x",
           ),
       )
 
@@ -82,5 +123,155 @@ class ApiServerTest {
         GetNetworkIdentityResponse::class.java,
       )
     assertThat(getNetworkIdentityResponse).isEqualTo(expectedGetNetworkIdentityResponse)
+  }
+
+  @Test
+  fun `test GetPeers method`() {
+    val url = (apiServerUrl + GetPeers.ROUTE).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+    val peerData =
+      PeerData(
+        peerId = "TEST_PEER_ID",
+        enr = "TEST_PEER_ENR",
+        lastSeenP2PAddress = "TEST_PEER_ADDRESS",
+        state = "connected",
+        direction = "outbound",
+      )
+
+    val expectedResponse = GetPeersResponse(data = listOf(peerData), meta = PeerMetaData(count = 1))
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(200)
+    val responseBody = httpResponse.body?.string()
+    val response =
+      defaultObjectMapper.readValue(
+        responseBody,
+        GetPeersResponse::class.java,
+      )
+    assertThat(response).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `test GetPeerById method`() {
+    val url = (apiServerUrl + GetPeer.ROUTE.replace("{${GetPeer.PEER_ID}}", "TEST_PEER_ID")).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+    val peerData =
+      PeerData(
+        peerId = "TEST_PEER_ID",
+        enr = "TEST_PEER_ENR",
+        lastSeenP2PAddress = "TEST_PEER_ADDRESS",
+        state = "connected",
+        direction = "outbound",
+      )
+
+    val expectedResponse = GetPeerResponse(data = peerData)
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(200)
+    val responseBody = httpResponse.body?.string()
+    val response =
+      defaultObjectMapper.readValue(
+        responseBody,
+        GetPeerResponse::class.java,
+      )
+    assertThat(response).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `test GetPeerById method when peer not found`() {
+    val url = (apiServerUrl + GetPeer.ROUTE.replace("{${GetPeer.PEER_ID}}", "TEST_PEER_ID_2")).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(404)
+    val responseBody = httpResponse.body?.string()
+    val response =
+      defaultObjectMapper.readValue(
+        responseBody,
+        ApiExceptionResponse::class.java,
+      )
+    assertThat(response).isEqualTo(ApiExceptionResponse(404, "Peer not found"))
+  }
+
+  @Test
+  fun `test GetPeerCount method`() {
+    val url = (apiServerUrl + GetPeerCount.ROUTE).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+    val peerCountData =
+      PeerCountData(
+        disconnected = "0",
+        connected = "1",
+        connecting = "0",
+        disconnecting = "0",
+      )
+
+    val expectedResponse = GetPeerCountResponse(data = peerCountData)
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(200)
+    val responseBody = httpResponse.body?.string()
+    val response =
+      defaultObjectMapper.readValue(
+        responseBody,
+        GetPeerCountResponse::class.java,
+      )
+    assertThat(response).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `test GetVersion method`() {
+    val url = (apiServerUrl + GetVersion.ROUTE).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+    val expectedResponse = GetVersionResponse(data = VersionData(version = fakeVersionProvider.getVersion()))
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(200)
+    val responseBody = httpResponse.body?.string()
+    val response =
+      defaultObjectMapper.readValue(
+        responseBody,
+        GetVersionResponse::class.java,
+      )
+    assertThat(response).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `test GetSyncingStatus method`() {
+    val url = (apiServerUrl + GetSyncingStatus.ROUTE).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+    val expectedResponse =
+      GetSyncingStatusResponse(
+        data =
+          SyncingStatusData(
+            headSlot = "12345678",
+            syncDistance = "0",
+            isSyncing = false,
+            isOptimistic = false,
+            elOffline = false,
+          ),
+      )
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(200)
+    val responseBody = httpResponse.body?.string()
+    val response =
+      defaultObjectMapper.readValue(
+        responseBody,
+        GetSyncingStatusResponse::class.java,
+      )
+    assertThat(response).isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `test GetHealth method`() {
+    val url = (apiServerUrl + GetHealth.ROUTE).toHttpUrl()
+    val request = Request.Builder().url(url).build()
+    val expectedResponse = "Node is ready"
+    val httpResponse = client.newCall(request).execute()
+    assertThat(httpResponse).isNotNull
+    assertThat(httpResponse.code).isEqualTo(200)
+    val response = httpResponse.body?.string()
+    assertThat(response).isEqualTo(expectedResponse)
   }
 }

--- a/api/src/test/kotlin/maru/api/ApiServerTest.kt
+++ b/api/src/test/kotlin/maru/api/ApiServerTest.kt
@@ -31,7 +31,7 @@ import maru.api.node.PeerData
 import maru.api.node.PeerMetaData
 import maru.api.node.SyncingStatusData
 import maru.api.node.VersionData
-import maru.p2p.Peer
+import maru.p2p.PeerInfo
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -57,18 +57,18 @@ class ApiServerTest {
 
       override fun getDiscoveryAddresses(): List<String> = listOf("TEST_DISCOVERY_ADDRESS")
 
-      override fun getPeers(): List<Peer> =
+      override fun getPeers(): List<PeerInfo> =
         listOf(
-          Peer(
+          PeerInfo(
             nodeId = "TEST_PEER_ID",
             enr = "TEST_PEER_ENR",
             address = "TEST_PEER_ADDRESS",
-            status = Peer.PeerStatus.CONNECTED,
-            direction = Peer.PeerDirection.OUTBOUND,
+            status = PeerInfo.PeerStatus.CONNECTED,
+            direction = PeerInfo.PeerDirection.OUTBOUND,
           ),
         )
 
-      override fun getPeer(peerId: String): Peer? = getPeers().firstOrNull { it.nodeId == peerId }
+      override fun getPeer(peerId: String): PeerInfo? = getPeers().firstOrNull { it.nodeId == peerId }
     }
 
   private val fakeVersionProvider =

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -21,6 +21,7 @@ import linea.kotlin.encodeHex
 import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import maru.api.ApiServer
+import maru.api.ApiServerImpl
 import maru.config.MaruConfig
 import maru.config.P2P
 import maru.consensus.ForkIdHashProvider
@@ -59,6 +60,7 @@ class MaruAppFactory {
     overridingP2PNetwork: P2PNetwork? = null,
     overridingFinalizationProvider: FinalizationProvider? = null,
     overridingLineaContractClient: LineaRollupSmartContractClientReadOnly? = null,
+    overridingApiServer: ApiServer? = null,
   ): MaruApp {
     log.info("configs: {}", config)
     val privateKey = getOrGeneratePrivateKey(config.persistence.privateKeyPath)
@@ -131,14 +133,15 @@ class MaruAppFactory {
         ?: setupFinalizationProvider(config, overridingLineaContractClient, vertx)
 
     val apiServer =
-      ApiServer(
-        config =
-          ApiServer.Config(
-            port = config.apiConfig.port,
-          ),
-        networkDataProvider = P2PNetworkDataProvider(p2pNetwork),
-        versionProvider = MaruVersionProvider(),
-      )
+      overridingApiServer
+        ?: ApiServerImpl(
+          config =
+            ApiServerImpl.Config(
+              port = config.apiConfig.port,
+            ),
+          networkDataProvider = P2PNetworkDataProvider(p2pNetwork),
+          versionProvider = MaruVersionProvider(),
+        )
 
     val maru =
       MaruApp(

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -137,6 +137,7 @@ class MaruAppFactory {
             port = config.apiConfig.port,
           ),
         networkDataProvider = P2PNetworkDataProvider(p2pNetwork),
+        versionProvider = MaruVersionProvider(),
       )
 
     val maru =

--- a/app/src/main/kotlin/maru/app/MaruVersionProvider.kt
+++ b/app/src/main/kotlin/maru/app/MaruVersionProvider.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.app
+
+import maru.VersionProvider
+
+class MaruVersionProvider : VersionProvider {
+  override fun getVersion(): String = "maru/v0.1.0"
+}

--- a/app/src/main/kotlin/maru/app/MaruVersionProvider.kt
+++ b/app/src/main/kotlin/maru/app/MaruVersionProvider.kt
@@ -11,5 +11,6 @@ package maru.app
 import maru.VersionProvider
 
 class MaruVersionProvider : VersionProvider {
+  // TODO: Get the version from a build file or environment variable
   override fun getVersion(): String = "maru/v0.1.0"
 }

--- a/app/src/test/kotlin/maru/testutils/MaruFactory.kt
+++ b/app/src/test/kotlin/maru/testutils/MaruFactory.kt
@@ -19,6 +19,7 @@ import java.nio.file.Path
 import kotlin.time.Duration.Companion.milliseconds
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.kotlin.decodeHex
+import maru.api.ApiServer
 import maru.app.MaruApp
 import maru.app.MaruAppFactory
 import maru.config.ApiConfig
@@ -138,6 +139,14 @@ class MaruFactory {
       overridingP2PNetwork = overridingP2PNetwork,
       overridingFinalizationProvider = overridingFinalizationProvider,
       overridingLineaContractClient = overridingLineaContractClient,
+      overridingApiServer =
+        object : ApiServer {
+          override fun start() {}
+
+          override fun stop() {}
+
+          override fun port(): Int = 0
+        },
     )
 
   private fun buildP2pConfig(

--- a/build.gradle
+++ b/build.gradle
@@ -151,13 +151,13 @@ allprojects {
       events 'passed', 'skipped', 'failed'
       showStandardStreams = true
     }
+  }
 
-    systemProperties["junit.jupiter.execution.parallel.enabled"] =  true
+  tasks.withType(Test).configureEach {
+    systemProperties["junit.jupiter.execution.parallel.enabled"] = true
     systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
     systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
-    systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "fixed"
-    systemProperties["junit.jupiter.execution.parallel.config.fixed.parallelism"] =
-      Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    maxParallelForks = 1
   }
 }
 
@@ -190,7 +190,6 @@ subprojects {
   }
 }
 
-
 task jacocoAggregatedReport(type: JacocoReport) {
   group = "verification"
 
@@ -204,7 +203,6 @@ task jacocoAggregatedReport(type: JacocoReport) {
     html.destination file("build/reports/jacocoHtml")
   }
 }
-
 
 apply plugin: 'application'
 

--- a/build.gradle
+++ b/build.gradle
@@ -151,13 +151,13 @@ allprojects {
       events 'passed', 'skipped', 'failed'
       showStandardStreams = true
     }
-  }
 
-  tasks.withType(Test).configureEach {
-    systemProperties["junit.jupiter.execution.parallel.enabled"] = true
+    systemProperties["junit.jupiter.execution.parallel.enabled"] =  true
     systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
     systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
-    maxParallelForks = 1
+    systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "fixed"
+    systemProperties["junit.jupiter.execution.parallel.config.fixed.parallelism"] =
+      Runtime.runtime.availableProcessors().intdiv(2) ?: 1
   }
 }
 
@@ -190,6 +190,7 @@ subprojects {
   }
 }
 
+
 task jacocoAggregatedReport(type: JacocoReport) {
   group = "verification"
 
@@ -203,6 +204,7 @@ task jacocoAggregatedReport(type: JacocoReport) {
     html.destination file("build/reports/jacocoHtml")
   }
 }
+
 
 apply plugin: 'application'
 

--- a/core/src/main/kotlin/maru/VersionProvider.kt
+++ b/core/src/main/kotlin/maru/VersionProvider.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru
+
+interface VersionProvider {
+  fun getVersion(): String
+}

--- a/core/src/main/kotlin/maru/api/ApiServer.kt
+++ b/core/src/main/kotlin/maru/api/ApiServer.kt
@@ -8,12 +8,10 @@
  */
 package maru.api
 
-data class ApiExceptionResponse(
-  val code: Int,
-  val message: String,
-)
+interface ApiServer {
+  fun start()
 
-class HandlerException(
-  val code: Int,
-  override val message: String,
-) : Exception(message)
+  fun stop()
+
+  fun port(): Int
+}

--- a/core/src/main/kotlin/maru/api/NetworkDataProvider.kt
+++ b/core/src/main/kotlin/maru/api/NetworkDataProvider.kt
@@ -8,6 +8,8 @@
  */
 package maru.api
 
+import maru.p2p.Peer
+
 interface NetworkDataProvider {
   fun getNodeId(): String
 
@@ -16,4 +18,8 @@ interface NetworkDataProvider {
   fun getNodeAddresses(): List<String>
 
   fun getDiscoveryAddresses(): List<String>
+
+  fun getPeers(): List<Peer>
+
+  fun getPeer(peerId: String): Peer?
 }

--- a/core/src/main/kotlin/maru/api/NetworkDataProvider.kt
+++ b/core/src/main/kotlin/maru/api/NetworkDataProvider.kt
@@ -8,7 +8,7 @@
  */
 package maru.api
 
-import maru.p2p.Peer
+import maru.p2p.PeerInfo
 
 interface NetworkDataProvider {
   fun getNodeId(): String
@@ -19,7 +19,11 @@ interface NetworkDataProvider {
 
   fun getDiscoveryAddresses(): List<String>
 
-  fun getPeers(): List<Peer>
+  fun getPeers(): List<PeerInfo>
 
-  fun getPeer(peerId: String): Peer?
+  fun getPeer(peerId: String): PeerInfo?
 }
+
+class InvalidPeerIdException(
+  peerId: String,
+) : Exception("Invalid peer ID: $peerId")

--- a/core/src/main/kotlin/maru/p2p/P2PNetwork.kt
+++ b/core/src/main/kotlin/maru/p2p/P2PNetwork.kt
@@ -100,12 +100,12 @@ interface P2PNetwork {
 
   val enr: String?
 
-  fun getPeers(): List<Peer>
+  fun getPeers(): List<PeerInfo>
 
-  fun getPeer(peerId: String): Peer?
+  fun getPeer(peerId: String): PeerInfo?
 }
 
-data class Peer(
+data class PeerInfo(
   val nodeId: String,
   val enr: String?,
   val address: String,

--- a/core/src/main/kotlin/maru/p2p/P2PNetwork.kt
+++ b/core/src/main/kotlin/maru/p2p/P2PNetwork.kt
@@ -99,4 +99,28 @@ interface P2PNetwork {
   val discoveryAddresses: List<String>
 
   val enr: String?
+
+  fun getPeers(): List<Peer>
+
+  fun getPeer(peerId: String): Peer?
+}
+
+data class Peer(
+  val nodeId: String,
+  val enr: String?,
+  val address: String,
+  val status: PeerStatus,
+  val direction: PeerDirection,
+) {
+  enum class PeerStatus {
+    DISCONNECTED,
+    CONNECTING,
+    CONNECTED,
+    DISCONNECTING,
+  }
+
+  enum class PeerDirection {
+    INBOUND,
+    OUTBOUND,
+  }
 }

--- a/p2p/src/main/kotlin/maru/p2p/Extensions.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Extensions.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.p2p
+
+import tech.pegasys.teku.networking.p2p.peer.Peer as TekuPeer
+
+fun TekuPeer.toMaruPeer(): Peer =
+  Peer(
+    nodeId = id.toBase58(),
+    enr = null,
+    address = address.toExternalForm(),
+    status = if (isConnected) Peer.PeerStatus.CONNECTED else Peer.PeerStatus.DISCONNECTED,
+    direction =
+      if (connectionInitiatedLocally()) {
+        Peer.PeerDirection.OUTBOUND
+      } else {
+        Peer.PeerDirection.INBOUND
+      },
+  )

--- a/p2p/src/main/kotlin/maru/p2p/Extensions.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Extensions.kt
@@ -8,18 +8,16 @@
  */
 package maru.p2p
 
-import tech.pegasys.teku.networking.p2p.peer.Peer as TekuPeer
-
-fun TekuPeer.toMaruPeer(): Peer =
-  Peer(
+fun MaruPeer.toPeerInfo(): PeerInfo =
+  PeerInfo(
     nodeId = id.toBase58(),
     enr = null,
     address = address.toExternalForm(),
-    status = if (isConnected) Peer.PeerStatus.CONNECTED else Peer.PeerStatus.DISCONNECTED,
+    status = if (isConnected) PeerInfo.PeerStatus.CONNECTED else PeerInfo.PeerStatus.DISCONNECTED,
     direction =
       if (connectionInitiatedLocally()) {
-        Peer.PeerDirection.OUTBOUND
+        PeerInfo.PeerDirection.OUTBOUND
       } else {
-        Peer.PeerDirection.INBOUND
+        PeerInfo.PeerDirection.INBOUND
       },
   )

--- a/p2p/src/main/kotlin/maru/p2p/Libp2pNetworkFactory.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Libp2pNetworkFactory.kt
@@ -51,6 +51,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod
 data class TekuLibP2PNetwork(
   val p2PNetwork: P2PNetwork<Peer>,
   val host: Host,
+  val peerLookup: PeerLookup,
 )
 
 class Libp2pNetworkFactory(
@@ -128,7 +129,7 @@ class Libp2pNetworkFactory(
         /* gossipNetwork = */ gossipNetwork,
         /* listenPorts = */ listOf(port.toInt()),
       )
-    return TekuLibP2PNetwork(p2pNetwork, host)
+    return TekuLibP2PNetwork(p2pNetwork, host, maruPeerManager)
   }
 
   private fun getMessageFactory(

--- a/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
@@ -53,4 +53,6 @@ class MaruPeerManager(
   }
 
   override fun getPeer(nodeId: NodeId): MaruPeer? = connectedPeers[nodeId]
+
+  override fun getPeers(): List<MaruPeer> = connectedPeers.values.toList()
 }

--- a/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
+++ b/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
@@ -49,7 +49,7 @@ object NoOpP2PNetwork : P2PNetwork {
   override val discoveryAddresses: List<String> = emptyList()
   override val enr: String? = null
 
-  override fun getPeers(): List<Peer> = emptyList()
+  override fun getPeers(): List<PeerInfo> = emptyList()
 
-  override fun getPeer(peerId: String): Peer? = null
+  override fun getPeer(peerId: String): PeerInfo? = null
 }

--- a/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
+++ b/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
@@ -48,4 +48,8 @@ object NoOpP2PNetwork : P2PNetwork {
   override val nodeAddresses: List<String> = emptyList()
   override val discoveryAddresses: List<String> = emptyList()
   override val enr: String? = null
+
+  override fun getPeers(): List<Peer> = emptyList()
+
+  override fun getPeer(peerId: String): Peer? = null
 }

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkDataProvider.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkDataProvider.kt
@@ -8,6 +8,7 @@
  */
 package maru.p2p
 
+import maru.api.InvalidPeerIdException
 import maru.api.NetworkDataProvider
 
 class P2PNetworkDataProvider(
@@ -21,7 +22,15 @@ class P2PNetworkDataProvider(
 
   override fun getDiscoveryAddresses(): List<String> = p2PNetwork.discoveryAddresses
 
-  override fun getPeers(): List<Peer> = p2PNetwork.getPeers()
+  override fun getPeers(): List<PeerInfo> = p2PNetwork.getPeers()
 
-  override fun getPeer(peerId: String): Peer? = p2PNetwork.getPeer(peerId)
+  override fun getPeer(peerId: String): PeerInfo? =
+    try {
+      p2PNetwork.getPeer(peerId)
+    } catch (e: Exception) {
+      if (e.message?.contains("invalid base58 encoded form") == true) {
+        throw InvalidPeerIdException(peerId)
+      }
+      throw e
+    }
 }

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkDataProvider.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkDataProvider.kt
@@ -20,4 +20,8 @@ class P2PNetworkDataProvider(
   override fun getNodeAddresses(): List<String> = p2PNetwork.nodeAddresses
 
   override fun getDiscoveryAddresses(): List<String> = p2PNetwork.discoveryAddresses
+
+  override fun getPeers(): List<Peer> = p2PNetwork.getPeers()
+
+  override fun getPeer(peerId: String): Peer? = p2PNetwork.getPeer(peerId)
 }

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
@@ -17,6 +17,7 @@ import kotlin.jvm.optionals.getOrNull
 import maru.config.P2P
 import maru.core.SealedBeaconBlock
 import maru.metrics.MaruMetricsCategory
+import maru.p2p.MaruPeerManager
 import maru.p2p.messages.StatusMessageFactory
 import maru.p2p.topics.TopicHandlerWithInOrderDelivering
 import maru.serialization.SerDe
@@ -85,6 +86,7 @@ class P2PNetworkImpl(
 
   private val builtNetwork: TekuLibP2PNetwork = buildP2PNetwork(privateKeyBytes, p2pConfig)
   internal val p2pNetwork = builtNetwork.p2PNetwork
+  internal val peerLookup = builtNetwork.peerLookup
   private val log: Logger = LogManager.getLogger(this::javaClass)
   private val delayedExecutor =
     SafeFuture.delayedExecutor(p2pConfig.reconnectDelay.inWholeMilliseconds, TimeUnit.MILLISECONDS)
@@ -252,8 +254,8 @@ class P2PNetworkImpl(
     }
   }
 
-  internal fun getPeer(peer: String) =
-    p2pNetwork
-      .getPeer(LibP2PNodeId(PeerId.fromBase58(peer)))
-      .getOrNull()
+  override fun getPeers(): List<PeerInfo> = peerLookup.getPeers().map { it.toPeerInfo() }
+
+  override fun getPeer(peerId: String): PeerInfo? =
+    peerLookup.getPeer(LibP2PNodeId(PeerId.fromBase58(peerId)))?.toPeerInfo()
 }

--- a/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
@@ -8,6 +8,7 @@
  */
 package maru.p2p
 
+import io.libp2p.core.PeerId
 import java.lang.Thread.sleep
 import java.util.concurrent.TimeUnit
 import maru.config.P2P
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId
 import tech.pegasys.teku.networking.p2p.libp2p.MultiaddrPeerAddress
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 
@@ -414,7 +416,7 @@ class P2PTest {
           latestBlockNumber = latestBeaconBlockHeader.number,
         )
       val peer1 =
-        p2pManagerImpl2.getPeer(PEER_ID_NODE_1)
+        p2pManagerImpl2.peerLookup.getPeer(LibP2PNodeId(PeerId.fromBase58(PEER_ID_NODE_1)))
           ?: throw IllegalStateException("Peer with ID $PEER_ID_NODE_1 not found in p2pManagerImpl2")
       val maruPeer1 = DefaultMaruPeer(peer1, rpcMethods, statusMessageFactory)
 


### PR DESCRIPTION
#95 

Implement the following node apis:

- [/eth/v1/node/peers](https://ethereum.github.io/beacon-APIs/#/Node/getPeers)
- [/eth/v1/node/peers/{peer_id}](https://ethereum.github.io/beacon-APIs/#/Node/getPeer)
- [/eth/v1/node/peer_count](https://ethereum.github.io/beacon-APIs/#/Node/getPeerCount)
- [/eth/v1/node/version](https://ethereum.github.io/beacon-APIs/#/Node/getNodeVersion)
- [/eth/v1/node/syncing](https://ethereum.github.io/beacon-APIs/#/Node/getSyncingStatus)
- [/eth/v1/node/health](https://ethereum.github.io/beacon-APIs/#/Node/getHealth)

Syncing and Health apis have placeholder data for now as they need information about syncing which isn't implemented yet.