### PR TITLE
Fixing flacky test

### DIFF
--- a/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
@@ -106,7 +105,7 @@ class SyncControllerThreadSafetyTest {
     }
   }
 
-  @RepeatedTest(10)
+  @Test
   fun `should maintain EL-follows-CL invariant under concurrent access`() {
     val executor = Executors.newFixedThreadPool(3)
     val latch = CountDownLatch(3)

--- a/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
@@ -105,7 +106,7 @@ class SyncControllerThreadSafetyTest {
     }
   }
 
-  @Test
+  @RepeatedTest(10)
   fun `should maintain EL-follows-CL invariant under concurrent access`() {
     val executor = Executors.newFixedThreadPool(3)
     val latch = CountDownLatch(3)
@@ -115,8 +116,9 @@ class SyncControllerThreadSafetyTest {
     // Monitor for invariant violations: when CL starts syncing, EL should never be SYNCED
     executor.submit {
       repeat(iterations * 3) {
-        val clStatus = syncController.getCLSyncStatus()
-        val elStatus = syncController.getElSyncStatus()
+        val stateSnapshot = syncController.captureStateSnapshot()
+        val elStatus = stateSnapshot.elStatus
+        val clStatus = stateSnapshot.clStatus
 
         // This should never happen: CL syncing while EL is synced
         if (clStatus == CLSyncStatus.SYNCING && elStatus == ELSyncStatus.SYNCED) {


### PR DESCRIPTION
Failed test [run](https://github.com/Consensys/maru/actions/runs/16655684252/job/47139973173) 
Error:
```
SyncControllerThreadSafetyTest > should maintain EL-follows-CL invariant under concurrent access() FAILED
    org.opentest4j.AssertionFailedError: 
    expected: 0
     but was: 1
        at app//maru.syncing.SyncControllerThreadSafetyTest.should maintain EL-follows-CL invariant under concurrent access(SyncControllerThreadSafetyTest.kt:152)
```

I think it could happen because the reads to el and cl states are separate and not atomic