### PR TITLE
Stop the LineaFinalizaiton poller on Maru app stop

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruApp.kt
+++ b/app/src/main/kotlin/maru/app/MaruApp.kt
@@ -23,6 +23,7 @@ import maru.consensus.state.FinalizationProvider
 import maru.core.Protocol
 import maru.crypto.Crypto
 import maru.database.BeaconChain
+import maru.finalization.LineaFinalizationProvider
 import maru.metrics.MaruMetricsCategory
 import maru.p2p.P2PNetwork
 import maru.p2p.PeerInfo
@@ -118,6 +119,14 @@ class MaruApp(
       throw th
     }
     try {
+      if (finalizationProvider is LineaFinalizationProvider) {
+        finalizationProvider.start()
+      }
+    } catch (th: Throwable) {
+      log.error("Error while trying to start the finalization provider", th)
+      throw th
+    }
+    try {
       p2pNetwork.start().get()
     } catch (th: Throwable) {
       log.error("Error while trying to start the P2P network", th)
@@ -140,6 +149,13 @@ class MaruApp(
       }
     } catch (th: Throwable) {
       log.warn("Error while trying to stop the vertx verticles", th)
+    }
+    try {
+      if (finalizationProvider is LineaFinalizationProvider) {
+        finalizationProvider.stop()
+      }
+    } catch (th: Throwable) {
+      log.warn("Error while trying to stop the finalization provider", th)
     }
     try {
       p2pNetwork.stop().get()


### PR DESCRIPTION
This should fix the constant exception in CI and locally while running `./gradlew build`

```
Exception in thread "l1-finalization-poller" java.util.concurrent.ExecutionException: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.CompletableFuture$AsyncRun@584977dd rejected from java.util.concurrent.ThreadPoolExecutor@2344a258[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 4600]
        at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
        at maru.finalization.LineaFinalizationProvider.update(LineaFinalizationProvider.kt:93)
        at maru.finalization.LineaFinalizationProvider$special$$inlined$timer$1.run(Timer.kt:149)
        at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
        at java.base/java.util.TimerThread.run(Timer.java:516)
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.CompletableFuture$AsyncRun@584977dd rejected from java.util.concurrent.ThreadPoolExecutor@2344a258[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 4600]
        at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2081)
        at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:841)
        at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1376)
        at java.base/java.util.concurrent.CompletableFuture.asyncRunStage(CompletableFuture.java:1818)
        at java.base/java.util.concurrent.CompletableFuture.runAsync(CompletableFuture.java:2033)
        at org.web3j.utils.Async.run(Async.java:35)
        at org.web3j.protocol.Service.sendAsync(Service.java:60)
        at org.web3j.protocol.core.Request.sendAsync(Request.java:91)
        at linea.web3j.RequestHelperKt.requestAsync(RequestHelper.kt:33)
        at linea.web3j.ethapi.Web3jEthApiClient.findBlockByNumberWithoutTransactionsData(Web3jEthApiClient.kt:46)
        at maru.finalization.LineaFinalizationProvider.getHighestBlockAvailableUpToBlock-VKZWuLQ(LineaFinalizationProvider.kt:126)
        at maru.finalization.LineaFinalizationProvider.getFinalizationUpdate$lambda$4(LineaFinalizationProvider.kt:100)
        at maru.finalization.LineaFinalizationProvider.getFinalizationUpdate$lambda$5(LineaFinalizationProvider.kt:99)
        at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1187)
        at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2341)
        at tech.pegasys.teku.infrastructure.async.SafeFuture.thenCompose(SafeFuture.java:542)
        at maru.finalization.LineaFinalizationProvider.getFinalizationUpdate(LineaFinalizationProvider.kt:99)
        ... 4 more
```