### PR TITLE
Implemented desync tolerance. Fixed the switch

### DIFF
--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
@@ -443,16 +443,6 @@ class MaruFollowerTest {
       }
   }
 
-  private fun generateFailMessage(
-    checkedBlocks: List<Pair<BigInteger, String>>,
-    referenceBlocks: List<Pair<BigInteger, String>>,
-  ): String {
-    val difference = referenceBlocks - checkedBlocks.toSet()
-    return "Checked blocks: $checkedBlocks " +
-      "Reference blocks: $referenceBlocks " +
-      "Difference: $difference"
-  }
-
   private fun blocksToMetadata(blocks: List<EthBlock.Block>): List<Pair<BigInteger, String>> =
     blocks.map {
       it.number to it.hash

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
@@ -39,7 +39,7 @@ class MaruFollowerTest {
   private lateinit var transactionsHelper: BesuTransactionsHelper
   private val log = LogManager.getLogger(this.javaClass)
   private val maruFactory = MaruFactory()
-  private val desyncTolerance = 3
+  private val desyncTolerance = 0
 
   @BeforeEach
   fun setUp() {
@@ -152,7 +152,7 @@ class MaruFollowerTest {
     followerStack.maruApp.awaitTillMaruHasPeers(1u)
     validatorStack.maruApp.awaitTillMaruHasPeers(1u)
 
-    repeat(desyncTolerance.inc()) {
+    repeat(blocksToProduce) {
       transactionsHelper.run {
         validatorStack.besuNode.sendTransactionAndAssertExecution(
           logger = log,
@@ -162,7 +162,7 @@ class MaruFollowerTest {
       }
     }
 
-    checkValidatorAndFollowerBlocks(blocksToProduce + desyncTolerance.inc())
+    checkValidatorAndFollowerBlocks(blocksToProduce * 2)
   }
 
   @Test

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
@@ -379,9 +379,9 @@ class MaruFollowerTest {
     validatorBlocks: List<EthBlock.Block>,
   ): String {
     val followerBlockHashes = followerBlocks.map { it.hash }
-    val validatorBlocks = validatorBlocks.map { it.hash }
+    val validatorBlockHashes = validatorBlocks.map { it.hash }
     return "Follower blocks: $followerBlockHashes " +
-      "Validator blocks: $validatorBlocks"
+      "Validator blocks: $validatorBlockHashes"
   }
 
   private fun checkNetworkStackBlocksProduced(

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
@@ -162,7 +162,6 @@ class MaruFollowerTest {
         engineApiRpc = followerStack.besuNode.engineRpcUrl().get(),
         dataDir = followerStack.tmpDir,
         validatorPortForStaticPeering = validatorStack.p2pPort,
-        syncingConfig = MaruFactory.defaultSyncingConfig.copy(desyncTolerance = desyncTolerance),
       ),
     )
     followerStack.maruApp.start()

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
@@ -39,7 +39,7 @@ class MaruFollowerTest {
   private lateinit var transactionsHelper: BesuTransactionsHelper
   private val log = LogManager.getLogger(this.javaClass)
   private val maruFactory = MaruFactory()
-  private val desyncTolerance = 0
+  private val desyncTolerance = 0UL
 
   @BeforeEach
   fun setUp() {
@@ -82,7 +82,7 @@ class MaruFollowerTest {
         dataDir = followerStack.tmpDir,
         validatorPortForStaticPeering = validatorP2pPort,
         syncPeerChainGranularity = 1u,
-        desyncTolerance = desyncTolerance.toULong(),
+        desyncTolerance = desyncTolerance,
       )
     followerStack.setMaruApp(followerMaruApp)
     followerStack.maruApp.start()
@@ -144,7 +144,7 @@ class MaruFollowerTest {
         engineApiRpc = followerStack.besuNode.engineRpcUrl().get(),
         dataDir = followerStack.tmpDir,
         validatorPortForStaticPeering = validatorStack.p2pPort,
-        desyncTolerance = desyncTolerance.toULong(),
+        desyncTolerance = desyncTolerance,
       ),
     )
     followerStack.maruApp.start()
@@ -264,7 +264,7 @@ class MaruFollowerTest {
         engineApiRpc = followerStack.besuNode.engineRpcUrl().get(),
         dataDir = followerStack.tmpDir,
         validatorPortForStaticPeering = validatorStack.p2pPort,
-        desyncTolerance = desyncTolerance.toULong(),
+        desyncTolerance = desyncTolerance,
       ),
     )
     followerStack.maruApp.start()
@@ -308,7 +308,7 @@ class MaruFollowerTest {
         engineApiRpc = followerStack.besuNode.engineRpcUrl().get(),
         dataDir = followerStack.tmpDir,
         validatorPortForStaticPeering = validatorStack.p2pPort,
-        desyncTolerance = desyncTolerance.toULong(),
+        desyncTolerance = desyncTolerance,
       ),
     )
     followerStack.maruApp.start()
@@ -378,10 +378,12 @@ class MaruFollowerTest {
     followerBlocks: List<EthBlock.Block>,
     validatorBlocks: List<EthBlock.Block>,
   ): String {
-    val followerBlockHashes = followerBlocks.map { it.hash }
-    val validatorBlockHashes = validatorBlocks.map { it.hash }
-    return "Follower blocks: $followerBlockHashes " +
-      "Validator blocks: $validatorBlockHashes"
+    val followerBlocksMetadata = followerBlocks.map { it.number to it.hash }
+    val validatorBlockBlocksMetadata = validatorBlocks.map { it.number to it.hash }
+    val difference = validatorBlockBlocksMetadata - followerBlocksMetadata.toSet()
+    return "Follower blocks: $followerBlocksMetadata " +
+      "Validator blocks: $validatorBlockBlocksMetadata " +
+      "Difference: $difference"
   }
 
   private fun checkNetworkStackBlocksProduced(

--- a/app/src/integrationTest/kotlin/testutils/Checks.kt
+++ b/app/src/integrationTest/kotlin/testutils/Checks.kt
@@ -26,7 +26,7 @@ object Checks {
             DefaultBlockParameter.valueOf(BigInteger.valueOf(it.toLong())),
             false,
           ).sendAsync()
-      }.map { it.get().block }
+      }.mapNotNull { it?.get()?.block }
 
   // Checks that all block times in the list are exactly BesuFactory.MIN_BLOCK_TIME (1 second)
   // First block is skipped, because after startup block time is sometimes floating above 1 second

--- a/app/src/integrationTest/resources/log4j2-test.xml
+++ b/app/src/integrationTest/resources/log4j2-test.xml
@@ -14,10 +14,9 @@
             level="INFO"/>
 <!--    <Logger name="org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator"-->
 <!--            level="TRACE"/>-->
-    <Logger name="clients.l2.eth" level="DEBUG"/>
     <Logger name="maru.executionlayer.manager" level="DEBUG"/>
     <Logger name="maru.syncing" level="DEBUG"/>
-    <Logger name="org.hyperledger.besu" level="DEBUG"/>
+    <Logger name="org.hyperledger.besu" level="INFO"/>
     <Logger name="org.hyperledger.besu.consensus.qbft" level="INFO"/>
     <Root level="INFO" additivity="false">
       <appender-ref ref="console"/>

--- a/app/src/main/kotlin/maru/app/MaruApp.kt
+++ b/app/src/main/kotlin/maru/app/MaruApp.kt
@@ -212,6 +212,7 @@ class MaruApp(
           allowEmptyBlocks = config.allowEmptyBlocks,
           syncStatusProvider = syncStatusProvider,
           metadataCacheUpdaterHandlerEntry = metadataCacheUpdaterHandlerEntry,
+          forksSchedule = beaconGenesisConfig,
         )
       } else {
         QbftFollowerFactory(

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -175,7 +175,7 @@ class MaruAppFactory {
         statusMessageFactory = statusMessageFactory,
         besuMetricsSystem = besuMetricsSystemAdapter,
         forkIdHashProvider = forkIdHashProvider,
-        isBlockImportEnabledProvider = { syncControllerImpl!!.isBeaconChainSynced() },
+        isBlockImportEnabledProvider = { syncControllerImpl!!.isNodeFullInSync() },
       )
     val peersHeadBlockProvider = P2PPeersHeadBlockProvider(p2pNetwork.getPeerLookup())
     val finalizationProvider =

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -200,6 +200,7 @@ class MaruAppFactory {
           elSyncServiceConfig = ELSyncService.Config(config.syncing.elSyncStatusRefreshInterval),
           finalizationProvider = finalizationProvider,
           allowEmptyBlocks = config.allowEmptyBlocks,
+          desyncTolerance = config.syncing.desyncTolerance,
         )
       } else {
         AlwaysSyncedController(beaconChain)

--- a/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
@@ -12,6 +12,7 @@ import java.time.Clock
 import maru.config.QbftOptions
 import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ForkSpec
+import maru.consensus.ForksSchedule
 import maru.consensus.NewBlockHandler
 import maru.consensus.NewBlockHandlerMultiplexer
 import maru.consensus.NextBlockTimestampProvider
@@ -46,6 +47,7 @@ class QbftProtocolValidatorFactory(
   private val allowEmptyBlocks: Boolean,
   private val syncStatusProvider: SyncStatusProvider,
   private val metadataCacheUpdaterHandlerEntry: Pair<String, NewBlockHandler<*>>,
+  private val forksSchedule: ForksSchedule,
 ) : ProtocolFactory {
   override fun create(forkSpec: ForkSpec): Protocol {
     require(forkSpec.configuration is QbftConsensusConfig) {
@@ -99,6 +101,7 @@ class QbftProtocolValidatorFactory(
         clock = clock,
         p2PNetwork = p2pNetwork,
         allowEmptyBlocks = allowEmptyBlocks,
+        forksSchedule = forksSchedule,
       )
     val qbftProtocol = qbftValidatorFactory.create(forkSpec)
     syncStatusProvider.onFullSyncComplete {

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -168,6 +168,7 @@ data class SyncingConfig(
   val peerChainHeightPollingInterval: Duration,
   val peerChainHeightGranularity: UInt,
   val elSyncStatusRefreshInterval: Duration,
+  val desyncTolerance: ULong,
   val download: Download? = Download(),
 ) {
   data class Download(

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -56,6 +56,7 @@ class HopliteFriendlinessTest {
     port = 8080
 
     [syncing]
+    desync-tolerance = 10
     peer-chain-height-polling-interval = "5 seconds"
     peer-chain-height-granularity = 10
     el-sync-status-refresh-interval = "6 seconds"
@@ -168,6 +169,7 @@ class HopliteFriendlinessTest {
       peerChainHeightPollingInterval = 5.seconds,
       peerChainHeightGranularity = 10u,
       elSyncStatusRefreshInterval = 6.seconds,
+      desyncTolerance = 10UL,
       SyncingConfig.Download(
         blockRangeRequestTimeout = 10.seconds,
         blocksBatchSize = 64u,

--- a/consensus/src/main/kotlin/maru/consensus/ProtocolStarter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/ProtocolStarter.kt
@@ -162,7 +162,6 @@ class ProtocolStarter(
       poller?.cancel()
       poller = null
       currentProtocolWithForkReference.get()?.protocol?.stop()
-      currentProtocolWithForkReference.set(null)
       log.debug("Stopped fork transition polling")
     }
   }

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/BeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/BeaconBlockImporter.kt
@@ -80,7 +80,7 @@ class BlockBuildingBeaconBlockImporter(
   private val finalizationStateProvider: FinalizationProvider,
   private val nextBlockTimestampProvider: NextBlockTimestampProvider,
   private val prevRandaoProvider: PrevRandaoProvider<ULong>,
-  private val shouldBuildNextBlock: (BeaconState, ConsensusRoundIdentifier) -> Boolean,
+  private val shouldBuildNextBlock: (BeaconState, ConsensusRoundIdentifier, Long) -> Boolean,
   private val feeRecipient: ByteArray,
 ) : BeaconBlockImporter {
   private val log: Logger = LogManager.getLogger(this.javaClass)
@@ -92,13 +92,13 @@ class BlockBuildingBeaconBlockImporter(
     val beaconBlockHeader = beaconBlock.beaconBlockHeader
     val finalizationState = finalizationStateProvider(beaconBlock.beaconBlockBody)
     val nextBlocksRoundIdentifier = ConsensusRoundIdentifier(beaconBlockHeader.number.toLong() + 1, 0)
-    return if (shouldBuildNextBlock(beaconState, nextBlocksRoundIdentifier)) {
-      val nextBlockTimestamp =
-        nextBlockTimestampProvider.nextTargetBlockUnixTimestamp(
-          beaconState
-            .latestBeaconBlockHeader.timestamp
-            .toLong(),
-        )
+    val nextBlockTimestamp =
+      nextBlockTimestampProvider.nextTargetBlockUnixTimestamp(
+        beaconState
+          .latestBeaconBlockHeader.timestamp
+          .toLong(),
+      )
+    return if (shouldBuildNextBlock(beaconState, nextBlocksRoundIdentifier, nextBlockTimestamp)) {
       log.info(
         "importing block and starting build next block: " +
           "clBlockNumber={} clBlockTimestamp={} clNextBlockTimestamp={} beaconBlockHeader={}",

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
@@ -168,7 +168,7 @@ class ValidatingSealedBeaconBlockImporter(
 
             is Err -> {
               log.error(
-                "block seals validation failed: clBlockNumber={} elBlockNumber={} clBlockHash={} error={}",
+                "validation failed: clBlockNumber={} elBlockNumber={} clBlockHash={} error={}",
                 sealedBeaconBlock.beaconBlock.beaconBlockHeader.number,
                 sealedBeaconBlock.beaconBlock.beaconBlockBody.executionPayload.blockNumber,
                 sealedBeaconBlock.beaconBlock.beaconBlockHeader.hash

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
@@ -88,7 +88,7 @@ class TransactionalSealedBeaconBlockImporter(
     val clBlockNumber = sealedBeaconBlock.beaconBlock.beaconBlockHeader.number
     val elBLockNumber = sealedBeaconBlock.beaconBlock.beaconBlockBody.executionPayload.blockNumber
     try {
-      log.debug(
+      log.trace(
         "Importing clBlockNumber={} elBlockNumber={}",
         clBlockNumber,
         elBLockNumber,
@@ -103,14 +103,14 @@ class TransactionalSealedBeaconBlockImporter(
             .importBlock(resultingState, sealedBeaconBlock.beaconBlock)
         }.thenApply {
           updater.commit()
-          log.debug(
+          log.trace(
             "Import complete clBlockNumber={} elBlockNumber={}",
             clBlockNumber,
             elBLockNumber,
           )
           ValidationResult.Companion.Valid as ValidationResult
         }.exceptionally { ex ->
-          log.debug(
+          log.trace(
             "Import reverted clBlockNumber={} elBlockNumber={}",
             clBlockNumber,
             elBLockNumber,

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
@@ -86,6 +86,11 @@ class TransactionalSealedBeaconBlockImporter(
   override fun importBlock(sealedBeaconBlock: SealedBeaconBlock): SafeFuture<ValidationResult> {
     val updater = beaconChain.newUpdater()
     try {
+      log.debug(
+        "Importing block number={} elPayloadBlockNumber={}",
+        sealedBeaconBlock.beaconBlock.beaconBlockHeader.number,
+        sealedBeaconBlock.beaconBlock.beaconBlockBody.executionPayload.blockNumber,
+      )
       return stateTransition
         .processBlock(sealedBeaconBlock.beaconBlock)
         .thenCompose { resultingState ->
@@ -96,6 +101,7 @@ class TransactionalSealedBeaconBlockImporter(
             .importBlock(resultingState, sealedBeaconBlock.beaconBlock)
         }.thenApply {
           updater.commit()
+          log.debug("Import complete")
           ValidationResult.Companion.Valid as ValidationResult
         }.exceptionally { ex ->
           updater.rollback()

--- a/consensus/src/test/kotlin/maru/consensus/qbft/FollowerBeaconBlockImporterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/FollowerBeaconBlockImporterTest.kt
@@ -48,7 +48,7 @@ class FollowerBeaconBlockImporterTest {
         finalizationStateProvider = { finalizationState },
         nextBlockTimestampProvider = { nextBlockTimestamp },
         prevRandaoProvider = prevRandaoProvider,
-        shouldBuildNextBlock = { _: BeaconState, _: ConsensusRoundIdentifier ->
+        shouldBuildNextBlock = { _: BeaconState, _: ConsensusRoundIdentifier, _: Long ->
           shouldBuildNextBlock
         },
         feeRecipient = feeRecipient,
@@ -113,9 +113,13 @@ class FollowerBeaconBlockImporterTest {
     val randomBeaconBlock = DataGenerators.randomBeaconBlock(1UL)
     val randomBeaconState = DataGenerators.randomBeaconState(1UL)
     val expectedConsensusRoundIdentifier = ConsensusRoundIdentifier(2, 0)
-    val shouldBuildNextBlockPredicate: (BeaconState, ConsensusRoundIdentifier) -> Boolean = mock()
+    val shouldBuildNextBlockPredicate: (BeaconState, ConsensusRoundIdentifier, Long) -> Boolean = mock()
     whenever(
-      shouldBuildNextBlockPredicate.invoke(eq(randomBeaconState), eq(expectedConsensusRoundIdentifier)),
+      shouldBuildNextBlockPredicate.invoke(
+        eq(randomBeaconState),
+        eq(expectedConsensusRoundIdentifier),
+        eq(nextBlockTimestamp),
+      ),
     ).thenReturn(true)
     val nextBlockTimestampProvider: NextBlockTimestampProvider = mock()
     val expectedParentTimestamp = randomBeaconState.latestBeaconBlockHeader.timestamp.toLong()
@@ -134,7 +138,12 @@ class FollowerBeaconBlockImporterTest {
 
     beaconBlockImporter.importBlock(randomBeaconState, randomBeaconBlock)
 
-    verify(shouldBuildNextBlockPredicate, times(1)).invoke(eq(randomBeaconState), eq(expectedConsensusRoundIdentifier))
+    verify(shouldBuildNextBlockPredicate, times(1)).invoke(
+      eq(randomBeaconState),
+      eq
+        (expectedConsensusRoundIdentifier),
+      eq(nextBlockTimestamp),
+    )
     verify(nextBlockTimestampProvider, times(1)).nextTargetBlockUnixTimestamp(eq(expectedParentTimestamp))
   }
 }

--- a/core/src/main/kotlin/maru/consensus/ForkSchedule.kt
+++ b/core/src/main/kotlin/maru/consensus/ForkSchedule.kt
@@ -11,7 +11,6 @@ package maru.consensus
 import java.util.NavigableSet
 import java.util.TreeSet
 import kotlin.reflect.KClass
-import org.apache.logging.log4j.LogManager
 
 data class ForkSpec(
   val timestampSeconds: Long,
@@ -27,7 +26,6 @@ class ForksSchedule(
   val chainId: UInt,
   forks: Collection<ForkSpec>,
 ) {
-  private val log = LogManager.getLogger(this.javaClass)
   private val forks: NavigableSet<ForkSpec> =
     run {
       val newForks =
@@ -45,6 +43,15 @@ class ForksSchedule(
     forks.firstOrNull { timestamp >= it.timestampSeconds } ?: throw IllegalArgumentException(
       "No fork found for $timestamp, first known fork is at ${forks.last.timestampSeconds}",
     )
+
+  fun getNextForkByTimestamp(timestamp: Long): ForkSpec? {
+    val nextFork =
+      forks
+        .filter { it.timestampSeconds > timestamp }
+        .minByOrNull { it.timestampSeconds }
+
+    return nextFork
+  }
 
   fun <T : ConsensusConfig> getForkByConfigType(configClass: KClass<T>): ForkSpec {
     // Uses findLast since the list is reversed to get the first matching fork

--- a/core/src/test/kotlin/maru/consensus/ForksScheduleTest.kt
+++ b/core/src/test/kotlin/maru/consensus/ForksScheduleTest.kt
@@ -125,4 +125,83 @@ class ForksScheduleTest {
     val result = schedule.getForkByConfigType(qbftConsensusConfig::class)
     assertThat(result).isEqualTo(qbftFork1)
   }
+
+  @Test
+  fun `getNextForkByTimestamp returns next fork when one exists`() {
+    val fork1 = ForkSpec(1000L, 10, consensusConfig)
+    val fork2 = ForkSpec(2000L, 20, qbftConsensusConfig)
+    val fork3 = ForkSpec(3000L, 30, otherConsensusConfig)
+    val forks = listOf(fork1, fork2, fork3)
+
+    val schedule = ForksSchedule(expectedChainId, forks)
+
+    // Test getting next fork from before first fork
+    assertThat(schedule.getNextForkByTimestamp(500L)).isEqualTo(fork1)
+
+    // Test getting next fork from first fork timestamp
+    assertThat(schedule.getNextForkByTimestamp(1000L)).isEqualTo(fork2)
+
+    // Test getting next fork from between first and second fork
+    assertThat(schedule.getNextForkByTimestamp(1500L)).isEqualTo(fork2)
+
+    // Test getting next fork from second fork timestamp
+    assertThat(schedule.getNextForkByTimestamp(2000L)).isEqualTo(fork3)
+
+    // Test getting next fork from between second and third fork
+    assertThat(schedule.getNextForkByTimestamp(2500L)).isEqualTo(fork3)
+  }
+
+  @Test
+  fun `getNextForkByTimestamp returns null when no next fork exists`() {
+    val fork1 = ForkSpec(1000L, 10, consensusConfig)
+    val fork2 = ForkSpec(2000L, 20, qbftConsensusConfig)
+    val fork3 = ForkSpec(3000L, 30, otherConsensusConfig)
+    val forks = listOf(fork1, fork2, fork3)
+
+    val schedule = ForksSchedule(expectedChainId, forks)
+
+    // Test getting next fork from last fork timestamp
+    assertThat(schedule.getNextForkByTimestamp(3000L)).isNull()
+
+    // Test getting next fork from after last fork
+    assertThat(schedule.getNextForkByTimestamp(4000L)).isNull()
+  }
+
+  @Test
+  fun `getNextForkByTimestamp works with single fork`() {
+    val fork1 = ForkSpec(1000L, 10, consensusConfig)
+    val forks = listOf(fork1)
+
+    val schedule = ForksSchedule(expectedChainId, forks)
+
+    // Test getting next fork from before the only fork
+    assertThat(schedule.getNextForkByTimestamp(500L)).isEqualTo(fork1)
+
+    // Test getting next fork from the only fork timestamp
+    assertThat(schedule.getNextForkByTimestamp(1000L)).isNull()
+
+    // Test getting next fork from after the only fork
+    assertThat(schedule.getNextForkByTimestamp(1500L)).isNull()
+  }
+
+  @Test
+  fun `getNextForkByTimestamp with edge case timestamps`() {
+    val fork1 = ForkSpec(1000L, 10, consensusConfig)
+    val fork2 = ForkSpec(2000L, 20, qbftConsensusConfig)
+    val forks = listOf(fork1, fork2)
+
+    val schedule = ForksSchedule(expectedChainId, forks)
+
+    // Test with timestamp exactly one less than first fork
+    assertThat(schedule.getNextForkByTimestamp(999L)).isEqualTo(fork1)
+
+    // Test with timestamp exactly one more than first fork
+    assertThat(schedule.getNextForkByTimestamp(1001L)).isEqualTo(fork2)
+
+    // Test with timestamp exactly one less than second fork
+    assertThat(schedule.getNextForkByTimestamp(1999L)).isEqualTo(fork2)
+
+    // Test with timestamp exactly one more than second fork
+    assertThat(schedule.getNextForkByTimestamp(2001L)).isNull()
+  }
 }

--- a/core/src/test/kotlin/maru/consensus/ForksScheduleTest.kt
+++ b/core/src/test/kotlin/maru/consensus/ForksScheduleTest.kt
@@ -20,9 +20,9 @@ class ForksScheduleTest {
 
   @Test
   fun `throws exception on duplicate timestamps`() {
-    val fork1 = ForkSpec(1L, 1, consensusConfig)
-    val fork2 = ForkSpec(1L, 2, consensusConfig)
-    val fork3 = ForkSpec(3L, 3, consensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1L, blockTimeSeconds = 1, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 1L, blockTimeSeconds = 2, configuration = consensusConfig)
+    val fork3 = ForkSpec(timestampSeconds = 3L, blockTimeSeconds = 3, configuration = consensusConfig)
     val forks = listOf(fork1, fork2, fork3)
 
     val exception = assertThrows<IllegalArgumentException> { ForksSchedule(expectedChainId, forks) }
@@ -31,9 +31,9 @@ class ForksScheduleTest {
 
   @Test
   fun `test getForkByTimestamp returns correct fork`() {
-    val fork1 = ForkSpec(1L, 1, consensusConfig)
-    val fork2 = ForkSpec(2L, 2, consensusConfig)
-    val fork3 = ForkSpec(3L, 3, consensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1L, blockTimeSeconds = 1, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2L, blockTimeSeconds = 2, configuration = consensusConfig)
+    val fork3 = ForkSpec(timestampSeconds = 3L, blockTimeSeconds = 3, configuration = consensusConfig)
     val forks = listOf(fork1, fork2, fork3)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -45,8 +45,8 @@ class ForksScheduleTest {
 
   @Test
   fun `getForkByTimestamp throws if timestamp is before all forks`() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
-    val fork2 = ForkSpec(2000L, 20, consensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = consensusConfig)
     val forks = listOf(fork1, fork2)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -62,15 +62,15 @@ class ForksScheduleTest {
   fun `ForkSpec initialization with invalid blockTimeSeconds`() {
     val exception =
       assertThrows<IllegalArgumentException> {
-        ForkSpec(1000L, 0, consensusConfig)
+        ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 0, configuration = consensusConfig)
       }
     assertThat(exception).hasMessage("blockTimeSeconds must be greater or equal to 1 second")
   }
 
   @Test
   fun equality() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
-    val fork2 = ForkSpec(2000L, 20, consensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = consensusConfig)
     val forks1 = listOf(fork1, fork2)
     val forks2 = listOf(fork1, fork2)
 
@@ -83,9 +83,9 @@ class ForksScheduleTest {
 
   @Test
   fun inequality() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
-    val fork2 = ForkSpec(2000L, 20, consensusConfig)
-    val fork3 = ForkSpec(3000L, 30, consensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = consensusConfig)
+    val fork3 = ForkSpec(timestampSeconds = 3000L, blockTimeSeconds = 30, configuration = consensusConfig)
     val forks1 = listOf(fork1, fork2)
     val forks2 = listOf(fork1, fork3)
 
@@ -98,7 +98,7 @@ class ForksScheduleTest {
 
   @Test
   fun `getForkByConfigType throws exception when config class not found`() {
-    val qbftFork = ForkSpec(1000L, 10, qbftConsensusConfig)
+    val qbftFork = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = qbftConsensusConfig)
     val forks = listOf(qbftFork)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -112,11 +112,11 @@ class ForksScheduleTest {
 
   @Test
   fun `getForkByConfigType returns first matching fork`() {
-    val otherFork1 = ForkSpec(1000L, 10, consensusConfig)
-    val qbftFork1 = ForkSpec(2000L, 20, qbftConsensusConfig)
-    val otherFork2 = ForkSpec(3000L, 30, consensusConfig)
-    val qbftFork2 = ForkSpec(4000L, 40, qbftConsensusConfig)
-    val qbftFork3 = ForkSpec(5000L, 50, qbftConsensusConfig)
+    val otherFork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val qbftFork1 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = qbftConsensusConfig)
+    val otherFork2 = ForkSpec(timestampSeconds = 3000L, blockTimeSeconds = 30, configuration = consensusConfig)
+    val qbftFork2 = ForkSpec(timestampSeconds = 4000L, blockTimeSeconds = 40, configuration = qbftConsensusConfig)
+    val qbftFork3 = ForkSpec(timestampSeconds = 5000L, blockTimeSeconds = 50, configuration = qbftConsensusConfig)
     val forks = listOf(otherFork1, qbftFork1, otherFork2, qbftFork2, qbftFork3)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -128,9 +128,9 @@ class ForksScheduleTest {
 
   @Test
   fun `getNextForkByTimestamp returns next fork when one exists`() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
-    val fork2 = ForkSpec(2000L, 20, qbftConsensusConfig)
-    val fork3 = ForkSpec(3000L, 30, otherConsensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = qbftConsensusConfig)
+    val fork3 = ForkSpec(timestampSeconds = 3000L, blockTimeSeconds = 30, configuration = otherConsensusConfig)
     val forks = listOf(fork1, fork2, fork3)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -153,9 +153,9 @@ class ForksScheduleTest {
 
   @Test
   fun `getNextForkByTimestamp returns null when no next fork exists`() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
-    val fork2 = ForkSpec(2000L, 20, qbftConsensusConfig)
-    val fork3 = ForkSpec(3000L, 30, otherConsensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = qbftConsensusConfig)
+    val fork3 = ForkSpec(timestampSeconds = 3000L, blockTimeSeconds = 30, configuration = otherConsensusConfig)
     val forks = listOf(fork1, fork2, fork3)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -169,7 +169,7 @@ class ForksScheduleTest {
 
   @Test
   fun `getNextForkByTimestamp works with single fork`() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
     val forks = listOf(fork1)
 
     val schedule = ForksSchedule(expectedChainId, forks)
@@ -186,8 +186,8 @@ class ForksScheduleTest {
 
   @Test
   fun `getNextForkByTimestamp with edge case timestamps`() {
-    val fork1 = ForkSpec(1000L, 10, consensusConfig)
-    val fork2 = ForkSpec(2000L, 20, qbftConsensusConfig)
+    val fork1 = ForkSpec(timestampSeconds = 1000L, blockTimeSeconds = 10, configuration = consensusConfig)
+    val fork2 = ForkSpec(timestampSeconds = 2000L, blockTimeSeconds = 20, configuration = qbftConsensusConfig)
     val forks = listOf(fork1, fork2)
 
     val schedule = ForksSchedule(expectedChainId, forks)

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -39,3 +39,4 @@ port = 8080
 peer-chain-height-polling-interval = "5 seconds"
 peer-chain-height-granularity = 10
 el-sync-status-refresh-interval = "5 seconds"
+desync-tolerance = 10

--- a/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
+++ b/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
@@ -287,6 +287,7 @@ class CliqueToPosTest {
         ethereumApiConfig = engineApiConfig,
         dataDir = followerDataDir,
         validatorPortForStaticPeering = maruSequencer.p2pPort(),
+        desyncTolerance = 3UL,
       )
     if (nodeName.contains("besu")) {
       // Required to change validation rules from Clique to PostMerge

--- a/executionlayer/src/main/kotlin/maru/executionlayer/manager/JsonRpcExecutionLayerManager.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/manager/JsonRpcExecutionLayerManager.kt
@@ -56,6 +56,9 @@ class JsonRpcExecutionLayerManager(
         nextBlockTimestamp,
         executionLayerEngineApiClient.getFork(),
       )
+      require(it.payloadId != null) {
+        "Unexpected FCU result. Payload ID is null! $it"
+      }
       payloadId = it.payloadId
     }
   }

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -74,10 +74,10 @@ class MaruFactory(
         )
       return listOf(
         defaultSyncingConfig,
-//        defaultSyncingConfig.copy(
-//          syncTargetSelection = syncTargetSelectionForMostFrequent,
-//          useUnconditionalRandomDownloadPeer = true,
-//        ),
+        defaultSyncingConfig.copy(
+          syncTargetSelection = syncTargetSelectionForMostFrequent,
+          useUnconditionalRandomDownloadPeer = true,
+        ),
       )
     }
 

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -184,15 +184,25 @@ class MaruFactory(
     ethereumApiConfig: ApiEndpointConfig,
     validatorPortForStaticPeering: UInt? = null,
     overridingP2PNetwork: P2PNetwork? = null,
+    desyncTolerance: ULong = 10UL,
   ): MaruApp {
     val p2pConfig = buildP2pConfig(validatorPortForStaticPeering = validatorPortForStaticPeering)
     val beaconGenesisConfig = beaconGenesisConfig
+
+    val syncingConfig =
+      SyncingConfig(
+        peerChainHeightPollingInterval = 1.seconds,
+        peerChainHeightGranularity = 1u,
+        elSyncStatusRefreshInterval = 500.milliseconds,
+        desyncTolerance = desyncTolerance,
+      )
     val config =
       buildMaruConfig(
         engineApiEndpointConfig = engineApiConfig,
         ethereumApiEndpointConfig = ethereumApiConfig,
         dataDir = dataDir,
         p2pConfig = p2pConfig,
+        syncingConfig = syncingConfig,
       )
     return buildApp(
       config = config,
@@ -217,7 +227,7 @@ class MaruFactory(
         peerChainHeightPollingInterval = 1.seconds,
         peerChainHeightGranularity = 1u,
         elSyncStatusRefreshInterval = 500.milliseconds,
-        desyncTolerance = 10UL,
+        desyncTolerance = 0UL,
       ),
     allowEmptyBlocks: Boolean = false,
   ): MaruConfig {
@@ -438,20 +448,14 @@ class MaruFactory(
     dataDir: Path,
     validatorPortForStaticPeering: UInt? = null,
     overridingP2PNetwork: P2PNetwork? = null,
-  ): MaruApp {
-    val p2pConfig = buildP2pConfig(validatorPortForStaticPeering = validatorPortForStaticPeering)
-    val beaconGenesisConfig = beaconGenesisConfig
-    val config =
-      buildMaruConfig(
-        ethereumJsonRpcUrl = ethereumJsonRpcUrl,
-        engineApiRpc = engineApiRpc,
-        dataDir = dataDir,
-        p2pConfig = p2pConfig,
-      )
-    return buildApp(
-      config = config,
-      beaconGenesisConfig = beaconGenesisConfig,
+    desyncTolerance: ULong = 10UL,
+  ): MaruApp =
+    buildTestMaruFollowerWithConsensusSwitch(
+      ethereumApiConfig = ApiEndpointConfig(endpoint = URI.create(ethereumJsonRpcUrl).toURL()),
+      engineApiConfig = ApiEndpointConfig(endpoint = URI.create(engineApiRpc).toURL()),
+      dataDir = dataDir,
+      validatorPortForStaticPeering = validatorPortForStaticPeering,
       overridingP2PNetwork = overridingP2PNetwork,
+      desyncTolerance = desyncTolerance,
     )
-  }
 }

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -147,6 +147,7 @@ class MaruFactory(
         peerChainHeightPollingInterval = 1.seconds,
         peerChainHeightGranularity = 1u,
         elSyncStatusRefreshInterval = 500.milliseconds,
+        desyncTolerance = 10UL,
       ),
     allowEmptyBlocks: Boolean = false,
   ): MaruConfig {
@@ -216,6 +217,7 @@ class MaruFactory(
         peerChainHeightPollingInterval = 1.seconds,
         peerChainHeightGranularity = 1u,
         elSyncStatusRefreshInterval = 500.milliseconds,
+        desyncTolerance = 10UL,
       ),
     allowEmptyBlocks: Boolean = false,
   ): MaruConfig {
@@ -354,6 +356,7 @@ class MaruFactory(
     overridingLineaContractClient: LineaRollupSmartContractClientReadOnly? = null,
     allowEmptyBlocks: Boolean = false,
     syncPeerChainGranularity: UInt = 1u,
+    desyncTolerance: ULong = 10UL,
   ): MaruApp {
     val p2pConfig = buildP2pConfig(validatorPortForStaticPeering = validatorPortForStaticPeering)
     val config =
@@ -369,6 +372,7 @@ class MaruFactory(
             peerChainHeightPollingInterval = 1.seconds,
             peerChainHeightGranularity = syncPeerChainGranularity,
             elSyncStatusRefreshInterval = 500.milliseconds,
+            desyncTolerance = desyncTolerance,
           ),
       )
     return buildApp(

--- a/syncing/src/main/kotlin/maru/syncing/SyncController.kt
+++ b/syncing/src/main/kotlin/maru/syncing/SyncController.kt
@@ -172,7 +172,7 @@ class BeaconSyncControllerImpl(
     if (currentClStatus == CLSyncStatus.SYNCING) {
       // If already syncing, always update the sync target regardless of tolerance
       log.debug(
-        "Updating target while node is syncing sync_target={} current_head={}",
+        "Updating target while node is syncing syncTarget={} currentHead={}",
         syncTargetBlockNumber,
         currentHead,
       )
@@ -180,7 +180,7 @@ class BeaconSyncControllerImpl(
     } else if (blockDifference > desyncTolerance) {
       // Only start new sync if difference exceeds tolerance
       log.debug(
-        "Node got desynced updating sync target sync_target={} block_difference={} current_head={} desync_tolerance={}",
+        "Node got desynced updating sync target syncTarget={} blockDifference={} currentHead={} desyncTolerance={}",
         syncTargetBlockNumber,
         blockDifference,
         currentHead,

--- a/syncing/src/main/kotlin/maru/syncing/SyncController.kt
+++ b/syncing/src/main/kotlin/maru/syncing/SyncController.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
+import linea.kotlin.minusCoercingUnderflow
 import maru.config.consensus.ElFork
 import maru.consensus.ForksSchedule
 import maru.consensus.ValidatorProvider
@@ -36,6 +37,7 @@ internal data class SyncState(
 class BeaconSyncControllerImpl(
   private val beaconChain: BeaconChain,
   private val clSyncService: CLSyncService,
+  private val desyncTolerance: ULong,
   clState: CLSyncStatus = CLSyncStatus.SYNCING,
   elState: ELSyncStatus = ELSyncStatus.SYNCING,
 ) : SyncStatusProvider,
@@ -163,19 +165,31 @@ class BeaconSyncControllerImpl(
 
   override fun onBeaconChainSyncTargetUpdated(syncTargetBlockNumber: ULong) {
     val currentHead = beaconChain.getLatestBeaconState().latestBeaconBlockHeader.number
+    val blockDifference = syncTargetBlockNumber.minusCoercingUnderflow(currentHead)
 
-    if (syncTargetBlockNumber > currentHead) {
+    val currentClStatus = lock.read { currentState.clStatus }
+
+    if (currentClStatus == CLSyncStatus.SYNCING) {
+      // If already syncing, always update the sync target regardless of tolerance
+      log.debug(
+        "Updating target while node is syncing sync_target={} current_head={}",
+        syncTargetBlockNumber,
+        currentHead,
+      )
+      clSyncService.setSyncTarget(syncTargetBlockNumber)
+    } else if (blockDifference > desyncTolerance) {
+      // Only start new sync if difference exceeds tolerance
+      log.debug(
+        "Node got desynced updating sync target sync_target={} block_difference={} current_head={} desync_tolerance={}",
+        syncTargetBlockNumber,
+        blockDifference,
+        currentHead,
+        desyncTolerance,
+      )
       updateClSyncStatus(CLSyncStatus.SYNCING)
       clSyncService.setSyncTarget(syncTargetBlockNumber)
-    } else {
-      // We're caught up or ahead, but check if we were previously syncing
-      val currentClStatus = lock.read { currentState.clStatus }
-      if (currentClStatus == CLSyncStatus.SYNCING) {
-        // Transition from SYNCING to SYNCED
-        clSyncService.setSyncTarget(syncTargetBlockNumber)
-      }
-      // If already SYNCED, do nothing
     }
+    // If not syncing and within tolerance, do nothing
   }
 
   override fun getCLSyncTarget(): ULong = clSyncService.getSyncTarget()
@@ -195,6 +209,7 @@ class BeaconSyncControllerImpl(
       elSyncServiceConfig: ELSyncService.Config,
       finalizationProvider: FinalizationProvider,
       allowEmptyBlocks: Boolean = true,
+      desyncTolerance: ULong,
     ): SyncController {
       val clSyncService =
         CLSyncServiceImpl(
@@ -212,6 +227,7 @@ class BeaconSyncControllerImpl(
         BeaconSyncControllerImpl(
           beaconChain = beaconChain,
           clSyncService = clSyncService,
+          desyncTolerance = desyncTolerance,
         )
 
       val elSyncService =

--- a/syncing/src/test/kotlin/maru/syncing/SyncControllerSubscriptionsTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/SyncControllerSubscriptionsTest.kt
@@ -19,7 +19,12 @@ class SyncControllerSubscriptionsTest {
   private fun createController(
     blockNumber: ULong,
     clSyncService: CLSyncService = fakeClSyncService,
-  ): BeaconSyncControllerImpl = createSyncController(blockNumber, clSyncService)
+  ): BeaconSyncControllerImpl =
+    createSyncController(
+      blockNumber = blockNumber,
+      clSyncService = clSyncService,
+      desyncTolerance = 1UL,
+    )
 
   @BeforeEach
   fun setUp() {

--- a/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
@@ -29,7 +29,12 @@ class SyncControllerThreadSafetyTest {
   private fun createController(
     blockNumber: ULong,
     clSyncService: CLSyncService = FakeCLSyncService(),
-  ): BeaconSyncControllerImpl = createSyncController(blockNumber, clSyncService)
+  ): BeaconSyncControllerImpl =
+    createSyncController(
+      blockNumber = blockNumber,
+      clSyncService = clSyncService,
+      desyncTolerance = 1UL,
+    )
 
   @BeforeEach
   fun setUp() {

--- a/syncing/src/test/kotlin/maru/syncing/SyncControllerUtils.kt
+++ b/syncing/src/test/kotlin/maru/syncing/SyncControllerUtils.kt
@@ -38,11 +38,13 @@ class FakeCLSyncService : CLSyncService {
 fun createSyncController(
   blockNumber: ULong,
   clSyncService: CLSyncService = FakeCLSyncService(),
+  desyncTolerance: ULong,
 ): BeaconSyncControllerImpl {
   val state = DataGenerators.randomBeaconState(blockNumber)
   val beaconChain = InMemoryBeaconChain(state)
   return BeaconSyncControllerImpl(
     beaconChain = beaconChain,
     clSyncService = clSyncService,
+    desyncTolerance = desyncTolerance,
   )
 }


### PR DESCRIPTION
* Implemented desync tolerance config to keep the node synced when it's slightly falling behind the head of the chain
* Fixed the switch issue that was caused by Unsupported block error, when the next block to build for a previous fork falls on the next block. I.e. when there's a constant flow of blocks
* Fixed a bug in ProtocolStarter which was de-assigning protocols on stop and causing re-creation of the protocols and additional assignation of the new block import handlers every time node gets in sync