### PR TITLE
Update besu to 25.7.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,8 +40,8 @@ dependencies {
   implementation "info.picocli:picocli"
   implementation "com.sksamuel.hoplite:hoplite-core"
 
-  implementation("org.hyperledger.besu.internal:metrics-core")
-  implementation("org.hyperledger.besu.internal:algorithms")
+  implementation("org.hyperledger.besu.internal:besu-metrics-core")
+  implementation("org.hyperledger.besu.internal:besu-crypto-algorithms")
   implementation("tech.pegasys.teku.internal:p2p")
   implementation("io.libp2p:jvm-libp2p")
 
@@ -49,14 +49,14 @@ dependencies {
   integrationTestImplementation(testFixtures(project(":core")))
   integrationTestImplementation(testFixtures(project(":config")))
   integrationTestImplementation(project(":crypto"))
-  integrationTestImplementation "org.hyperledger.besu.internal:api"
-  integrationTestImplementation(group: 'org.hyperledger.besu.internal', name: 'core', classifier: 'test-support')
-  integrationTestImplementation("org.hyperledger.besu.internal:p2p")
-  integrationTestImplementation("org.hyperledger.besu.internal:qbft-core")
+  integrationTestImplementation "org.hyperledger.besu.internal:besu-ethereum-api"
+  integrationTestImplementation(group: 'org.hyperledger.besu.internal', name: 'besu-ethereum-core', classifier: 'test-support')
+  integrationTestImplementation("org.hyperledger.besu.internal:besu-ethereum-p2p")
+  integrationTestImplementation("org.hyperledger.besu.internal:besu-consensus-qbft-core")
   integrationTestImplementation("org.hyperledger.besu:besu-datatypes")
 
-  integrationTestImplementation("org.hyperledger.besu.internal:merge")
-  integrationTestImplementation("org.hyperledger.besu.internal:plugins-rocksdb")
+  integrationTestImplementation("org.hyperledger.besu.internal:besu-consensus-merge")
+  integrationTestImplementation("org.hyperledger.besu.internal:besu-plugins-rocksdb")
   integrationTestImplementation "org.jetbrains.kotlin:kotlin-test:2.1.0"
 }
 

--- a/consensus/build.gradle
+++ b/consensus/build.gradle
@@ -35,22 +35,22 @@ dependencies {
     because "because of protocol builders"
   }
 
-  api("org.hyperledger.besu.internal:common") {
+  api("org.hyperledger.besu.internal:besu-consensus-common") {
     because("API of the BftEventHandler interface")
   }
-  implementation("org.hyperledger.besu.internal:core")
-  implementation("org.hyperledger.besu.internal:rlp")
-  implementation("org.hyperledger.besu.internal:algorithms")
-  implementation("org.hyperledger.besu.internal:services")
-  implementation("org.hyperledger.besu.internal:p2p")
-  implementation("org.hyperledger.besu.internal:config")
-  api("org.hyperledger.besu.internal:blockcreation") {
+  implementation("org.hyperledger.besu.internal:besu-ethereum-core")
+  implementation("org.hyperledger.besu.internal:besu-ethereum-rlp")
+  implementation("org.hyperledger.besu.internal:besu-crypto-algorithms")
+  implementation("org.hyperledger.besu.internal:besu-crypto-services")
+  implementation("org.hyperledger.besu.internal:besu-ethereum-p2p")
+  implementation("org.hyperledger.besu.internal:besu-config")
+  api("org.hyperledger.besu.internal:besu-ethereum-blockcreation") {
     because("of the BlockCreator")
   }
-  implementation "org.hyperledger.besu.internal:qbft-core"
+  implementation "org.hyperledger.besu.internal:besu-consensus-qbft-core"
+  implementation("org.hyperledger.besu.internal:besu-util")
   implementation("org.hyperledger.besu:besu-datatypes")
-  implementation("org.hyperledger.besu:evm")
-  implementation("org.hyperledger.besu.internal:util")
+  implementation("org.hyperledger.besu:besu-evm")
 
   implementation "tech.pegasys.teku.internal:executionclient"
   implementation "tech.pegasys.teku.internal:spec"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,10 +23,10 @@ dependencies {
   implementation "build.linea.internal:metrics"
 
   testImplementation(project(":serialization"))
-  testFixturesImplementation("org.hyperledger.besu.internal:core")
   testFixturesImplementation("org.hyperledger.besu:besu-datatypes")
-  testFixturesImplementation("org.hyperledger.besu:plugin-api")
-  testFixturesImplementation("org.hyperledger.besu.internal:algorithms")
+  testFixturesImplementation("org.hyperledger.besu:besu-plugin-api")
+  testFixturesImplementation("org.hyperledger.besu.internal:besu-ethereum-core")
+  testFixturesImplementation("org.hyperledger.besu.internal:besu-crypto-algorithms")
   testFixturesImplementation("build.linea.internal:metrics")
   testFixturesImplementation("build.linea.internal:micrometer")
   testFixturesImplementation(project(":serialization"))

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -4,8 +4,8 @@ plugins {
 
 dependencies {
   implementation(project(":core"))
-  implementation("org.hyperledger.besu.internal:algorithms")
   implementation("org.hyperledger.besu:besu-datatypes")
-  implementation("org.hyperledger.besu.internal:core")
+  implementation("org.hyperledger.besu.internal:besu-crypto-algorithms")
+  implementation("org.hyperledger.besu.internal:besu-ethereum-core")
   implementation "io.tmio:tuweni-bytes"
 }

--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
   implementation('com.palantir.docker.compose:docker-compose-rule-junit4')
   implementation('com.palantir.docker.compose:docker-compose-junit-jupiter')
-  implementation "org.hyperledger.besu.internal:dsl"
+  implementation "org.hyperledger.besu.internal:besu-acceptance-tests-dsl"
 
   implementation "build.linea.internal:metrics"
   implementation "build.linea.internal:micrometer"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -150,13 +150,13 @@ dependencyManagement {
       entry 'log4j-slf4j2-impl'
     }
 
-    def besuVersion = "25.5.0"
+    def besuVersion = "25.7.0"
 
     imports {
       mavenBom "org.hyperledger.besu:bom:$besuVersion"
     }
 
-    dependency "org.hyperledger.besu.internal:plugins-rocksdb:$besuVersion"
+    dependency "org.hyperledger.besu.internal:besu-plugins-rocksdb:$besuVersion"
 
     dependency "com.michael-bull.kotlin-result:kotlin-result:1.1.16"
 

--- a/jvm-libs/mappers/build.gradle
+++ b/jvm-libs/mappers/build.gradle
@@ -24,11 +24,11 @@ dependencies {
   implementation "tech.pegasys.teku.internal:unsigned"
   implementation "tech.pegasys.teku.internal:bytes"
   implementation "tech.pegasys.teku.internal:executionclient"
-  implementation("org.hyperledger.besu.internal:metrics-core")
-  implementation("org.hyperledger.besu.internal:algorithms")
-  implementation("org.hyperledger.besu.internal:core")
-  implementation("org.hyperledger.besu:besu-datatypes")
+  implementation "org.hyperledger.besu.internal:besu-metrics-core"
+  implementation "org.hyperledger.besu.internal:besu-crypto-algorithms"
+  implementation "org.hyperledger.besu.internal:besu-ethereum-core"
+  implementation "org.hyperledger.besu:besu-datatypes"
+  implementation "org.hyperledger.besu:besu-plugin-api"
   implementation "io.tmio:tuweni-bytes"
-  implementation "org.hyperledger.besu:plugin-api"
   implementation "tech.pegasys.teku.internal:spec"
 }

--- a/jvm-libs/test-utils/build.gradle
+++ b/jvm-libs/test-utils/build.gradle
@@ -5,13 +5,13 @@ plugins {
 dependencies {
   implementation(project(":consensus"))
 
-  api "org.hyperledger.besu.internal:dsl"
-  implementation("org.hyperledger.besu.internal:core")
-  implementation("org.hyperledger.besu.internal:merge")
-  implementation("org.hyperledger.besu.internal:algorithms")
-  implementation("org.hyperledger.besu.internal:clique")
-  implementation("org.hyperledger.besu.internal:plugins-rocksdb")
-  implementation(group: 'org.hyperledger.besu.internal', name: 'core', classifier: 'test-support')
+  api "org.hyperledger.besu.internal:besu-acceptance-tests-dsl"
+  implementation("org.hyperledger.besu.internal:besu-ethereum-core")
+  implementation("org.hyperledger.besu.internal:besu-consensus-merge")
+  implementation("org.hyperledger.besu.internal:besu-crypto-algorithms")
+  implementation("org.hyperledger.besu.internal:besu-consensus-clique")
+  implementation("org.hyperledger.besu.internal:besu-plugins-rocksdb")
+  implementation(group: 'org.hyperledger.besu.internal', name: 'besu-ethereum-core', classifier: 'test-support')
 
   implementation "org.web3j:core"
   implementation 'org.assertj:assertj-core'

--- a/observability/build.gradle
+++ b/observability/build.gradle
@@ -5,8 +5,8 @@ plugins {
 dependencies {
   implementation "build.linea.internal:micrometer"
   implementation "build.linea.internal:metrics"
-  implementation "org.hyperledger.besu.internal:metrics-core"
-  implementation "org.hyperledger.besu:plugin-api"
+  implementation "org.hyperledger.besu.internal:besu-metrics-core"
+  implementation "org.hyperledger.besu:besu-plugin-api"
   implementation "com.google.guava:guava"
   implementation(project(":core"))
 }

--- a/p2p/build.gradle
+++ b/p2p/build.gradle
@@ -30,11 +30,10 @@ dependencies {
   implementation "tech.pegasys.teku.internal:storage"
   implementation "tech.pegasys.teku.internal:unsigned"
 
-  implementation("org.hyperledger.besu:plugin-api")
-  implementation("org.hyperledger.besu.internal:core")
-  implementation("org.hyperledger.besu.internal:metrics-core")
+  implementation("org.hyperledger.besu:besu-plugin-api")
+  implementation("org.hyperledger.besu.internal:besu-metrics-core")
+  implementation "org.hyperledger.besu.internal:besu-ethereum-rlp"
   implementation "build.linea.internal:metrics"
-  implementation "org.hyperledger.besu.internal:rlp"
 
   implementation "io.libp2p:jvm-libp2p"
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation(project(":crypto"))
   implementation(project(":jvm-libs:extensions"))
   implementation "io.tmio:tuweni-bytes"
-  implementation "org.hyperledger.besu.internal:rlp"
   implementation "org.hyperledger.besu:besu-datatypes"
+  implementation "org.hyperledger.besu.internal:besu-ethereum-rlp"
   testImplementation(testFixtures(project(":core")))
 }

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation (project(":jvm-libs:extensions"))
   implementation "org.rocksdb:rocksdbjni"
   implementation "tech.pegasys.teku.internal:storage"
-  implementation "org.hyperledger.besu.internal:metrics-core"
-  implementation "org.hyperledger.besu:plugin-api"
+  implementation "org.hyperledger.besu.internal:besu-metrics-core"
+  implementation "org.hyperledger.besu:besu-plugin-api"
   testImplementation (testFixtures(project(":core")))
 }


### PR DESCRIPTION
Update besu to 25.7.0. Note the maven dependency names were updated recently in Besu. Was also able to remove the Besu core dependency from the p2p module as it wasn't used.