### PR TITLE
Subscription manager interface

### DIFF
--- a/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
+++ b/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.subscription
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+
+interface SubscriptionManager<T> {
+  fun addSyncSubscriber(
+    subscriberId: String,
+    syncHandler: (T) -> Unit,
+  )
+
+  fun addAsyncSubscriber(
+    subscriberId: String,
+    asyncHandler: (T) -> SafeFuture<Unit>,
+  )
+
+  /**
+   * It will notify all subscribers in a blocking manner, by order they were added.
+   * If there sync and async subscribers, it will wait for async subscriber to complete
+   * before notifying the next subscriber.
+   */
+  fun notifySubscribers(data: T)
+
+  /**
+   * It will notify all subscribers asynchronously, without blocking the current thread.
+   * Subscriber notification order my not follow the order they were added,
+   */
+  fun notifySubscribersAsync(data: T): SafeFuture<Unit>
+
+  fun removeSubscriber(subscriberId: String)
+}

--- a/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
+++ b/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
@@ -18,7 +18,7 @@ interface SubscriptionManager<T> {
 
   fun addAsyncSubscriber(
     subscriberId: String,
-    asyncHandler: (T) -> SafeFuture<Unit>,
+    asyncHandler: (T) -> SafeFuture<*>,
   )
 
   /**

--- a/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
+++ b/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
@@ -13,7 +13,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 interface SubscriptionManager<T> {
   fun addSyncSubscriber(
     subscriberId: String,
-    syncHandler: (T) -> Unit,
+    syncHandler: (T) -> Any?,
   )
 
   fun addAsyncSubscriber(


### PR DESCRIPTION
Adds a subscription manager interface. It's implementation is meant to be used as "object composition pattern"


```kotlin
class MyComponent(
) {
  val elStatusSubsManager: SubscriptionManager<CLSyncStatus>
  val newBlocksSubsManager: SubscriptionManager<BeaconBlock>

  fun subscribeNewBlocks(handlerId: String, newBlockHandler: (BeaconBlock) -> SafeFuture<Unit>) {
    newBlocksSubsManager.addAsyncSubscriber(handlerId, newBlockHandler)
  }

  fun subscribeStatusUpdate(handlerId: String, handler: (CLSyncStatus) -> Unit) {
    elStatusSubsManager.addAsyncSubscriber(handlerId, handler)
  }
}
```