### PR TITLE
[96] Implement GetBlock and GetBlockHeader endpoints

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -7,6 +7,7 @@ dependencies {
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
   implementation "io.javalin:javalin"
   implementation project(":core")
+  implementation project(":jvm-libs:extensions")
 
   testImplementation(testFixtures(project(":core")))
   testImplementation("com.squareup.okhttp3:okhttp")

--- a/api/src/main/kotlin/maru/api/ApiServerImpl.kt
+++ b/api/src/main/kotlin/maru/api/ApiServerImpl.kt
@@ -10,6 +10,8 @@ package maru.api
 
 import io.javalin.Javalin
 import maru.VersionProvider
+import maru.api.beacon.GetBlock
+import maru.api.beacon.GetBlockHeader
 import maru.api.node.GetHealth
 import maru.api.node.GetNetworkIdentity
 import maru.api.node.GetPeer
@@ -22,6 +24,7 @@ class ApiServerImpl(
   val config: Config,
   val networkDataProvider: NetworkDataProvider,
   val versionProvider: VersionProvider,
+  val chainDataProvider: ChainDataProvider,
 ) : ApiServer {
   data class Config(
     val port: UInt,
@@ -49,6 +52,8 @@ class ApiServerImpl(
           .get(GetVersion.ROUTE, GetVersion(versionProvider))
           .get(GetSyncingStatus.ROUTE, GetSyncingStatus())
           .get(GetHealth.ROUTE, GetHealth())
+          .get(GetBlockHeader.ROUTE, GetBlockHeader(chainDataProvider))
+          .get(GetBlock.ROUTE, GetBlock(chainDataProvider))
           .start(config.port.toInt())
     }
   }

--- a/api/src/main/kotlin/maru/api/ChainDataProviderImpl.kt
+++ b/api/src/main/kotlin/maru/api/ChainDataProviderImpl.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api
+
+import maru.core.SealedBeaconBlock
+import maru.database.BeaconChain
+import maru.extensions.fromHexToByteArray
+
+class ChainDataProviderImpl(
+  val beaconChain: BeaconChain,
+) : ChainDataProvider {
+  override fun getBeaconBlockByNumber(blockNumber: ULong): SealedBeaconBlock =
+    beaconChain.getSealedBeaconBlock(blockNumber) ?: throw BlockNotFoundException()
+
+  override fun getLatestBeaconBlock(): SealedBeaconBlock {
+    val latestBeaconBlockHeader = beaconChain.getLatestBeaconState().latestBeaconBlockHeader
+    return beaconChain.getSealedBeaconBlock(latestBeaconBlockHeader.number)
+      ?: throw BlockNotFoundException()
+  }
+
+  override fun getBeaconBlockByBlockRoot(blockRoot: String): SealedBeaconBlock {
+    val blockRootBytes = blockRoot.fromHexToByteArray()
+    return beaconChain.getSealedBeaconBlock(blockRootBytes) ?: throw BlockNotFoundException()
+  }
+}

--- a/api/src/main/kotlin/maru/api/beacon/BeaconBlock.kt
+++ b/api/src/main/kotlin/maru/api/beacon/BeaconBlock.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblockheader
+data class SignedBeaconBlockHeader(
+  @JsonProperty("message") val message: BeaconBlockHeader,
+  @JsonProperty("signature") val signature: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblockheader
+@JsonDeserialize(`as` = MaruApiBeaconBlockHeader::class)
+interface BeaconBlockHeader {
+  val slot: String
+  val proposerIndex: String
+  val parentRoot: String
+  val stateRoot: String
+  val bodyRoot: String
+}
+
+data class MaruApiBeaconBlockHeader(
+  @JsonProperty("slot") override val slot: String,
+  @JsonProperty("proposer_index") override val proposerIndex: String,
+  @JsonProperty("parent_root") override val parentRoot: String,
+  @JsonProperty("state_root") override val stateRoot: String,
+  @JsonProperty("body_root") override val bodyRoot: String,
+  @JsonProperty("round") val round: String,
+  @JsonProperty("timestamp") val timestamp: String,
+) : BeaconBlockHeader
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblock
+data class SignedBeaconBlock(
+  @JsonProperty("message") val message: BeaconBlock,
+  @JsonProperty("signature") val signature: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblock
+@JsonDeserialize(`as` = MaruApiSealedBeaconBlock::class)
+interface BeaconBlock {
+  val slot: String
+  val proposerIndex: String
+  val parentRoot: String
+  val stateRoot: String
+  val body: BeaconBlockBody
+}
+
+data class MaruApiSealedBeaconBlock(
+  @JsonProperty("slot") override val slot: String,
+  @JsonProperty("proposer_index") override val proposerIndex: String,
+  @JsonProperty("parent_root") override val parentRoot: String,
+  @JsonProperty("state_root") override val stateRoot: String,
+  @JsonProperty("body") override val body: MaruApiBeaconBlockBody,
+) : BeaconBlock
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#beaconblockbody
+@JsonDeserialize(`as` = MaruApiBeaconBlockBody::class)
+interface BeaconBlockBody {
+  val randaoReveal: String
+  val eth1Data: Eth1Data
+  val graffiti: String
+  val proposerSlashings: List<ProposerSlashing>
+  val attesterSlashings: List<AttesterSlashing>
+  val attestations: List<Attestation>
+  val deposits: List<Deposit>
+  val syncAggregate: SyncAggregate
+  val executionPayload: ExecutionPayload
+}
+
+data class MaruApiBeaconBlockBody(
+  @JsonProperty("randao_reveal") override val randaoReveal: String,
+  @JsonProperty("eth1_data") override val eth1Data: Eth1Data,
+  @JsonProperty("graffiti") override val graffiti: String,
+  @JsonProperty("proposer_slashings") override val proposerSlashings: List<ProposerSlashing>,
+  @JsonProperty("attester_slashings") override val attesterSlashings: List<AttesterSlashing>,
+  // attestations will be repurposed for commit seals of the current and previous block
+  @JsonProperty("attestations") override val attestations: List<Attestation>,
+  @JsonProperty("deposits") override val deposits: List<Deposit>,
+  @JsonProperty("sync_aggregate") override val syncAggregate: SyncAggregate,
+  @JsonProperty("execution_payload") override val executionPayload: ExecutionPayload,
+) : BeaconBlockBody
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#eth1data
+data class Eth1Data(
+  @JsonProperty("deposit_root") val depositRoot: String,
+  @JsonProperty("deposit_count") val depositCount: String,
+  @JsonProperty("block_hash") val blockHash: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#proposerslashing
+data class ProposerSlashing(
+  @JsonProperty("signed_header_1") val signedHeader1: SignedBeaconBlockHeader,
+  @JsonProperty("signed_header_2") val signedHeader2: SignedBeaconBlockHeader,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attesterslashing
+data class AttesterSlashing(
+  @JsonProperty("attestation_1") val attestation1: IndexedAttestation,
+  @JsonProperty("attestation_2") val attestation2: IndexedAttestation,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#indexedattestation
+data class IndexedAttestation(
+  @JsonProperty("attesting_indices") val attestingIndices: List<String> = emptyList(),
+  @JsonProperty("data") val data: AttestationData,
+  @JsonProperty("signature") val signature: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attestationdata
+data class AttestationData(
+  @JsonProperty("slot") val slot: String,
+  @JsonProperty("index") val index: String,
+  @JsonProperty("beacon_block_root") val beaconBlockRoot: String,
+  @JsonProperty("source") val source: Checkpoint,
+  @JsonProperty("target") val target: Checkpoint,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#checkpoint
+data class Checkpoint(
+  @JsonProperty("epoch") val epoch: String,
+  @JsonProperty("root") val root: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#attestation
+data class Attestation(
+  @JsonProperty("aggregation_bits") val aggregationBits: String,
+  @JsonProperty("data") val data: AttestationData,
+  @JsonProperty("signature") val signature: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#deposit
+data class Deposit(
+  @JsonProperty("proof") val proof: List<String>,
+  @JsonProperty("data") val data: DepositData,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#depositdata
+data class DepositData(
+  @JsonProperty("pubkey") val pubkey: String,
+  @JsonProperty("withdrawal_credentials") val withdrawalCredentials: String,
+  @JsonProperty("amount") val amount: String,
+  @JsonProperty("signature") val signature: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#syncaggregate
+data class SyncAggregate(
+  @JsonProperty("sync_committee_bits") val syncCommitteeBits: String,
+  @JsonProperty("sync_committee_signature") val syncCommitteeSignature: String,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#executionpayload
+data class ExecutionPayload(
+  @JsonProperty("parent_hash") val parentHash: String,
+  @JsonProperty("fee_recipient") val feeRecipient: String,
+  @JsonProperty("state_root") val stateRoot: String,
+  @JsonProperty("receipts_root") val receiptsRoot: String,
+  @JsonProperty("logs_bloom") val logsBloom: String,
+  @JsonProperty("prev_randao") val prevRandao: String,
+  @JsonProperty("block_number") val blockNumber: String,
+  @JsonProperty("gas_limit") val gasLimit: String,
+  @JsonProperty("gas_used") val gasUsed: String,
+  @JsonProperty("timestamp") val timestamp: String,
+  @JsonProperty("extra_data") val extraData: String,
+  @JsonProperty("base_fee_per_gas") val baseFeePerGas: String,
+  @JsonProperty("block_hash") val blockHash: String,
+  @JsonProperty("transactions") val transactions: List<String>,
+)

--- a/api/src/main/kotlin/maru/api/beacon/Extensions.kt
+++ b/api/src/main/kotlin/maru/api/beacon/Extensions.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import maru.extensions.encodeHex
+import maru.core.BeaconBlockHeader as MaruBeaconBlockHeader
+import maru.core.ExecutionPayload as MaruExecutionPayload
+import maru.core.Seal as MaruSeal
+import maru.core.SealedBeaconBlock as MaruSealedBeaconBlock
+
+fun MaruSealedBeaconBlock.toBeaconBlock(): BeaconBlock {
+  val maruHeader = this.beaconBlock.beaconBlockHeader
+  val currentBlockAttestations =
+    this.commitSeals.map {
+      it.toAttestation(
+        blockNumber = maruHeader.number,
+        beaconBlockRoot = maruHeader.hash(),
+      )
+    }
+
+  val maruBody = this.beaconBlock.beaconBlockBody
+  val prevBlockAttestations =
+    if (maruHeader.number > 0u) {
+      maruBody.prevCommitSeals.map {
+        it.toAttestation(
+          blockNumber = maruHeader.number - 1u,
+          beaconBlockRoot = maruHeader.parentRoot,
+        )
+      }
+    } else {
+      emptyList()
+    }
+
+  val blockBody =
+    MaruApiBeaconBlockBody(
+      randaoReveal = "0x",
+      eth1Data =
+        Eth1Data(
+          depositCount = "0",
+          depositRoot = "0x",
+          blockHash = "0x",
+        ),
+      graffiti = "0x",
+      proposerSlashings = emptyList(),
+      attesterSlashings = emptyList(),
+      attestations = currentBlockAttestations + prevBlockAttestations,
+      deposits = emptyList(),
+      syncAggregate =
+        SyncAggregate(
+          syncCommitteeBits = "0x",
+          syncCommitteeSignature = "0x",
+        ),
+      executionPayload = maruBody.executionPayload.toExecutionPayload(),
+    )
+
+  val header = maruHeader.toBeaconBlockHeader()
+  return MaruApiSealedBeaconBlock(
+    slot = header.slot,
+    proposerIndex = header.proposerIndex,
+    parentRoot = header.parentRoot,
+    stateRoot = header.stateRoot,
+    body = blockBody,
+  )
+}
+
+fun MaruBeaconBlockHeader.toBeaconBlockHeader(): BeaconBlockHeader =
+  MaruApiBeaconBlockHeader(
+    slot = this.number.toString(),
+    round = this.round.toString(),
+    timestamp = this.timestamp.toString(),
+    proposerIndex = this.proposer.address.encodeHex(),
+    parentRoot = this.parentRoot.encodeHex(),
+    stateRoot = this.stateRoot.encodeHex(),
+    bodyRoot = this.bodyRoot.encodeHex(),
+  )
+
+fun MaruSeal.toAttestation(
+  blockNumber: ULong,
+  beaconBlockRoot: ByteArray,
+): Attestation {
+  val attestationData =
+    AttestationData(
+      slot = blockNumber.toString(),
+      index = "0",
+      beaconBlockRoot = beaconBlockRoot.encodeHex(),
+      source = Checkpoint("0", "0x"),
+      target = Checkpoint("0", "0x"),
+    )
+  return Attestation(
+    aggregationBits = "0x",
+    data = attestationData,
+    signature = this.signature.encodeHex(),
+  )
+}
+
+private fun MaruExecutionPayload.toExecutionPayload(): ExecutionPayload =
+  ExecutionPayload(
+    parentHash = this.parentHash.encodeHex(),
+    feeRecipient = this.feeRecipient.encodeHex(),
+    stateRoot = this.stateRoot.encodeHex(),
+    receiptsRoot = this.receiptsRoot.encodeHex(),
+    logsBloom = this.logsBloom.encodeHex(),
+    prevRandao = this.prevRandao.encodeHex(),
+    blockNumber = this.blockNumber.toString(),
+    gasLimit = this.gasLimit.toString(),
+    gasUsed = this.gasUsed.toString(),
+    timestamp = this.timestamp.toString(),
+    extraData = this.extraData.encodeHex(),
+    baseFeePerGas = this.baseFeePerGas.toString(),
+    blockHash = this.blockHash.encodeHex(),
+    transactions = this.transactions.map { it.encodeHex() },
+  )

--- a/api/src/main/kotlin/maru/api/beacon/GetBlock.kt
+++ b/api/src/main/kotlin/maru/api/beacon/GetBlock.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import maru.api.ChainDataProvider
+
+// https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
+data class GetBlockResponse(
+  @JsonProperty("version") val version: String,
+  @JsonProperty("execution_optimistic")val executionOptimistic: Boolean,
+  @JsonProperty("finalized") val finalized: Boolean,
+  @JsonProperty("data") val data: SignedBeaconBlock,
+)
+
+class GetBlock(
+  val chainDataProvider: ChainDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val maruSealedBeaconBlock = getBlock(ctx.pathParam(BLOCK_ID), chainDataProvider)
+    val signedBeaconBlock =
+      SignedBeaconBlock(
+        message = maruSealedBeaconBlock.toBeaconBlock(),
+        signature = "0x",
+      )
+    val response =
+      GetBlockResponse(
+        version = "maru",
+        executionOptimistic = false,
+        finalized = false,
+        data = signedBeaconBlock,
+      )
+    ctx.header("Eth-Consensus-Version", "bellatrix").status(200).json(response)
+  }
+
+  companion object {
+    const val BLOCK_ID: String = "block_id"
+    const val ROUTE: String = "/eth/v2/beacon/blocks/{$BLOCK_ID}"
+  }
+}

--- a/api/src/main/kotlin/maru/api/beacon/GetBlockHeader.kt
+++ b/api/src/main/kotlin/maru/api/beacon/GetBlockHeader.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import maru.api.ChainDataProvider
+
+// https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeader
+data class GetBlockHeaderResponse(
+  @JsonProperty("execution_optimistic")val executionOptimistic: Boolean,
+  @JsonProperty("finalized") val finalized: Boolean,
+  @JsonProperty("data") val data: SignedBeaconBlockHeader,
+)
+
+class GetBlockHeader(
+  val chainDataProvider: ChainDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val maruSealedBeaconBlock = getBlock(ctx.pathParam(BLOCK_ID), chainDataProvider)
+    val signedBeaconBlockHeader =
+      SignedBeaconBlockHeader(
+        message = maruSealedBeaconBlock.beaconBlock.beaconBlockHeader.toBeaconBlockHeader(),
+        signature = "0x",
+      )
+    val response =
+      GetBlockHeaderResponse(
+        executionOptimistic = false,
+        finalized = false,
+        data = signedBeaconBlockHeader,
+      )
+    ctx.status(200).json(response)
+  }
+
+  companion object {
+    const val BLOCK_ID: String = "block_id"
+    const val ROUTE: String = "/eth/v1/beacon/headers/{$BLOCK_ID}"
+  }
+}

--- a/api/src/main/kotlin/maru/api/beacon/ParameterHelpers.kt
+++ b/api/src/main/kotlin/maru/api/beacon/ParameterHelpers.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import maru.api.BlockNotFoundException
+import maru.api.ChainDataProvider
+import maru.api.HandlerException
+import maru.core.SealedBeaconBlock
+import maru.extensions.isPositiveNumber
+
+fun getBlock(
+  blockId: String,
+  chainDataProvider: ChainDataProvider,
+): SealedBeaconBlock {
+  val maruSealedBeaconBlock =
+    try {
+      when {
+        blockId.lowercase() == "head" -> chainDataProvider.getLatestBeaconBlock()
+        blockId.lowercase() == "finalized" -> chainDataProvider.getLatestBeaconBlock()
+        blockId.lowercase() == "genesis" -> chainDataProvider.getGenesisBeaconBlock()
+        blockId.isPositiveNumber() -> chainDataProvider.getBeaconBlockByNumber(blockId.toLong().toULong())
+        blockId.startsWith("0x") -> chainDataProvider.getBeaconBlockByBlockRoot(blockId)
+        else -> throw HandlerException(400, "Invalid block ID: $blockId")
+      }
+    } catch (e: BlockNotFoundException) {
+      throw HandlerException(404, "Block not found")
+    }
+  return maruSealedBeaconBlock
+}

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -22,6 +22,7 @@ import linea.web3j.createWeb3jHttpClient
 import linea.web3j.ethapi.createEthApiClient
 import maru.api.ApiServer
 import maru.api.ApiServerImpl
+import maru.api.ChainDataProviderImpl
 import maru.config.MaruConfig
 import maru.config.P2P
 import maru.consensus.ForkIdHashProvider
@@ -141,6 +142,7 @@ class MaruAppFactory {
             ),
           networkDataProvider = P2PNetworkDataProvider(p2pNetwork),
           versionProvider = MaruVersionProvider(),
+          chainDataProvider = ChainDataProviderImpl(beaconChain),
         )
 
     val maru =

--- a/core/src/main/kotlin/maru/api/ChainDataProvider.kt
+++ b/core/src/main/kotlin/maru/api/ChainDataProvider.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api
+
+import maru.core.SealedBeaconBlock
+
+interface ChainDataProvider {
+  fun getGenesisBeaconBlock(): SealedBeaconBlock = getBeaconBlockByNumber(0u)
+
+  fun getBeaconBlockByNumber(blockNumber: ULong): SealedBeaconBlock
+
+  fun getLatestBeaconBlock(): SealedBeaconBlock
+
+  fun getBeaconBlockByBlockRoot(blockRoot: String): SealedBeaconBlock
+}
+
+class BlockNotFoundException : Exception()

--- a/jvm-libs/extensions/src/main/kotlin/StringExtensions.kt
+++ b/jvm-libs/extensions/src/main/kotlin/StringExtensions.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.extensions
+
+fun String.isPositiveNumber(): Boolean = this.isNotEmpty() && this.all { it.isDigit() }


### PR DESCRIPTION
#96 

Implement the following endpoints
- [/eth/v1/beacon/headers/{block_id}](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeader)
- [/eth/v2/beacon/blocks/{block_id}](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2)