### PR TITLE
Spacing out block download attempts when there are no peers

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -203,8 +203,9 @@ class MaruAppFactory {
             ),
           elSyncServiceConfig = ELSyncService.Config(config.syncing.elSyncStatusRefreshInterval),
           finalizationProvider = finalizationProvider,
-          allowEmptyBlocks = config.allowEmptyBlocks,
           desyncTolerance = config.syncing.desyncTolerance,
+          pauseBetweenDownloadAttempts = config.syncing.download.pauseBetweenAttempts,
+          allowEmptyBlocks = config.allowEmptyBlocks,
           useUnconditionalRandomDownloadPeer = config.syncing.useUnconditionalRandomDownloadPeer,
         )
       } else {

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -65,6 +65,7 @@ import maru.syncing.MostFrequentHeadTargetSelector
 import maru.syncing.PeerChainTracker
 import maru.syncing.SyncController
 import maru.syncing.SyncTargetSelector
+import maru.syncing.beaconchain.pipeline.BeaconChainDownloadPipelineFactory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
@@ -204,9 +205,16 @@ class MaruAppFactory {
           elSyncServiceConfig = ELSyncService.Config(config.syncing.elSyncStatusRefreshInterval),
           finalizationProvider = finalizationProvider,
           desyncTolerance = config.syncing.desyncTolerance,
-          pauseBetweenDownloadAttempts = config.syncing.download.pauseBetweenAttempts,
+          pipelineConfig =
+            BeaconChainDownloadPipelineFactory.Config(
+              blockRangeRequestTimeout = config.syncing.download.blockRangeRequestTimeout,
+              pauseBetweenAttempts = config.syncing.download.pauseBetweenAttempts,
+              blocksBatchSize = config.syncing.download.blocksBatchSize,
+              blocksParallelism = config.syncing.download.blocksParallelism,
+              maxRetries = config.syncing.download.maxRetries,
+              useUnconditionalRandomDownloadPeer = config.syncing.download.useUnconditionalRandomDownloadPeer,
+            ),
           allowEmptyBlocks = config.allowEmptyBlocks,
-          useUnconditionalRandomDownloadPeer = config.syncing.useUnconditionalRandomDownloadPeer,
         )
       } else {
         AlwaysSyncedController(beaconChain)
@@ -333,6 +341,7 @@ class MaruAppFactory {
       when (config) {
         is SyncingConfig.SyncTargetSelection.Highest ->
           HighestHeadTargetSelector()
+
         is SyncingConfig.SyncTargetSelection.MostFrequent ->
           MostFrequentHeadTargetSelector(config.peerChainHeightGranularity)
       }

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -208,7 +208,7 @@ class MaruAppFactory {
           pipelineConfig =
             BeaconChainDownloadPipelineFactory.Config(
               blockRangeRequestTimeout = config.syncing.download.blockRangeRequestTimeout,
-              pauseBetweenAttempts = config.syncing.download.pauseBetweenAttempts,
+              backoffDelay = config.syncing.download.backoffDelay,
               blocksBatchSize = config.syncing.download.blocksBatchSize,
               blocksParallelism = config.syncing.download.blocksParallelism,
               maxRetries = config.syncing.download.maxRetries,

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -170,7 +170,7 @@ data class SyncingConfig(
   val elSyncStatusRefreshInterval: Duration,
   val desyncTolerance: ULong,
   val useUnconditionalRandomDownloadPeer: Boolean = false,
-  val download: Download? = Download(),
+  val download: Download = Download(),
 ) {
   sealed interface SyncTargetSelection {
     data object Highest : SyncTargetSelection
@@ -191,6 +191,7 @@ data class SyncingConfig(
     val blocksBatchSize: UInt = 10u,
     val blocksParallelism: UInt = 1u,
     val maxRetries: UInt = 5u,
+    val pauseBetweenAttempts: Duration = 1.seconds,
   )
 }
 

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -168,7 +168,7 @@ data class SyncingConfig(
   val peerChainHeightPollingInterval: Duration,
   val syncTargetSelection: SyncTargetSelection,
   val elSyncStatusRefreshInterval: Duration,
-  val desyncTolerance: ULong,
+  val desyncTolerance: ULong = 5UL,
   val download: Download,
 ) {
   sealed interface SyncTargetSelection {

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -169,8 +169,7 @@ data class SyncingConfig(
   val syncTargetSelection: SyncTargetSelection,
   val elSyncStatusRefreshInterval: Duration,
   val desyncTolerance: ULong,
-  val useUnconditionalRandomDownloadPeer: Boolean = false,
-  val download: Download = Download(),
+  val download: Download,
 ) {
   sealed interface SyncTargetSelection {
     data object Highest : SyncTargetSelection
@@ -192,6 +191,7 @@ data class SyncingConfig(
     val blocksParallelism: UInt = 1u,
     val maxRetries: UInt = 5u,
     val pauseBetweenAttempts: Duration = 1.seconds,
+    val useUnconditionalRandomDownloadPeer: Boolean = false,
   )
 }
 

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -190,7 +190,7 @@ data class SyncingConfig(
     val blocksBatchSize: UInt = 10u,
     val blocksParallelism: UInt = 1u,
     val maxRetries: UInt = 5u,
-    val pauseBetweenAttempts: Duration = 1.seconds,
+    val backoffDelay: Duration = 1.seconds,
     val useUnconditionalRandomDownloadPeer: Boolean = false,
   )
 }

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -68,7 +68,7 @@ class HopliteFriendlinessTest {
     blocks-batch-size = 64
     blocks-parallelism = 10
     max-retries = 5
-    pause-between-attempts = "10 seconds"
+    backoff-delay = "10 seconds"
     use-unconditional-random-download-peer = true
     """.trimIndent()
   private val rawConfigToml =
@@ -183,7 +183,7 @@ class HopliteFriendlinessTest {
           blocksBatchSize = 64u,
           blocksParallelism = 10u,
           maxRetries = 5u,
-          pauseBetweenAttempts = 10.seconds,
+          backoffDelay = 10.seconds,
           useUnconditionalRandomDownloadPeer = true,
         ),
     )

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -69,6 +69,7 @@ class HopliteFriendlinessTest {
     blocks-batch-size = 64
     blocks-parallelism = 10
     max-retries = 5
+    pause-between-attempts = "10 seconds"
     """.trimIndent()
   private val rawConfigToml =
     """
@@ -176,12 +177,12 @@ class HopliteFriendlinessTest {
         ),
       elSyncStatusRefreshInterval = 6.seconds,
       desyncTolerance = 10UL,
-      useUnconditionalRandomDownloadPeer = false,
       SyncingConfig.Download(
         blockRangeRequestTimeout = 10.seconds,
         blocksBatchSize = 64u,
         blocksParallelism = 10u,
         maxRetries = 5u,
+        pauseBetweenAttempts = 10.seconds,
       ),
     )
 

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -61,7 +61,6 @@ class HopliteFriendlinessTest {
     desync-tolerance = 10
     peer-chain-height-polling-interval = "5 seconds"
     el-sync-status-refresh-interval = "6 seconds"
-    use-unconditional-random-download-peer = false
     sync-target-selection = { _type = "MostFrequent", peer-chain-height-granularity = 10 }
 
     [syncing.download]
@@ -70,6 +69,7 @@ class HopliteFriendlinessTest {
     blocks-parallelism = 10
     max-retries = 5
     pause-between-attempts = "10 seconds"
+    use-unconditional-random-download-peer = true
     """.trimIndent()
   private val rawConfigToml =
     """
@@ -184,7 +184,7 @@ class HopliteFriendlinessTest {
           blocksParallelism = 10u,
           maxRetries = 5u,
           pauseBetweenAttempts = 10.seconds,
-          useUnconditionalRandomDownloadPeer = false,
+          useUnconditionalRandomDownloadPeer = true,
         ),
     )
 

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -47,5 +47,5 @@ block-range-request-timeout = "10 seconds"
 blocks-batch-size = 10
 blocks-parallelism = 10
 max-retries = 5
-pause-between-attempts = "1 seconds"
+backoff-delay = "1 seconds"
 use-unconditional-random-download-peer = false

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -42,3 +42,4 @@ use-unconditional-random-download-peer = false
 sync-target-selection = "Highest"
 # sync-target-selection = { _type = "MostFrequent", peer-chain-height-granularity = 10 }
 desync-tolerance = 10
+pause-between-attempts = "1 seconds"

--- a/docker/maru/config.dev.toml
+++ b/docker/maru/config.dev.toml
@@ -38,8 +38,14 @@ port = 8080
 [syncing]
 peer-chain-height-polling-interval = "5 seconds"
 el-sync-status-refresh-interval = "5 seconds"
-use-unconditional-random-download-peer = false
 sync-target-selection = "Highest"
 # sync-target-selection = { _type = "MostFrequent", peer-chain-height-granularity = 10 }
 desync-tolerance = 10
+
+[syncing.download]
+block-range-request-timeout = "10 seconds"
+blocks-batch-size = 10
+blocks-parallelism = 10
+max-retries = 5
 pause-between-attempts = "1 seconds"
+use-unconditional-random-download-peer = false

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -63,8 +63,8 @@ class MaruFactory(
         peerChainHeightPollingInterval = 1.seconds,
         syncTargetSelection = SyncTargetSelection.Highest,
         elSyncStatusRefreshInterval = 500.milliseconds,
-        useUnconditionalRandomDownloadPeer = false,
         desyncTolerance = 0UL,
+        download = SyncingConfig.Download(),
       )
 
     fun enumeratingSyncingConfigs(): List<SyncingConfig> {
@@ -76,7 +76,7 @@ class MaruFactory(
         defaultSyncingConfig,
         defaultSyncingConfig.copy(
           syncTargetSelection = syncTargetSelectionForMostFrequent,
-          useUnconditionalRandomDownloadPeer = true,
+          download = SyncingConfig.Download(useUnconditionalRandomDownloadPeer = true),
         ),
       )
     }
@@ -211,8 +211,8 @@ class MaruFactory(
         peerChainHeightPollingInterval = 1.seconds,
         syncTargetSelection = SyncTargetSelection.Highest,
         elSyncStatusRefreshInterval = 500.milliseconds,
-        useUnconditionalRandomDownloadPeer = false,
         desyncTolerance = desyncTolerance,
+        download = SyncingConfig.Download(),
       )
     val config =
       buildMaruConfig(

--- a/syncing/src/main/kotlin/maru/syncing/SyncController.kt
+++ b/syncing/src/main/kotlin/maru/syncing/SyncController.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
+import kotlin.time.Duration
 import linea.kotlin.minusCoercingUnderflow
 import maru.config.consensus.ElFork
 import maru.consensus.ForksSchedule
@@ -208,9 +209,10 @@ class BeaconSyncControllerImpl(
       metricsFacade: MetricsFacade,
       elSyncServiceConfig: ELSyncService.Config,
       finalizationProvider: FinalizationProvider,
+      desyncTolerance: ULong,
+      pauseBetweenDownloadAttempts: Duration,
       allowEmptyBlocks: Boolean = true,
       useUnconditionalRandomDownloadPeer: Boolean = false,
-      desyncTolerance: ULong,
     ): SyncController {
       val clSyncService =
         CLSyncServiceImpl(
@@ -222,6 +224,7 @@ class BeaconSyncControllerImpl(
           pipelineConfig =
             BeaconChainDownloadPipelineFactory.Config(
               useUnconditionalRandomDownloadPeer = useUnconditionalRandomDownloadPeer,
+              pauseBetweenAttempts = pauseBetweenDownloadAttempts,
             ),
           peerLookup = peerLookup,
           besuMetrics = besuMetrics,

--- a/syncing/src/main/kotlin/maru/syncing/SyncController.kt
+++ b/syncing/src/main/kotlin/maru/syncing/SyncController.kt
@@ -12,7 +12,6 @@ import java.util.concurrent.Executors
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
-import kotlin.time.Duration
 import linea.kotlin.minusCoercingUnderflow
 import maru.config.consensus.ElFork
 import maru.consensus.ForksSchedule
@@ -210,9 +209,8 @@ class BeaconSyncControllerImpl(
       elSyncServiceConfig: ELSyncService.Config,
       finalizationProvider: FinalizationProvider,
       desyncTolerance: ULong,
-      pauseBetweenDownloadAttempts: Duration,
+      pipelineConfig: BeaconChainDownloadPipelineFactory.Config,
       allowEmptyBlocks: Boolean = true,
-      useUnconditionalRandomDownloadPeer: Boolean = false,
     ): SyncController {
       val clSyncService =
         CLSyncServiceImpl(
@@ -221,11 +219,7 @@ class BeaconSyncControllerImpl(
           allowEmptyBlocks = allowEmptyBlocks,
           executorService =
             Executors.newCachedThreadPool(Thread.ofPlatform().daemon().factory()),
-          pipelineConfig =
-            BeaconChainDownloadPipelineFactory.Config(
-              useUnconditionalRandomDownloadPeer = useUnconditionalRandomDownloadPeer,
-              pauseBetweenAttempts = pauseBetweenDownloadAttempts,
-            ),
+          pipelineConfig = pipelineConfig,
           peerLookup = peerLookup,
           besuMetrics = besuMetrics,
           metricsFacade = metricsFacade,

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
@@ -9,7 +9,6 @@
 package maru.syncing.beaconchain.pipeline
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import maru.extensions.clampedAdd
 import maru.p2p.PeerLookup
@@ -43,12 +42,12 @@ class BeaconChainDownloadPipelineFactory(
   }
 
   data class Config(
-    val blockRangeRequestTimeout: Duration = 5.seconds,
+    val blockRangeRequestTimeout: Duration,
     val pauseBetweenAttempts: Duration,
-    val blocksBatchSize: UInt = 10u,
-    val blocksParallelism: UInt = 1u,
-    val maxRetries: UInt = 5u,
-    val useUnconditionalRandomDownloadPeer: Boolean = false,
+    val blocksBatchSize: UInt,
+    val blocksParallelism: UInt,
+    val maxRetries: UInt,
+    val useUnconditionalRandomDownloadPeer: Boolean,
   )
 
   fun createPipeline(startBlock: ULong): BeaconChainPipeline {

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
@@ -43,7 +43,7 @@ class BeaconChainDownloadPipelineFactory(
 
   data class Config(
     val blockRangeRequestTimeout: Duration,
-    val pauseBetweenAttempts: Duration,
+    val backoffDelay: Duration,
     val blocksBatchSize: UInt,
     val blocksParallelism: UInt,
     val maxRetries: UInt,
@@ -80,7 +80,7 @@ class BeaconChainDownloadPipelineFactory(
           DownloadBlocksStep.Config(
             maxRetries = config.maxRetries,
             blockRangeRequestTimeout = config.blockRangeRequestTimeout,
-            pauseBetweenAttempts = config.pauseBetweenAttempts,
+            backoffDelay = config.backoffDelay,
           ),
       )
     val importBlocksStep = ImportBlocksStep(blockImporter)

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
@@ -29,7 +29,7 @@ class BeaconChainDownloadPipelineFactory(
   private val blockImporter: SealedBeaconBlockImporter<ValidationResult>,
   private val metricsSystem: MetricsSystem,
   private val peerLookup: PeerLookup,
-  private val config: Config = Config(),
+  private val config: Config,
   private val syncTargetProvider: () -> ULong,
 ) {
   init {
@@ -44,6 +44,7 @@ class BeaconChainDownloadPipelineFactory(
 
   data class Config(
     val blockRangeRequestTimeout: Duration = 5.seconds,
+    val pauseBetweenAttempts: Duration,
     val blocksBatchSize: UInt = 10u,
     val blocksParallelism: UInt = 1u,
     val maxRetries: UInt = 5u,
@@ -76,8 +77,12 @@ class BeaconChainDownloadPipelineFactory(
             peerLookup = peerLookup,
             useUnconditionalRandomSelection = config.useUnconditionalRandomDownloadPeer,
           ),
-        maxRetries = config.maxRetries,
-        blockRangeRequestTimeout = config.blockRangeRequestTimeout,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = config.maxRetries,
+            blockRangeRequestTimeout = config.blockRangeRequestTimeout,
+            pauseBetweenAttempts = config.pauseBetweenAttempts,
+          ),
       )
     val importBlocksStep = ImportBlocksStep(blockImporter)
 

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
@@ -86,7 +86,7 @@ class DownloadBlocksStep(
       do {
         val peer = downloadPeerProvider.getDownloadingPeer(targetRange.endBlock)
         try {
-          require(peer != null) { "No suitable downloading peer" }
+          require(peer != null) { "No suitable peer for the download" }
           peer
             .sendBeaconBlocksByRange(startBlockNumber, remaining)
             .orTimeout(config.blockRangeRequestTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
@@ -93,8 +93,6 @@ class DownloadBlocksStep(
     )
 
     while (state.downloadedBlocks.size.toULong() < totalCount) {
-      checkMaxRetries(state.retries)
-
       state =
         when (val peer = downloadPeerProvider.getDownloadingPeer(targetRange.endBlock)) {
           null -> {
@@ -104,6 +102,7 @@ class DownloadBlocksStep(
 
           else -> downloadFromPeer(peer, state)
         }
+      checkMaxRetries(state.retries)
     }
 
     return state.downloadedBlocks

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
@@ -178,13 +178,13 @@ class DownloadBlocksStep(
     peer: MaruPeer,
     state: DownloadState,
   ): DownloadState {
-    when (e.cause) {
-      is TimeoutException -> {
+    when {
+      e is TimeoutException || e.cause is TimeoutException -> {
         log.debug("Timed out while downloading blocks from peer: {}", peer.id)
         peer.adjustReputation(ReputationAdjustment.LARGE_PENALTY)
       }
 
-      is RpcException -> {
+      e.cause is RpcException -> {
         log.warn("RpcException while downloading blocks from peer: {}", peer.id, e.cause)
         peer.adjustReputation(ReputationAdjustment.SMALL_PENALTY)
       }

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
@@ -59,7 +59,7 @@ class DownloadBlocksStep(
   data class Config(
     val maxRetries: UInt,
     val blockRangeRequestTimeout: Duration,
-    val pauseBetweenAttempts: Duration,
+    val backoffDelay: Duration,
   )
 
   private val log: Logger = LogManager.getLogger(this.javaClass)
@@ -98,7 +98,7 @@ class DownloadBlocksStep(
       state =
         when (val peer = downloadPeerProvider.getDownloadingPeer(targetRange.endBlock)) {
           null -> {
-            sleep(config.pauseBetweenAttempts.inWholeMilliseconds)
+            sleep(config.backoffDelay.inWholeMilliseconds)
             state.copy(retries = state.retries + 1u)
           }
 
@@ -191,7 +191,7 @@ class DownloadBlocksStep(
 
       else -> {
         log.debug("Failed to download blocks from peer: {}", peer.id, e)
-        sleep(config.pauseBetweenAttempts.inWholeMilliseconds)
+        sleep(config.backoffDelay.inWholeMilliseconds)
       }
     }
     return state.copy(retries = state.retries + 1u)

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
@@ -94,6 +94,15 @@ class CLSyncServiceImplTest {
   private lateinit var clSyncService: CLSyncServiceImpl
   private lateinit var peerLookup: PeerLookup
   private lateinit var executorService: ExecutorService
+  private val defaultPipelineConfig =
+    Config(
+      blockRangeRequestTimeout = 5.seconds,
+      blocksBatchSize = 10u,
+      blocksParallelism = 1u,
+      pauseBetweenAttempts = pauseBetweenAttempts,
+      maxRetries = 5u,
+      useUnconditionalRandomDownloadPeer = false,
+    )
 
   @BeforeEach
   fun setUp() {
@@ -130,12 +139,7 @@ class CLSyncServiceImplTest {
         peerLookup = peerLookup,
         besuMetrics = TestMetricsSystemAdapter,
         metricsFacade = TestMetricsFacade,
-        pipelineConfig =
-          Config(
-            blocksBatchSize = 10u,
-            blocksParallelism = 1u,
-            pauseBetweenAttempts = pauseBetweenAttempts,
-          ),
+        pipelineConfig = defaultPipelineConfig,
       )
 
     try {
@@ -207,12 +211,7 @@ class CLSyncServiceImplTest {
         peerLookup = peerLookup,
         besuMetrics = TestMetricsSystemAdapter,
         metricsFacade = metricsFacade,
-        pipelineConfig =
-          Config(
-            blocksBatchSize = 10u,
-            blocksParallelism = 1u,
-            pauseBetweenAttempts = pauseBetweenAttempts,
-          ),
+        pipelineConfig = defaultPipelineConfig,
       )
 
     syncToTarget(BEACON_CHAIN_2_HEAD, restartClSyncService)

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
@@ -78,7 +78,7 @@ class CLSyncServiceImplTest {
     private val sourceNodeKey =
       "0x0802122100f3d2fffa99dc8906823866d96316492ebf7a8478713a89a58b7385af85b088a1"
         .fromHexToByteArray()
-    private val pauseBetweenAttempts = 1.seconds
+    private val backoffDelay = 1.seconds
   }
 
   private var sourceNodePort: UInt = 0u
@@ -99,7 +99,7 @@ class CLSyncServiceImplTest {
       blockRangeRequestTimeout = 5.seconds,
       blocksBatchSize = 10u,
       blocksParallelism = 1u,
-      pauseBetweenAttempts = pauseBetweenAttempts,
+      backoffDelay = backoffDelay,
       maxRetries = 5u,
       useUnconditionalRandomDownloadPeer = false,
     )

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
@@ -13,6 +13,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
 import maru.config.P2P
 import maru.config.consensus.ElFork
 import maru.config.consensus.qbft.QbftConsensusConfig
@@ -77,6 +78,7 @@ class CLSyncServiceImplTest {
     private val sourceNodeKey =
       "0x0802122100f3d2fffa99dc8906823866d96316492ebf7a8478713a89a58b7385af85b088a1"
         .fromHexToByteArray()
+    private val pauseBetweenAttempts = 1.seconds
   }
 
   private var sourceNodePort: UInt = 0u
@@ -128,7 +130,12 @@ class CLSyncServiceImplTest {
         peerLookup = peerLookup,
         besuMetrics = TestMetricsSystemAdapter,
         metricsFacade = TestMetricsFacade,
-        pipelineConfig = Config(blocksBatchSize = 10u, blocksParallelism = 1u),
+        pipelineConfig =
+          Config(
+            blocksBatchSize = 10u,
+            blocksParallelism = 1u,
+            pauseBetweenAttempts = pauseBetweenAttempts,
+          ),
       )
 
     try {
@@ -200,7 +207,12 @@ class CLSyncServiceImplTest {
         peerLookup = peerLookup,
         besuMetrics = TestMetricsSystemAdapter,
         metricsFacade = metricsFacade,
-        pipelineConfig = Config(blocksBatchSize = 10u, blocksParallelism = 1u),
+        pipelineConfig =
+          Config(
+            blocksBatchSize = 10u,
+            blocksParallelism = 1u,
+            pauseBetweenAttempts = pauseBetweenAttempts,
+          ),
       )
 
     syncToTarget(BEACON_CHAIN_2_HEAD, restartClSyncService)

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactoryTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactoryTest.kt
@@ -11,6 +11,7 @@ package maru.syncing.beaconchain.pipeline
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators.randomSealedBeaconBlock
@@ -38,6 +39,7 @@ class BeaconChainDownloadPipelineFactoryTest {
   private lateinit var factory: BeaconChainDownloadPipelineFactory
   private lateinit var executorService: ExecutorService
   private lateinit var syncTargetProvider: () -> ULong
+  private val defaultPauseBetweenAttempts = 1.seconds
 
   @BeforeEach
   fun setUp() {
@@ -50,7 +52,7 @@ class BeaconChainDownloadPipelineFactoryTest {
         blockImporter = blockImporter,
         metricsSystem = NoOpMetricsSystem(),
         peerLookup = peerLookup,
-        config = BeaconChainDownloadPipelineFactory.Config(),
+        config = BeaconChainDownloadPipelineFactory.Config(pauseBetweenAttempts = defaultPauseBetweenAttempts),
         syncTargetProvider = syncTargetProvider,
       )
   }
@@ -166,7 +168,11 @@ class BeaconChainDownloadPipelineFactoryTest {
         blockImporter = blockImporter,
         metricsSystem = NoOpMetricsSystem(),
         peerLookup = peerLookup,
-        config = BeaconChainDownloadPipelineFactory.Config(blocksBatchSize = 100u),
+        config =
+          BeaconChainDownloadPipelineFactory.Config(
+            blocksBatchSize = 100u,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
         syncTargetProvider = { 50uL },
       )
 
@@ -210,7 +216,11 @@ class BeaconChainDownloadPipelineFactoryTest {
         blockImporter = blockImporter,
         metricsSystem = NoOpMetricsSystem(),
         peerLookup = peerLookup,
-        config = BeaconChainDownloadPipelineFactory.Config(blocksBatchSize = 0u),
+        config =
+          BeaconChainDownloadPipelineFactory.Config(
+            blocksBatchSize = 0u,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
         syncTargetProvider = { 0uL },
       )
     }.isInstanceOf(IllegalArgumentException::class.java)

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactoryTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactoryTest.kt
@@ -40,13 +40,13 @@ class BeaconChainDownloadPipelineFactoryTest {
   private lateinit var factory: BeaconChainDownloadPipelineFactory
   private lateinit var executorService: ExecutorService
   private lateinit var syncTargetProvider: () -> ULong
-  private val defaultPauseBetweenAttempts = 1.seconds
+  private val defaultBackoffDelay = 1.seconds
   private val defaultPipelineConfig =
     Config(
       blockRangeRequestTimeout = 5.seconds,
       blocksBatchSize = 10u,
       blocksParallelism = 1u,
-      pauseBetweenAttempts = defaultPauseBetweenAttempts,
+      backoffDelay = defaultBackoffDelay,
       maxRetries = 5u,
       useUnconditionalRandomDownloadPeer = false,
     )

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
@@ -37,6 +37,13 @@ class DownloadBlocksTest {
   private val defaultEndBlock = 11UL
   private val defaultPauseBetweenAttempts = 15.milliseconds
 
+  private val defaultConfig =
+    DownloadBlocksStep.Config(
+      maxRetries = 5u,
+      blockRangeRequestTimeout = 5.seconds,
+      pauseBetweenAttempts = defaultPauseBetweenAttempts,
+    )
+
   @Test
   fun `downloads blocks successfully from peer`() {
     val peer = mock<MaruPeer>()
@@ -49,12 +56,7 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(10uL, defaultEndBlock)
     val result = task.apply(range).get()
@@ -83,12 +85,7 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(10uL, endBlock)
     val result = task.apply(range).get()
@@ -112,12 +109,7 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(1uL, endBlock)
 
@@ -139,12 +131,7 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(1uL, endBlock)
 
@@ -168,12 +155,7 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(1uL, endBlock)
 
@@ -189,12 +171,7 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(1uL, 1uL)
 
@@ -215,12 +192,7 @@ class DownloadBlocksTest {
     val step =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(10u, defaultEndBlock)
     val result = step.apply(range).get()
@@ -248,12 +220,7 @@ class DownloadBlocksTest {
     val step =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(10u, defaultEndBlock)
     val result = step.apply(range).get()
@@ -268,12 +235,7 @@ class DownloadBlocksTest {
     val step =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = 5u,
-            blockRangeRequestTimeout = 5.seconds,
-            pauseBetweenAttempts = defaultPauseBetweenAttempts,
-          ),
+        config = defaultConfig,
       )
     val range = SyncTargetRange(0u, 0u)
 

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
@@ -281,7 +281,7 @@ class DownloadBlocksTest {
       catchThrowable {
         step.apply(range).get()
       }
-    assertThat(throwable).cause().hasMessageContaining("Maximum retries reached")
+    assertThat(throwable.cause).isInstanceOf(DownloadBlocksStep.MaxRetriesReachedException::class.java)
   }
 
   @Test

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
@@ -10,6 +10,7 @@ package maru.syncing.beaconchain.pipeline
 
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeoutException
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators.randomSealedBeaconBlock
@@ -18,6 +19,7 @@ import maru.p2p.MaruPeer
 import maru.p2p.PeerLookup
 import maru.p2p.messages.BeaconBlocksByRangeResponse
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -33,6 +35,7 @@ import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
 
 class DownloadBlocksTest {
   private val defaultEndBlock = 11UL
+  private val defaultPauseBetweenAttempts = 15.milliseconds
 
   @Test
   fun `downloads blocks successfully from peer`() {
@@ -46,8 +49,12 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(10uL, defaultEndBlock)
     val result = task.apply(range).get()
@@ -76,8 +83,12 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(10uL, endBlock)
     val result = task.apply(range).get()
@@ -101,8 +112,12 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(1uL, endBlock)
 
@@ -124,8 +139,12 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(1uL, endBlock)
 
@@ -149,8 +168,12 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(1uL, endBlock)
 
@@ -166,8 +189,12 @@ class DownloadBlocksTest {
     val task =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(1uL, 1uL)
 
@@ -188,8 +215,12 @@ class DownloadBlocksTest {
     val step =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(10u, defaultEndBlock)
     val result = step.apply(range).get()
@@ -217,8 +248,12 @@ class DownloadBlocksTest {
     val step =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(10u, defaultEndBlock)
     val result = step.apply(range).get()
@@ -233,16 +268,20 @@ class DownloadBlocksTest {
     val step =
       DownloadBlocksStep(
         downloadPeerProvider = DownloadPeerProviderImpl(peerLookup, false),
-        maxRetries = 5u,
-        blockRangeRequestTimeout = 5.seconds,
+        config =
+          DownloadBlocksStep.Config(
+            maxRetries = 5u,
+            blockRangeRequestTimeout = 5.seconds,
+            pauseBetweenAttempts = defaultPauseBetweenAttempts,
+          ),
       )
     val range = SyncTargetRange(0u, 0u)
-    try {
-      step.apply(range).get()
-      assert(false) { "Expected exception" }
-    } catch (e: Exception) {
-      assertThat(e.cause).isInstanceOf(NoSuchElementException::class.java)
-    }
+
+    val throwable =
+      catchThrowable {
+        step.apply(range).get()
+      }
+    assertThat(throwable).cause().hasMessageContaining("Maximum retries reached")
   }
 
   @Test
@@ -273,31 +312,19 @@ class DownloadBlocksTest {
 
     whenever(peerLookup.getPeers()).thenReturn(listOf(peer1, peer2, peer3))
 
-    try {
-      DownloadPeerProviderImpl(peerLookup, false).getDownloadingPeer(100U)
-      assert(false) { "Expected exception" }
-    } catch (e: Exception) {
-      assertThat(e).isInstanceOf(NoSuchElementException::class.java)
-    }
+    val peerWithFilter = DownloadPeerProviderImpl(peerLookup, false).getDownloadingPeer(100U)
+    assertThat(peerWithFilter).isNull()
   }
 
   @Test
   fun `throws if no peers are available regardless of purely random selection or not`() {
     val peerLookup = mock<PeerLookup>()
     whenever(peerLookup.getPeers()).thenReturn(emptyList())
-    try {
-      DownloadPeerProviderImpl(peerLookup, false).getDownloadingPeer(100U)
-      assert(false) { "Expected exception" }
-    } catch (e: Exception) {
-      assertThat(e).isInstanceOf(NoSuchElementException::class.java)
-    }
+    val peerWithFilter = DownloadPeerProviderImpl(peerLookup, false).getDownloadingPeer(100U)
+    assertThat(peerWithFilter).isNull()
 
-    try {
-      DownloadPeerProviderImpl(peerLookup, true).getDownloadingPeer(100U)
-      assert(false) { "Expected exception" }
-    } catch (e: Exception) {
-      assertThat(e).isInstanceOf(NoSuchElementException::class.java)
-    }
+    val peerWithoutFilter = DownloadPeerProviderImpl(peerLookup, true).getDownloadingPeer(100U)
+    assertThat(peerWithoutFilter).isNull()
   }
 
   private fun createSealedBlocksWithPeers(

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
@@ -181,7 +181,7 @@ class DownloadBlocksTest {
     val range = SyncTargetRange(1uL, endBlock)
 
     val ex = assertThrows<Exception> { task.apply(range).get() }
-    assertThat(ex.message).contains("Maximum retries reached.")
+    assertThat(ex.cause).isInstanceOf(DownloadBlocksStep.MaxRetriesReachedException::class.java)
   }
 
   @Test
@@ -196,7 +196,8 @@ class DownloadBlocksTest {
       )
     val range = SyncTargetRange(1uL, 1uL)
 
-    assertThrows<ExecutionException> { task.apply(range).get() }
+    val ex = assertThrows<ExecutionException> { task.apply(range).get() }
+    assertThat(ex.cause).isInstanceOf(DownloadBlocksStep.MaxRetriesReachedException::class.java)
   }
 
   @Test
@@ -281,7 +282,7 @@ class DownloadBlocksTest {
   }
 
   @Test
-  fun `throws if no peers have latest block number higher or equal to 100U when purely random selection is false`() {
+  fun `returns null if no peers have latest block number more or equal to 100U with filter enabled`() {
     val peerLookup = mock<PeerLookup>()
 
     val peer1 = mock<MaruPeer>()
@@ -300,7 +301,7 @@ class DownloadBlocksTest {
   }
 
   @Test
-  fun `throws if no peers are available regardless of purely random selection or not`() {
+  fun `returns null if no peers are available regardless of purely random selection or not`() {
     val peerLookup = mock<PeerLookup>()
     whenever(peerLookup.getPeers()).thenReturn(emptyList())
     val peerWithFilter = DownloadPeerProviderImpl(peerLookup, false).getDownloadingPeer(100U)

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
@@ -35,13 +35,13 @@ import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
 
 class DownloadBlocksTest {
   private val defaultEndBlock = 11UL
-  private val defaultPauseBetweenAttempts = 15.milliseconds
+  private val defaultBackoffDelay = 15.milliseconds
 
   private val defaultConfig =
     DownloadBlocksStep.Config(
       maxRetries = 5u,
       blockRangeRequestTimeout = 5.seconds,
-      pauseBetweenAttempts = defaultPauseBetweenAttempts,
+      backoffDelay = defaultBackoffDelay,
     )
 
   @Test


### PR DESCRIPTION
* Also, refactored `DownloadBlocksStep` to reduce its cyclomatic complexity
* Implemented actual configuration propagation to the download step