### PR TITLE
Ensure el payload validator is also not defined as el follower

### DIFF
--- a/chaos-testing/helm/values/maru-local-dev-validator.yaml
+++ b/chaos-testing/helm/values/maru-local-dev-validator.yaml
@@ -11,8 +11,6 @@ configFiles:
     engine-api-endpoint = { endpoint = "http://besu-sequencer-0.besu-sequencer.default.svc.cluster.local:8550" }
     eth-api-endpoint = { endpoint = "http://besu-sequencer-0.besu-sequencer.default.svc.cluster.local:8545" }
 
-    [follower-engine-apis]
-    follower-besu = { endpoint = "http://besu-sequencer-0.besu-sequencer.default.svc.cluster.local:8550" }
   log4j: |
     <?xml version="1.0" encoding="UTF-8"?>
     <Configuration status="INFO" monitorInterval="2">

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -188,4 +188,14 @@ data class MaruConfig(
   val linea: LineaConfig? = null,
   val apiConfig: ApiConfig,
   val syncing: SyncingConfig,
-)
+) {
+  init {
+    require(
+      !followers.followers.values
+        .map { it.endpoint }
+        .contains(validatorElNode.engineApiEndpoint.endpoint),
+    ) {
+      "Validator EL node cannot be defined as a follower"
+    }
+  }
+}

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -18,6 +18,7 @@ import linea.domain.RetryConfig
 import linea.kotlin.decodeHex
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @OptIn(ExperimentalHoplite::class)
 class HopliteFriendlinessTest {
@@ -202,6 +203,27 @@ class HopliteFriendlinessTest {
         syncing = syncingConfig,
       ),
     )
+  }
+
+  @Test
+  fun `throws when el validator is also specified as follower`() {
+    val exception =
+      assertThrows<IllegalArgumentException> {
+        MaruConfig(
+          protocolTransitionPollingInterval = protocolTransitionPollingInterval,
+          allowEmptyBlocks = false,
+          persistence = persistence,
+          qbftOptions = qbftOptions.toDomain(),
+          p2pConfig = p2pConfig,
+          validatorElNode = payloadValidator.domainFriendly(),
+          followers = FollowersConfig(mapOf("el-validator" to payloadValidator.engineApiEndpoint.domainFriendly())),
+          observabilityOptions = ObservabilityOptions(port = 9090u),
+          linea = null,
+          apiConfig = ApiConfig(port = 8080u),
+          syncing = syncingConfig,
+        )
+      }
+    assertThat(exception.message).isEqualTo("Validator EL node cannot be defined as a follower")
   }
 
   @Test

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -23,7 +23,6 @@ engine-api-endpoint = { endpoint = "http://sequencer:8550" }
 eth-api-endpoint = { endpoint = "http://sequencer:8545" }
 
 [follower-engine-apis]
-"follower-besu" = { endpoint = "http://follower-besu:8550" }
 "follower-erigon" = { endpoint = "http://follower-erigon:8551", jwt-secret-path = "../docker/jwt" }
 "follower-nethermind" = { endpoint = "http://follower-nethermind:8550", jwt-secret-path = "../docker/jwt" }
 "follower-geth" = { endpoint = "http://follower-geth:8551", jwt-secret-path = "../docker/jwt" }

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -294,9 +294,6 @@ class MaruFactory(
     )
   }
 
-  private fun buildFollowersConfig(engineApiRpc: String): FollowersConfig =
-    FollowersConfig(mapOf("validator-el-node" to ApiEndpointConfig(URI.create(engineApiRpc).toURL())))
-
   fun buildTestMaruValidatorWithoutP2pPeering(
     ethereumJsonRpcUrl: String,
     engineApiRpc: String,
@@ -358,7 +355,6 @@ class MaruFactory(
     allowEmptyBlocks: Boolean = false,
   ): MaruApp {
     val p2pConfig = buildP2pConfig(validatorPortForStaticPeering = validatorPortForStaticPeering)
-    val followers = buildFollowersConfig(engineApiRpc)
     val config =
       buildMaruConfig(
         allowEmptyBlocks = allowEmptyBlocks,
@@ -366,7 +362,6 @@ class MaruFactory(
         engineApiRpc = engineApiRpc,
         dataDir = dataDir,
         p2pConfig = p2pConfig,
-        followers = followers,
         overridingLineaContractClient = overridingLineaContractClient,
       )
     return buildApp(
@@ -382,13 +377,11 @@ class MaruFactory(
     dataDir: Path,
     p2pNetwork: P2PNetwork = NoOpP2PNetwork,
   ): MaruApp {
-    val followers = buildFollowersConfig(engineApiRpc)
     val config =
       buildMaruConfig(
         ethereumJsonRpcUrl = ethereumJsonRpcUrl,
         engineApiRpc = engineApiRpc,
         dataDir = dataDir,
-        followers = followers,
       )
     return buildApp(config, overridingP2PNetwork = p2pNetwork)
   }
@@ -436,7 +429,6 @@ class MaruFactory(
     overridingP2PNetwork: P2PNetwork? = null,
   ): MaruApp {
     val p2pConfig = buildP2pConfig(validatorPortForStaticPeering = validatorPortForStaticPeering)
-    val followersConfig = buildFollowersConfig(engineApiRpc)
     val beaconGenesisConfig = beaconGenesisConfig
     val config =
       buildMaruConfig(
@@ -444,7 +436,6 @@ class MaruFactory(
         engineApiRpc = engineApiRpc,
         dataDir = dataDir,
         p2pConfig = p2pConfig,
-        followers = followersConfig,
       )
     return buildApp(
       config = config,


### PR DESCRIPTION
After https://github.com/Consensys/maru/commit/1b02f6fa23a90c784034e8d91a1d768585d12973 we do not need the payload validator to be defined as a follower.