### PR TITLE
Fixing the wrong transactional block import

### DIFF
--- a/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
@@ -112,7 +112,7 @@ class TransactionalSealedBeaconBlockImporter(
             .thenApply { }
             .exceptionally { e ->
               // Block import doesn't participate in the validation, so we want it to complete, yet ignore its result
-              log.error(
+              log.warn(
                 "Failure importing a valid CL block! clBlockNumber={}, elBlockNumber={}",
                 clBlockNumber,
                 elBLockNumber,

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
@@ -106,11 +106,12 @@ class TransactionalSealedBeaconBlockImporter(
             elBLockNumber,
           )
           resultingState
-        }.thenPeek { resultingState ->
-          // Block import doesn't participate in the validation
+        }.thenCompose { resultingState ->
           beaconBlockImporter
             .importBlock(resultingState, sealedBeaconBlock.beaconBlock)
-            .whenException { e ->
+            .thenApply { }
+            .exceptionally { e ->
+              // Block import doesn't participate in the validation, so we want it to complete, yet ignore its result
               log.error(
                 "Failure importing a valid CL block! clBlockNumber={}, elBlockNumber={}",
                 clBlockNumber,


### PR DESCRIPTION
If Maru restarts after the block import, but before the Commit call, it can enter an inconsistent state. The issue is that EL head block is ahead, and CL block is behind in this case. Maru can't build new blocks in this state, because EL node won't return payload id if FCU is called on a block hash which isn't the current head of the EL chain.