### PR TITLE
[96] Implement beacon validator apis

### DIFF
--- a/api/src/main/kotlin/maru/api/ApiServerImpl.kt
+++ b/api/src/main/kotlin/maru/api/ApiServerImpl.kt
@@ -12,6 +12,8 @@ import io.javalin.Javalin
 import maru.VersionProvider
 import maru.api.beacon.GetBlock
 import maru.api.beacon.GetBlockHeader
+import maru.api.beacon.GetStateValidator
+import maru.api.beacon.GetStateValidators
 import maru.api.node.GetHealth
 import maru.api.node.GetNetworkIdentity
 import maru.api.node.GetPeer
@@ -54,6 +56,8 @@ class ApiServerImpl(
           .get(GetHealth.ROUTE, GetHealth())
           .get(GetBlockHeader.ROUTE, GetBlockHeader(chainDataProvider))
           .get(GetBlock.ROUTE, GetBlock(chainDataProvider))
+          .get(GetStateValidator.ROUTE, GetStateValidator(chainDataProvider))
+          .get(GetStateValidators.ROUTE, GetStateValidators(chainDataProvider))
           .start(config.port.toInt())
     }
   }

--- a/api/src/main/kotlin/maru/api/ChainDataProviderImpl.kt
+++ b/api/src/main/kotlin/maru/api/ChainDataProviderImpl.kt
@@ -8,6 +8,7 @@
  */
 package maru.api
 
+import maru.core.BeaconState
 import maru.core.SealedBeaconBlock
 import maru.database.BeaconChain
 import maru.extensions.fromHexToByteArray
@@ -15,6 +16,11 @@ import maru.extensions.fromHexToByteArray
 class ChainDataProviderImpl(
   val beaconChain: BeaconChain,
 ) : ChainDataProvider {
+  override fun getLatestBeaconState(): BeaconState = beaconChain.getLatestBeaconState()
+
+  override fun getBeaconStateByStateRoot(stateRoot: ByteArray): BeaconState =
+    beaconChain.getBeaconState(stateRoot) ?: throw BeaconStateNotFoundException()
+
   override fun getBeaconBlockByNumber(blockNumber: ULong): SealedBeaconBlock =
     beaconChain.getSealedBeaconBlock(blockNumber) ?: throw BlockNotFoundException()
 

--- a/api/src/main/kotlin/maru/api/beacon/GetStateValidator.kt
+++ b/api/src/main/kotlin/maru/api/beacon/GetStateValidator.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import maru.api.ChainDataProvider
+import maru.extensions.encodeHex
+
+data class GetStateValidatorResponse(
+  @JsonProperty("execution_optimistic") val executionOptimistic: Boolean,
+  @JsonProperty("finalized") val finalized: Boolean,
+  @JsonProperty("data") val data: ValidatorResponse,
+)
+
+data class ValidatorResponse(
+  @JsonProperty("index") val index: String,
+  @JsonProperty("balance") val balance: String,
+  @JsonProperty("status") val status: String,
+  @JsonProperty("validator") val validator: Validator,
+)
+
+// https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#validator
+data class Validator(
+  @JsonProperty("pubkey") val pubkey: String,
+  @JsonProperty("withdrawal_credentials") val withdrawalCredentials: String,
+  @JsonProperty("effective_balance") val effectiveBalance: String,
+  @JsonProperty("slashed") val slashed: Boolean,
+  @JsonProperty("activation_eligibility_epoch") val activationEligibilityEpoch: String,
+  @JsonProperty("activation_epoch") val activationEpoch: String,
+  @JsonProperty("exit_epoch") val exitEpoch: String,
+  @JsonProperty("withdrawable_epoch") val withdrawableEpoch: String,
+)
+
+class GetStateValidator(
+  val chainDataProvider: ChainDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val beaconState = getBeaconState(ctx.pathParam(STATE_ID), chainDataProvider)
+    val indexedValidator = getValidator(ctx.pathParam(VALIDATOR_ID), beaconState)
+    val validator =
+      ValidatorResponse(
+        index = indexedValidator.index.toString(),
+        balance = "",
+        status = "active_ongoing",
+        validator =
+          Validator(
+            pubkey = indexedValidator.value.address.encodeHex(),
+            withdrawalCredentials = "0x",
+            effectiveBalance = "",
+            slashed = false,
+            activationEligibilityEpoch = "",
+            activationEpoch = "",
+            exitEpoch = "",
+            withdrawableEpoch = "",
+          ),
+      )
+
+    val response =
+      GetStateValidatorResponse(
+        executionOptimistic = false,
+        finalized = false,
+        data = validator,
+      )
+    ctx.status(200).json(response)
+  }
+
+  companion object {
+    const val STATE_ID: String = "state_id"
+    const val VALIDATOR_ID: String = "validator_id"
+    const val ROUTE: String = "/eth/v1/beacon/states/{$STATE_ID}/validators/{$VALIDATOR_ID}"
+  }
+}

--- a/api/src/main/kotlin/maru/api/beacon/GetStateValidators.kt
+++ b/api/src/main/kotlin/maru/api/beacon/GetStateValidators.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.api.beacon
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.javalin.http.Context
+import io.javalin.http.Handler
+import maru.api.ChainDataProvider
+import maru.extensions.encodeHex
+
+data class GetStateValidatorsResponse(
+  @JsonProperty("execution_optimistic")val executionOptimistic: Boolean,
+  @JsonProperty("finalized") val finalized: Boolean,
+  @JsonProperty("data") val data: List<ValidatorResponse>,
+)
+
+class GetStateValidators(
+  val chainDataProvider: ChainDataProvider,
+) : Handler {
+  override fun handle(ctx: Context) {
+    val beaconState = getBeaconState(ctx.pathParam(GetStateValidators.STATE_ID), chainDataProvider)
+    val validators =
+      beaconState.validators.mapIndexed { index, validator ->
+        ValidatorResponse(
+          index = index.toString(),
+          balance = "",
+          status = "active_ongoing",
+          validator =
+            Validator(
+              pubkey = validator.address.encodeHex(),
+              withdrawalCredentials = "0x",
+              effectiveBalance = "",
+              slashed = false,
+              activationEligibilityEpoch = "",
+              activationEpoch = "",
+              exitEpoch = "",
+              withdrawableEpoch = "",
+            ),
+        )
+      }
+    val response =
+      GetStateValidatorsResponse(
+        executionOptimistic = false,
+        finalized = false,
+        data = validators,
+      )
+    ctx.status(200).json(response)
+  }
+
+  companion object {
+    const val ROUTE: String = "/eth/v1/beacon/states/{state_id}/validators"
+    const val STATE_ID: String = "state_id"
+  }
+}

--- a/api/src/main/kotlin/maru/api/beacon/ParameterHelpers.kt
+++ b/api/src/main/kotlin/maru/api/beacon/ParameterHelpers.kt
@@ -8,10 +8,14 @@
  */
 package maru.api.beacon
 
+import maru.api.BeaconStateNotFoundException
 import maru.api.BlockNotFoundException
 import maru.api.ChainDataProvider
 import maru.api.HandlerException
+import maru.core.BeaconState
 import maru.core.SealedBeaconBlock
+import maru.core.Validator
+import maru.extensions.fromHexToByteArray
 import maru.extensions.isPositiveNumber
 
 fun getBlock(
@@ -25,11 +29,49 @@ fun getBlock(
         blockId.lowercase() == "finalized" -> chainDataProvider.getLatestBeaconBlock()
         blockId.lowercase() == "genesis" -> chainDataProvider.getGenesisBeaconBlock()
         blockId.isPositiveNumber() -> chainDataProvider.getBeaconBlockByNumber(blockId.toLong().toULong())
-        blockId.startsWith("0x") -> chainDataProvider.getBeaconBlockByBlockRoot(blockId)
+        blockId.lowercase().startsWith("0x") -> chainDataProvider.getBeaconBlockByBlockRoot(blockId)
         else -> throw HandlerException(400, "Invalid block ID: $blockId")
       }
     } catch (e: BlockNotFoundException) {
       throw HandlerException(404, "Block not found")
     }
   return maruSealedBeaconBlock
+}
+
+fun getBeaconState(
+  stateId: String,
+  chainDataProvider: ChainDataProvider,
+): BeaconState =
+  try {
+    when {
+      stateId.lowercase() == "head" -> chainDataProvider.getLatestBeaconState()
+      stateId.lowercase() == "finalized" -> throw HandlerException(
+        400,
+        "Finalized state is not supported for validators endpoint",
+      )
+      stateId.lowercase() == "genesis" -> chainDataProvider.getGenesisBeaconState()
+      stateId.lowercase().startsWith("0x") -> chainDataProvider.getBeaconStateByStateRoot(stateId.fromHexToByteArray())
+      else -> throw HandlerException(400, "Invalid state ID: $stateId")
+    }
+  } catch (e: BeaconStateNotFoundException) {
+    throw HandlerException(404, "State not found")
+  }
+
+fun getValidator(
+  validatorId: String,
+  beaconState: BeaconState,
+): IndexedValue<Validator> {
+  val indexedValidator =
+    when {
+      validatorId.isPositiveNumber() -> beaconState.validators.withIndex().find { it.index == validatorId.toInt() }
+      validatorId.lowercase().startsWith(prefix = "0x") -> {
+        val address = validatorId.fromHexToByteArray()
+        beaconState.validators.withIndex().find { it.value.address.contentEquals(address) }
+      }
+      else -> throw HandlerException(400, "Invalid validator ID: $validatorId")
+    }
+  if (indexedValidator == null) {
+    throw HandlerException(404, "Validator not found")
+  }
+  return indexedValidator
 }

--- a/core/src/main/kotlin/maru/api/ChainDataProvider.kt
+++ b/core/src/main/kotlin/maru/api/ChainDataProvider.kt
@@ -8,9 +8,20 @@
  */
 package maru.api
 
+import maru.core.BeaconState
 import maru.core.SealedBeaconBlock
 
 interface ChainDataProvider {
+  fun getGenesisBeaconState(): BeaconState =
+    getGenesisBeaconBlock().let { genesisBlock ->
+      getBeaconStateByStateRoot(genesisBlock.beaconBlock.beaconBlockHeader.stateRoot)
+        ?: throw BeaconStateNotFoundException()
+    }
+
+  fun getLatestBeaconState(): BeaconState
+
+  fun getBeaconStateByStateRoot(stateRoot: ByteArray): BeaconState
+
   fun getGenesisBeaconBlock(): SealedBeaconBlock = getBeaconBlockByNumber(0u)
 
   fun getBeaconBlockByNumber(blockNumber: ULong): SealedBeaconBlock
@@ -21,3 +32,5 @@ interface ChainDataProvider {
 }
 
 class BlockNotFoundException : Exception()
+
+class BeaconStateNotFoundException : Exception()


### PR DESCRIPTION
#96 

Implement the following apis:
- [/eth/v1/beacon/states/{state_id}/validators](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators)
- [/eth/v1/beacon/states/{state_id}/validators/{validator_id}](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidator)