### PR TITLE
Chaos Testing - Setup deploy maru with discovery enabled

### DIFF
--- a/chaos-testing/Makefile
+++ b/chaos-testing/Makefile
@@ -22,8 +22,27 @@ chaos-full-reload:
 	@$(MAKE) chaos-experiment-podkill-besu-nodes
 	@echo "Chaos testing environment is ready. You can now run your chaos experiments."
 
+chaos-full-reload-with-local-maru-image:
+	@$(MAKE) k3s-reload
+	@sleep 5
+	@$(MAKE) build-and-import-maru-image
+	@$(MAKE) helm-redeploy-maru-and-besu
+
 chaos-redeploy-and-run-experiment:
 	@$(MAKE) helm-redeploy-maru-and-besu
 	@$(MAKE) wait-maru-follower-is-syncing
 	@sleep 20 # wait for some time to ensure nodes are cruising and ready for chaos experiments
 	@$(MAKE) chaos-experiment-podkill-besu-nodes
+
+build-maru-image:
+	@echo "Building Maru image"
+	cd .. && ./gradlew :app:installDist
+	cd .. && docker build app --build-context=libs=./app/build/install/app/lib/ --build-context=maru=./app/build/libs/ -t consensys/maru:local
+
+build-and-import-maru-image:
+	@$(MAKE) build-maru-image
+	@$(MAKE) k3s-import-local-maru-image
+
+build-and-redeploy-maru:
+	@$(MAKE) build-and-import-maru-image
+	@$(MAKE) helm-redeploy-maru

--- a/chaos-testing/README.md
+++ b/chaos-testing/README.md
@@ -1,17 +1,21 @@
 
 # Maru test network topology
 
-- 1 maru validator: `maru-validator` -> `besu-sequencer`
-- 1 maru follower: `maru-follower-0-0` -> `besu-follower-0`
-- 1 maru follower: `maru-follower-1-0` -> `besu-follower-1`+ `besu-follower-2`
-   - `besu-follower-1` is the primary EL client
-   - `besu-follower-2` is just EL client replica
+- 1 maru validator: `maru-validator` -> `besu-sequencer` (starts with Clique then switch to QBFT)
+- 4 maru followers:
+  - `maru-follower-0-0` -> `besu-follower-0` (will also work as bootnode)
+  - `maru-follower-1-0` -> `besu-follower-1`
+  - `maru-follower-2-0` -> `besu-follower-2`
+  - `maru-follower-3-0` -> [`besu-follower-3`, `besu-follower-4`]
+     - `besu-follower-3` is the primary EL client
+     - `besu-follower-4` is just EL client replica
 
 # Quick start
 
 ### Full provisioning
 
 ```bash
+export KUBECONFIG=~/.kube/k3s-server
 make chaos-full-reload
 ```
 

--- a/chaos-testing/README.md
+++ b/chaos-testing/README.md
@@ -26,15 +26,21 @@ make chaos-full-reload
 ### Troubleshooting & Redeploy Maru
 
 Builds Maru Locally and Deploys it with Fresh K8S Cluster and Besu Instances
-```
+```bash
 export KUBECONFIG=~/.kube/k3s-server
 make chaos-full-reload-with-local-maru-image
 ```
 
 Build and Redeploys Maru
-```
+```bash
 export KUBECONFIG=~/.kube/k3s-server
 make build-and-redeploy-maru
+```
+
+Check pods logs (Check list of pods with `kubectl get pods`)
+```bash
+kubectl logs maru-follower-0-0
+kubectl logs maru-follower-0-0 -f # follow logs
 ```
 
 ### Other helpful commands

--- a/chaos-testing/README.md
+++ b/chaos-testing/README.md
@@ -23,6 +23,20 @@ make chaos-full-reload
 - deploys Chaos-Mesh into `chaos-mesh` namespace
 - deploys Maru and Besu network into `default` namespace
 
+### Troubleshooting & Redeploy Maru
+
+Builds Maru Locally and Deploys it with Fresh K8S Cluster and Besu Instances
+```
+export KUBECONFIG=~/.kube/k3s-server
+make chaos-full-reload-with-local-maru-image
+```
+
+Build and Redeploys Maru
+```
+export KUBECONFIG=~/.kube/k3s-server
+make build-and-redeploy-maru
+```
+
 ### Other helpful commands
 
 - `make helm-redeploy-maru-and-besu` - redeploys Maru + Besu network from genesis

--- a/chaos-testing/helm.mk
+++ b/chaos-testing/helm.mk
@@ -56,7 +56,7 @@ helm-redeploy-maru:
 	@helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-0 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-0.yaml
 	@$(MAKE) wait_pods pod_name=maru-follower-0 pod_count=1
 	@$(MAKE) wait-for-log-entry pod_name=maru-follower-0-0 log_entry="enr"
-	BOOTNODE_ENR=$$(kubectl logs maru-follower-0-0 | grep -o 'ip enr=[^ ]*' | head -1 | cut -d= -f2); \
+	BOOTNODE_ENR=$$(kubectl logs maru-follower-0-0 | grep -o 'enr=[^ ]*' | head -1 | cut -d= -f2); \
 	echo "Bootnode ENR: $$BOOTNODE_ENR"; \
 	helm --kubeconfig $(KUBECONFIG) upgrade --install maru-validator ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-validator.yaml --set bootnodes=$$BOOTNODE_ENR ; \
 	helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-1 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-1.yaml --set bootnodes=$$BOOTNODE_ENR ; \

--- a/chaos-testing/helm.mk
+++ b/chaos-testing/helm.mk
@@ -5,6 +5,8 @@ helm-clean-releases:
 	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-validator
 	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-0
 	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-1
+	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-2
+	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-3
 	KUBECONFIG=$(KUBECONFIG) kubectl delete pvc --all
 	KUBECONFIG=$(KUBECONFIG) kubectl delete pv --all
 
@@ -24,6 +26,11 @@ wait_pods:
 		sleep 5; \
 	done
 
+wait-for-log-entry:
+	@until kubectl logs $(pod_name) | grep -q "$(log_entry)"; do \
+		sleep 1; \
+	done
+
 helm-deploy-besu:
 		@echo "Deploying Besu"
 		@helm --kubeconfig $(KUBECONFIG) upgrade --install besu-sequencer ./helm/charts/besu --force -f ./helm/charts/besu/values.yaml -f ./helm/values/besu-local-dev-sequencer.yaml
@@ -33,24 +40,29 @@ helm-deploy-besu:
 		@$(MAKE) wait_pods pod_name=besu-follower pod_count=3
 
 helm-redeploy-besu:
-		@echo "Redeploying Besu"
 		-@helm --kubeconfig $(KUBECONFIG) uninstall besu-sequencer
 		-@helm --kubeconfig $(KUBECONFIG) uninstall besu-follower
 		@sleep 3 # Wait for a second to ensure the previous release is fully uninstalled
 		@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) helm-deploy-besu
 
 helm-redeploy-maru:
-	@echo "Redeploying Maru"
 	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-validator
 	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-0
 	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-1
+	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-2
+	-@helm --kubeconfig $(KUBECONFIG) uninstall maru-follower-3
 	@sleep 2 # Wait for a second to ensure the previous release is fully uninstalled
-	@echo "Deploying Maru Followers"
+	@echo "Deploying Maru Nodes"
 	@helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-0 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-0.yaml
-	@helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-1 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-1.yaml
-	@$(MAKE) wait_pods pod_name=maru-follower-1 pod_count=1
-	@echo "Deploying Maru Validator"
-	@helm --kubeconfig $(KUBECONFIG) upgrade --install maru-validator ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-validator.yaml
+	@$(MAKE) wait_pods pod_name=maru-follower-0 pod_count=1
+	@$(MAKE) wait-for-log-entry pod_name=maru-follower-0-0 log_entry="enr"
+	BOOTNODE_ENR=$$(kubectl logs maru-follower-0-0 | grep -o 'ip enr=[^ ]*' | head -1 | cut -d= -f2); \
+	echo "Bootnode ENR: $$BOOTNODE_ENR"; \
+	helm --kubeconfig $(KUBECONFIG) upgrade --install maru-validator ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-validator.yaml --set bootnodes=$$BOOTNODE_ENR ; \
+	helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-1 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-1.yaml --set bootnodes=$$BOOTNODE_ENR ; \
+	helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-2 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-2.yaml --set bootnodes=$$BOOTNODE_ENR ; \
+	helm --kubeconfig $(KUBECONFIG) upgrade --install maru-follower-3 ./helm/charts/maru --force -f ./helm/charts/maru/values.yaml -f ./helm/values/maru-local-dev-follower-3.yaml --set bootnodes=$$BOOTNODE_ENR
+
 	@$(MAKE) wait_pods pod_name=maru-validator pod_count=1
 
 helm-redeploy-maru-and-besu:

--- a/chaos-testing/helm/charts/maru/templates/statefulset.yaml
+++ b/chaos-testing/helm/charts/maru/templates/statefulset.yaml
@@ -19,6 +19,15 @@ spec:
         - name: maru
           image: "{{ .Values.image.name }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- if .Values.bootnodes }}
+            - name: config__override__p2p__discovery__bootnodes
+              value: {{ .Values.bootnodes | quote }}
+            {{- end }}
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
           command:
             - java
             - -Dlog4j2.configurationFile=configs/log4j.xml

--- a/chaos-testing/helm/charts/maru/values.yaml
+++ b/chaos-testing/helm/charts/maru/values.yaml
@@ -1,6 +1,7 @@
 replicaCount: 1
 image:
-  name: consensys/maru:2985fa7
+#  name: consensys/maru:fc93b7d
+  name: consensys/maru:local
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
@@ -30,6 +31,15 @@ configFiles:
     [p2p]
     port = 3322
     ip-address = "0.0.0.0"
+
+    [p2p.discovery]
+    port = 3323
+    refresh-interval = "5 seconds"
+
+    [syncing]
+    peer-chain-height-polling-interval = "5 seconds"
+    peer-chain-height-granularity = 10
+    el-sync-status-refresh-interval = "5 seconds"
 
     [observability]
     port = 9545

--- a/chaos-testing/helm/values/besu-local-dev-follower.yaml
+++ b/chaos-testing/helm/values/besu-local-dev-follower.yaml
@@ -1,2 +1,2 @@
-replicaCount: 3
+replicaCount: 4
 fullnameOverride: besu-follower

--- a/chaos-testing/helm/values/maru-local-dev-follower-1.yaml
+++ b/chaos-testing/helm/values/maru-local-dev-follower-1.yaml
@@ -2,14 +2,11 @@ replicaCount: 1
 fullnameOverride: maru-follower-1
 configFiles:
   privateKey: |
-    0x080212201dd171cec7e2995408b5513004e8207fe88d6820aeff0d82463b3e41df251aa1
+    0x0802122100f6a9f0054ffd799028169880825eefc838be44eab1968bdde5ff94f737720e42
   configsToml: |
     [payload-validator]
     engine-api-endpoint = { endpoint = "http://besu-follower-1.besu-follower.default.svc.cluster.local:8550" }
     eth-api-endpoint = { endpoint = "http://besu-follower-1.besu-follower.default.svc.cluster.local:8545" }
-
-    [follower-engine-apis]
-    follower-besu = { endpoint = "http://besu-follower-2.besu-follower.default.svc.cluster.local:8550" }
 
   log4j: |
     <?xml version="1.0" encoding="UTF-8"?>
@@ -23,6 +20,7 @@ configFiles:
       <Logger name="org.hyperledger.besu" level="INFO"/>
       <Logger name="tech.pegasys.teku" level="INFO"/>
       <Logger name="maru" level="INFO"/>
+      <Logger name="maru.syncing" level="DEBUG"/>
       <Logger name="clients" level="DEBUG"/>
       <Root level="INFO">
         <AppenderRef ref="Console"/>

--- a/chaos-testing/helm/values/maru-local-dev-follower-2.yaml
+++ b/chaos-testing/helm/values/maru-local-dev-follower-2.yaml
@@ -1,12 +1,13 @@
 replicaCount: 1
-fullnameOverride: maru-follower-0
+fullnameOverride: maru-follower-2
 configFiles:
   privateKey: |
-    0x08021220064974d5f62a7ab9b76ea97fc6451d2dd6416cb8150625ccb15640a57b96510e
+    0x0802122007ff78e0ad0e7c04553bceeb52d0962980c7b1406320515c5baabfe9951fd424
   configsToml: |
     [payload-validator]
-    engine-api-endpoint = { endpoint = "http://besu-follower-0.besu-follower.default.svc.cluster.local:8550" }
-    eth-api-endpoint = { endpoint = "http://besu-follower-0.besu-follower.default.svc.cluster.local:8545" }
+    engine-api-endpoint = { endpoint = "http://besu-follower-2.besu-follower.default.svc.cluster.local:8550" }
+    eth-api-endpoint = { endpoint = "http://besu-follower-2.besu-follower.default.svc.cluster.local:8545" }
+
   log4j: |
     <?xml version="1.0" encoding="UTF-8"?>
     <Configuration status="INFO" monitorInterval="2">
@@ -16,9 +17,9 @@ configFiles:
       </Console>
     </Appenders>
     <Loggers>
-      <Logger name="org.hyperledger.besu" level="TRACE"/>
-      <Logger name="tech.pegasys.teku" level="DEBUG"/>
-      <Logger name="maru" level="DEBUG"/>
+      <Logger name="org.hyperledger.besu" level="INFO"/>
+      <Logger name="tech.pegasys.teku" level="INFO"/>
+      <Logger name="maru" level="INFO"/>
       <Logger name="maru.syncing" level="DEBUG"/>
       <Logger name="clients" level="DEBUG"/>
       <Root level="INFO">

--- a/chaos-testing/helm/values/maru-local-dev-follower-3.yaml
+++ b/chaos-testing/helm/values/maru-local-dev-follower-3.yaml
@@ -1,12 +1,16 @@
 replicaCount: 1
-fullnameOverride: maru-follower-0
+fullnameOverride: maru-follower-3
 configFiles:
   privateKey: |
-    0x08021220064974d5f62a7ab9b76ea97fc6451d2dd6416cb8150625ccb15640a57b96510e
+    0x0802122100cb876c984d90b683011e93321be79d6f384e6cc78b1b0f1f882b20d00fe89022
   configsToml: |
     [payload-validator]
-    engine-api-endpoint = { endpoint = "http://besu-follower-0.besu-follower.default.svc.cluster.local:8550" }
-    eth-api-endpoint = { endpoint = "http://besu-follower-0.besu-follower.default.svc.cluster.local:8545" }
+    engine-api-endpoint = { endpoint = "http://besu-follower-3.besu-follower.default.svc.cluster.local:8550" }
+    eth-api-endpoint = { endpoint = "http://besu-follower-3.besu-follower.default.svc.cluster.local:8545" }
+
+    [follower-engine-apis]
+    follower-besu = { endpoint = "http://besu-follower-4.besu-follower.default.svc.cluster.local:8550" }
+
   log4j: |
     <?xml version="1.0" encoding="UTF-8"?>
     <Configuration status="INFO" monitorInterval="2">
@@ -16,10 +20,10 @@ configFiles:
       </Console>
     </Appenders>
     <Loggers>
-      <Logger name="org.hyperledger.besu" level="TRACE"/>
-      <Logger name="tech.pegasys.teku" level="DEBUG"/>
-      <Logger name="maru" level="DEBUG"/>
+      <Logger name="org.hyperledger.besu" level="INFO"/>
+      <Logger name="tech.pegasys.teku" level="INFO"/>
       <Logger name="maru.syncing" level="DEBUG"/>
+      <Logger name="maru" level="INFO"/>
       <Logger name="clients" level="DEBUG"/>
       <Root level="INFO">
         <AppenderRef ref="Console"/>

--- a/chaos-testing/helm/values/maru-local-dev-validator.yaml
+++ b/chaos-testing/helm/values/maru-local-dev-validator.yaml
@@ -7,12 +7,6 @@ configFiles:
     [qbft]
     fee-recipient = "0x0000000000000000000000000000000000000000"
 
-    [p2p]
-    static-peers = [
-      "/dns4/maru-follower-0/tcp/3322/p2p/16Uiu2HAm5t3cGzbzjy5wE8u1siwkeCWtyob1kinEmNrcRsKXX8Z6",
-      "/dns4/maru-follower-1/tcp/3322/p2p/16Uiu2HAmLRVrc12TDbFM27MBi4fVvtjbiRKAYcXAMv3q5DpK6TVX"
-    ]
-
     [payload-validator]
     engine-api-endpoint = { endpoint = "http://besu-sequencer-0.besu-sequencer.default.svc.cluster.local:8550" }
     eth-api-endpoint = { endpoint = "http://besu-sequencer-0.besu-sequencer.default.svc.cluster.local:8545" }
@@ -31,6 +25,7 @@ configFiles:
      <Logger name="org.hyperledger.besu" level="INFO"/>
       <Logger name="tech.pegasys.teku" level="INFO"/>
       <Logger name="maru" level="INFO"/>
+      <Logger name="maru.syncing" level="DEBUG"/>
       <Logger name="clients" level="DEBUG"/>
       <Root level="INFO">
         <AppenderRef ref="Console"/>

--- a/chaos-testing/k3s.mk
+++ b/chaos-testing/k3s.mk
@@ -6,6 +6,8 @@ k3s-clean:
 	-@docker stop k3s-server
 	-@docker rm k3s-server
 
+# To debug the k3s server, you can run:
+# docker exec -it k3s-server sh
 k3s-run:
 	@docker run -d --name k3s-server \
 		--privileged \
@@ -34,3 +36,12 @@ k3s-reload:
 	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) k3s-run
 	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) k3s-setup-kubeconfig
 	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) k3s-wait
+#	@$(MAKE) -f $(firstword $(MAKEFILE_LIST)) k3s-install-calico
+
+k3s-import-local-maru-image:
+	@docker save consensys/maru:local -o maru-local.tar
+	@docker exec k3s-server sh -c "mkdir -p /images"
+	@docker cp maru-local.tar k3s-server:/images/maru-local.tar
+	@echo "Importing local Maru image into k3s server..."
+	@docker exec k3s-server sh -c "ctr -n k8s.io images import /images/maru-local.tar"
+	@echo "Local Maru image imported successfully."


### PR DESCRIPTION
It's not working yet because of issues with Peer Discovery.

This PR deploys a maru instance as bootnode, then configures all the remaining maru nodes to use that bootnode. 
It relies on log `enr=ENR` to retrieve boot node's ENR