### PR TITLE
Topic handler with in order delivering fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.errorprone)
@@ -55,8 +57,11 @@ allprojects {
     }
   }
 
-  // suppress warnings, see https://youtrack.jetbrains.com/issue/KT-73255
-  kotlin.compilerOptions.freeCompilerArgs.add("-Xannotation-default-target=param-property")
+  tasks.withType(KotlinCompilationTask) {
+    compilerOptions {
+      freeCompilerArgs.add("-Xannotation-default-target=param-property")
+    }
+  }
 
   tasks.withType(JavaCompile).configureEach {
     options.compilerArgs += [

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.errorprone)

--- a/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
+++ b/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
@@ -86,8 +86,6 @@ class TopicHandlerWithInOrderDelivering<T>(
       val sequenceNumber = sequenceNumberExtractor.extractSequenceNumber(deserializedMessage)
       val nextExpectedSequenceNumber = nextExpectedSequenceNumberProvider()
 
-      cleanUpMessagesBehind(nextExpectedSequenceNumber)
-
       when {
         sequenceNumber >= nextExpectedSequenceNumber -> {
           if (pendingEvents.size < maxQueueSize) {
@@ -156,6 +154,7 @@ class TopicHandlerWithInOrderDelivering<T>(
 
   @Synchronized
   private fun processPendingEvents() {
+    cleanUpMessagesBehind(nextExpectedSequenceNumberProvider())
     if (pendingEvents.isNotEmpty() &&
       isHandlingEnabled() &&
       sequenceNumberExtractor.extractSequenceNumber(pendingEvents.peek().first) ==

--- a/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
+++ b/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
@@ -96,7 +96,6 @@ class TopicHandlerWithInOrderDelivering<T>(
               sequenceNumber,
               nextExpectedSequenceNumber,
             )
-            addMessageToTheQueue(deserializedMessage)
           } else {
             // Queue is full - drop the oldest message and add the new one
             val oldestMessage = pendingEvents.remove()
@@ -108,22 +107,12 @@ class TopicHandlerWithInOrderDelivering<T>(
                 sequenceNumber,
               )
             }
-            addMessageToTheQueue(deserializedMessage)
           }
+          addMessageToTheQueue(deserializedMessage)
         }
-
-        sequenceNumber < nextExpectedSequenceNumber -> {
-          log.debug(
-            "ignoring outdated message with sequenceNumber={} next expectedSequenceNumber={}",
-            sequenceNumber,
-            nextExpectedSequenceNumber,
-          )
-          SafeFuture.completedFuture(Libp2pValidationResult.Ignore)
-        }
-
         else -> {
           log.debug(
-            "Ignoring message with sequenceNumber={}, expectedSequenceNumber={}",
+            "ignoring outdated message with sequenceNumber={} next expectedSequenceNumber={}",
             sequenceNumber,
             nextExpectedSequenceNumber,
           )

--- a/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
+++ b/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
@@ -84,8 +84,7 @@ class TopicHandlerWithInOrderDelivering<T>(
       val sequenceNumber = sequenceNumberExtractor.extractSequenceNumber(deserializedMessage)
       val nextExpectedSequenceNumber = nextExpectedSequenceNumberProvider()
 
-      // Clean up old messages that are now behind the expected sequence number
-      cleanUpOldMessages(nextExpectedSequenceNumber)
+      cleanUpMessagesBehind(nextExpectedSequenceNumber)
 
       when {
         sequenceNumber >= nextExpectedSequenceNumber -> {
@@ -142,7 +141,7 @@ class TopicHandlerWithInOrderDelivering<T>(
       SafeFuture.completedFuture(Libp2pValidationResult.Invalid)
     }
 
-  private fun cleanUpOldMessages(nextExpectedSequenceNumber: ULong) {
+  private fun cleanUpMessagesBehind(nextExpectedSequenceNumber: ULong) {
     val (toRemove, toKeep) = pendingEvents.partition { (event, _) ->
       sequenceNumberExtractor.extractSequenceNumber(event) < nextExpectedSequenceNumber
     }

--- a/syncing/src/main/kotlin/maru/syncing/ELSyncService.kt
+++ b/syncing/src/main/kotlin/maru/syncing/ELSyncService.kt
@@ -84,7 +84,7 @@ class ELSyncService(
         blockHash = latestBeaconBlockBody.executionPayload.blockHash,
       )
     if (newElSyncTarget != currentElSyncTarget) {
-      log.info("New elSyncTarget={}", newElSyncTarget)
+      log.debug("New elSyncTarget={}", newElSyncTarget)
       currentElSyncTarget = newElSyncTarget
     } else {
       log.trace("Current elSyncTarget={}", currentElSyncTarget)


### PR DESCRIPTION
* Improved the `TopicHandlerWithInOrderDelivering` to maintain the tail of the queue when the queue is full
* Refactored the tests to make them more readable
* Added more tests for the new property and for the `isHandlingEnabled` flag being false
* Fixed Kotlin compiler warning