### PR TITLE
Fix bug with status message

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -12,9 +12,11 @@ import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.unmarshalPrivateKey
 import io.vertx.core.Vertx
 import io.vertx.micrometer.backends.BackendRegistries
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Clock
 import java.util.Optional
+import kotlin.io.path.exists
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
 import linea.kotlin.encodeHex
@@ -53,7 +55,7 @@ import org.hyperledger.besu.plugin.services.metrics.MetricCategory
 import tech.pegasys.teku.networking.p2p.network.config.GeneratingFilePrivateKeySource
 
 class MaruAppFactory {
-  val log = LogManager.getLogger(MaruAppFactory::class.java)
+  private val log = LogManager.getLogger(MaruAppFactory::class.java)
 
   fun create(
     config: MaruConfig,
@@ -81,6 +83,7 @@ class MaruAppFactory {
       )
     val besuMetricsSystem = NoOpMetricsSystem()
 
+    ensureDirectoryExists(config.persistence.dataPath)
     val beaconChain =
       KvDatabaseFactory
         .createRocksDbDatabase(
@@ -170,7 +173,7 @@ class MaruAppFactory {
   companion object {
     private val log = LogManager.getLogger(MaruApp::class.java)
 
-    fun setupFinalizationProvider(
+    private fun setupFinalizationProvider(
       config: MaruConfig,
       overridingLineaContractClient: LineaRollupSmartContractClientReadOnly?,
       vertx: Vertx,
@@ -204,7 +207,7 @@ class MaruAppFactory {
           )
         } ?: InstantFinalizationProvider
 
-    fun setupP2PNetwork(
+    private fun setupP2PNetwork(
       p2pConfig: P2P?,
       privateKey: ByteArray,
       chainId: UInt,
@@ -229,7 +232,7 @@ class MaruAppFactory {
         NoOpP2PNetwork
       }
 
-    fun getOrGeneratePrivateKey(privateKeyPath: Path): ByteArray {
+    private fun getOrGeneratePrivateKey(privateKeyPath: Path): ByteArray {
       if (!privateKeyPath
           .toFile()
           .exists()
@@ -244,5 +247,9 @@ class MaruAppFactory {
 
       return GeneratingFilePrivateKeySource(privateKeyPath.toString()).privateKeyBytes.toArray()
     }
+  }
+
+  private fun ensureDirectoryExists(path: Path) {
+    if (!path.exists()) Files.createDirectories(path)
   }
 }

--- a/p2p/src/main/kotlin/maru/p2p/MaruPeer.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPeer.kt
@@ -14,6 +14,8 @@ import maru.p2p.messages.BeaconBlocksByRangeRequest
 import maru.p2p.messages.BeaconBlocksByRangeResponse
 import maru.p2p.messages.Status
 import maru.p2p.messages.StatusMessageFactory
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.networking.p2p.network.PeerAddress
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
@@ -60,15 +62,21 @@ class DefaultMaruPeer(
   private val rpcMethods: RpcMethods,
   private val statusMessageFactory: StatusMessageFactory,
 ) : MaruPeer {
+  private val log: Logger = LogManager.getLogger(this::javaClass)
   private val status = AtomicReference<Status?>(null)
 
   override fun getStatus(): Status? = status.get()
 
   override fun sendStatus(): SafeFuture<Status> {
-    val statusMessage = statusMessageFactory.createStatusMessage()
-    val sendRpcMessage: SafeFuture<Message<Status, RpcMessageType>> =
-      sendRpcMessage(statusMessage, rpcMethods.status())
-    return sendRpcMessage.thenApply { message -> message.payload }
+    try {
+      val statusMessage = statusMessageFactory.createStatusMessage()
+      val sendRpcMessage: SafeFuture<Message<Status, RpcMessageType>> =
+        sendRpcMessage(statusMessage, rpcMethods.status())
+      return sendRpcMessage.thenApply { message -> message.payload }
+    } catch (e: Exception) {
+      log.error("Failed to send status message to peer ${delegatePeer.id}", e)
+      return SafeFuture.failedFuture(e)
+    }
   }
 
   override fun updateStatus(status: Status) {

--- a/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
@@ -13,6 +13,8 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.networking.p2p.network.PeerHandler
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.peer.NodeId
@@ -25,7 +27,19 @@ class MaruPeerManager(
   private val maruPeerFactory: MaruPeerFactory,
 ) : PeerHandler,
   PeerLookup {
+  private val log: Logger = LogManager.getLogger(this::javaClass)
   private val connectedPeers: ConcurrentHashMap<NodeId, MaruPeer> = ConcurrentHashMap()
+
+  init {
+    scheduler.scheduleAtFixedRate({
+      logConnectedPeers()
+    }, 30, 30, TimeUnit.SECONDS)
+  }
+
+  private fun logConnectedPeers() {
+    val peerIds = connectedPeers.keys.joinToString(", ") { it.toString() }
+    log.info("Currently connected peers: [$peerIds]")
+  }
 
   override fun onConnect(peer: Peer) {
     val maruPeer = maruPeerFactory.createMaruPeer(peer)

--- a/p2p/src/test/kotlin/maru/p2p/DefaultMaruPeerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/DefaultMaruPeerTest.kt
@@ -168,4 +168,14 @@ class DefaultMaruPeerTest {
 
     verify(delegatePeer).adjustReputation(adjustment)
   }
+
+  @Test
+  fun `sendStatus returns failed future when exception is thrown`() {
+    whenever(statusMessageFactory.createStatusMessage()).thenThrow(RuntimeException("fail"))
+
+    val future = maruPeer.sendStatus()
+    assertThat(future).isNotNull()
+    assertThat(future.isDone).isTrue()
+    assertThat(future.isCompletedExceptionally).isTrue()
+  }
 }

--- a/serialization/src/main/kotlin/maru/serialization/ForkIdSerializers.kt
+++ b/serialization/src/main/kotlin/maru/serialization/ForkIdSerializers.kt
@@ -9,6 +9,7 @@
 package maru.serialization
 
 import java.nio.ByteBuffer
+import maru.config.consensus.delegated.ElDelegatedConfig
 import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ForkId
 import maru.consensus.ForkSpec
@@ -29,6 +30,8 @@ object ForkIdSerializers {
     }
   }
 
+  const val EL_DELEGATED_CONFIG_MARKER = 0xDE.toByte()
+
   object ForkSpecSerializer : Serializer<ForkSpec> {
     override fun serialize(value: ForkSpec): ByteArray =
       when (value.configuration) {
@@ -40,6 +43,15 @@ object ForkIdSerializers {
             .putInt(value.blockTimeSeconds)
             .putLong(value.timestampSeconds)
             .put(serializedConsensusConfig)
+            .array()
+        }
+
+        is ElDelegatedConfig -> {
+          ByteBuffer
+            .allocate(4 + 8 + 1)
+            .putInt(value.blockTimeSeconds)
+            .putLong(value.timestampSeconds)
+            .put(EL_DELEGATED_CONFIG_MARKER)
             .array()
         }
 

--- a/serialization/src/test/kotlin/maru/serialization/ForkSpecSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/ForkSpecSerializerTest.kt
@@ -9,6 +9,7 @@
 package maru.serialization
 
 import maru.config.consensus.ElFork
+import maru.config.consensus.delegated.ElDelegatedConfig
 import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ForkSpec
 import maru.core.ext.DataGenerators
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.Test
 
 class ForkSpecSerializerTest {
   @Test
-  fun `serialization is deterministic for same input`() {
+  fun `serialization for Qbft is deterministic for same input`() {
     val v1 = DataGenerators.randomValidator()
     val v2 = DataGenerators.randomValidator()
     val config1 =
@@ -48,7 +49,43 @@ class ForkSpecSerializerTest {
   }
 
   @Test
-  fun `serialization changes when blockTimeSeconds changes`() {
+  fun `serialization for ELDelegated is deterministic for same input`() {
+    val config = ElDelegatedConfig
+    val forkSpec1 =
+      ForkSpec(
+        blockTimeSeconds = 5,
+        timestampSeconds = 123456789L,
+        configuration = config,
+      )
+    val forkSpec2 =
+      ForkSpec(
+        blockTimeSeconds = 5,
+        timestampSeconds = 123456789L,
+        configuration = config,
+      )
+    val bytes1 = ForkIdSerializers.ForkSpecSerializer.serialize(forkSpec1)
+    val bytes2 = ForkIdSerializers.ForkSpecSerializer.serialize(forkSpec2)
+    assertThat(bytes1).isEqualTo(bytes2)
+  }
+
+  @Test
+  fun `serialization changes for ELDelegated when blockTimeSeconds changes`() {
+    val config = ElDelegatedConfig
+    val forkSpec1 =
+      ForkSpec(
+        blockTimeSeconds = 5,
+        timestampSeconds = 123456789L,
+        configuration = config,
+      )
+    val forkSpec2 =
+      forkSpec1.copy(blockTimeSeconds = 10)
+    val bytes1 = ForkIdSerializers.ForkSpecSerializer.serialize(forkSpec1)
+    val bytes2 = ForkIdSerializers.ForkSpecSerializer.serialize(forkSpec2)
+    assertThat(bytes1).isNotEqualTo(bytes2)
+  }
+
+  @Test
+  fun `serialization changes for QBFT when blockTimeSeconds changes`() {
     val v = DataGenerators.randomValidator()
     val config =
       QbftConsensusConfig(
@@ -69,13 +106,28 @@ class ForkSpecSerializerTest {
   }
 
   @Test
-  fun `serialization changes when timestampSeconds changes`() {
+  fun `serialization for QBFT changes when timestampSeconds changes`() {
     val v = DataGenerators.randomValidator()
     val config =
       QbftConsensusConfig(
         validatorSet = setOf(v),
         elFork = ElFork.Prague,
       )
+    val forkSpec1 =
+      ForkSpec(
+        blockTimeSeconds = 5,
+        timestampSeconds = 123456789L,
+        configuration = config,
+      )
+    val forkSpec2 = forkSpec1.copy(timestampSeconds = 3123L)
+    val bytes1 = ForkIdSerializers.ForkSpecSerializer.serialize(forkSpec1)
+    val bytes2 = ForkIdSerializers.ForkSpecSerializer.serialize(forkSpec2)
+    assertThat(bytes1).isNotEqualTo(bytes2)
+  }
+
+  @Test
+  fun `serialization for ELDelegated changes when timestampSeconds changes`() {
+    val config = ElDelegatedConfig
     val forkSpec1 =
       ForkSpec(
         blockTimeSeconds = 5,


### PR DESCRIPTION
This fixes an issue with sending status messages. The underlying cause was that we were trying to create a forkId for a ELDelegated forkspec which didn't have a serialiser. Also not handling the exception meant that we would no longer connect to the peer.

For the ELDelegated i've just used a marker byte + timestamp and blockperiod as there is no config for the delegated consensus.