### PR TITLE
move QbftConsensusConfig into core module

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -29,12 +29,12 @@ import maru.api.ChainDataProviderImpl
 import maru.config.MaruConfig
 import maru.config.P2PConfig
 import maru.config.SyncingConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkIdHashManager
 import maru.consensus.ForkIdHashManagerImpl
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.StaticValidatorProvider
 import maru.consensus.blockimport.ElForkAwareBlockImporter
 import maru.consensus.state.FinalizationProvider

--- a/app/src/main/kotlin/maru/app/QbftFollowerFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftFollowerFactory.kt
@@ -8,9 +8,9 @@
  */
 package maru.app
 
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ForkSpec
 import maru.consensus.ProtocolFactory
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.StaticValidatorProvider
 import maru.consensus.blockimport.FollowerBeaconBlockImporter
 import maru.consensus.blockimport.TransactionalSealedBeaconBlockImporter

--- a/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
@@ -10,11 +10,11 @@ package maru.app
 
 import java.time.Clock
 import maru.config.QbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
 import maru.consensus.NextBlockTimestampProvider
 import maru.consensus.ProtocolFactory
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.SealedBeaconBlockHandlerAdapter
 import maru.consensus.blockimport.NewSealedBeaconBlockHandlerMultiplexer
 import maru.consensus.qbft.QbftValidatorFactory

--- a/config/src/main/kotlin/maru/config/consensus/JsonFriendlyForksSchedule.kt
+++ b/config/src/main/kotlin/maru/config/consensus/JsonFriendlyForksSchedule.kt
@@ -24,12 +24,12 @@ import kotlin.collections.component2
 import kotlin.collections.map
 import kotlin.collections.toSet
 import kotlin.reflect.KType
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
 import maru.extensions.fromHexToByteArray
 

--- a/config/src/test/kotlin/maru/config/consensus/JsonFriendlyForksScheduleTest.kt
+++ b/config/src/test/kotlin/maru/config/consensus/JsonFriendlyForksScheduleTest.kt
@@ -9,11 +9,11 @@
 package maru.config.consensus
 
 import maru.config.MaruConfigLoader.parseBeaconChainConfig
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
 import maru.extensions.fromHexToByteArray
 import org.assertj.core.api.Assertions.assertThat

--- a/consensus/src/main/kotlin/maru/consensus/ProtocolFactory.kt
+++ b/consensus/src/main/kotlin/maru/consensus/ProtocolFactory.kt
@@ -8,8 +8,6 @@
  */
 package maru.consensus
 
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.qbft.DifficultyAwareQbftFactory
 import maru.core.Protocol
 

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/ElForkAwareBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/ElForkAwareBlockImporter.kt
@@ -8,12 +8,12 @@
  */
 package maru.consensus.blockimport
 
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
 import maru.consensus.NewBlockHandler
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.state.FinalizationProvider
 import maru.core.BeaconBlock
 import maru.executionlayer.manager.ExecutionLayerManager

--- a/consensus/src/main/kotlin/maru/consensus/qbft/DifficultyAwareQbft.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/DifficultyAwareQbft.kt
@@ -13,7 +13,7 @@ import java.util.Timer
 import java.util.UUID
 import kotlin.concurrent.timerTask
 import kotlin.time.Duration.Companion.seconds
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ForkSpec
 import maru.consensus.ProtocolFactory
 import maru.core.Protocol

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftValidatorFactory.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftValidatorFactory.kt
@@ -12,13 +12,13 @@ import java.time.Clock
 import java.util.concurrent.Executors
 import kotlin.time.Duration.Companion.seconds
 import maru.config.QbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
 import maru.consensus.NextBlockTimestampProvider
 import maru.consensus.PrevRandaoProvider
 import maru.consensus.PrevRandaoProviderImpl
 import maru.consensus.ProtocolFactory
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.StaticValidatorProvider
 import maru.consensus.blockimport.BlockBuildingBeaconBlockImporter
 import maru.consensus.blockimport.SealedBeaconBlockImporter

--- a/consensus/src/test/kotlin/maru/consensus/NextBlockTimestampProviderTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/NextBlockTimestampProviderTest.kt
@@ -12,8 +12,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import kotlin.test.Test
-import maru.config.consensus.qbft.QbftConsensusConfig
-import maru.consensus.ElFork
 import org.assertj.core.api.Assertions.assertThat
 
 class NextBlockTimestampProviderTest {

--- a/core/src/main/kotlin/maru/consensus/QbftConsensusConfigs.kt
+++ b/core/src/main/kotlin/maru/consensus/QbftConsensusConfigs.kt
@@ -6,10 +6,8 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package maru.config.consensus.qbft
+package maru.consensus
 
-import maru.consensus.ConsensusConfig
-import maru.consensus.ElFork
 import maru.core.Validator
 
 data class QbftConsensusConfig(

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -37,13 +37,13 @@ import maru.config.QbftConfig
 import maru.config.SyncingConfig
 import maru.config.SyncingConfig.SyncTargetSelection
 import maru.config.ValidatorElNode
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkIdHashManager
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.state.FinalizationProvider
 import maru.core.SealedBeaconBlock
 import maru.core.Validator

--- a/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
@@ -11,7 +11,6 @@ package maru.p2p
 import java.util.concurrent.ConcurrentHashMap
 import maru.config.P2PConfig
 import maru.config.SyncingConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkIdHashManager
@@ -19,6 +18,7 @@ import maru.consensus.ForkIdHashManagerImpl
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.core.ext.DataGenerators
 import maru.crypto.Hashing
 import maru.database.InMemoryBeaconChain

--- a/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
@@ -19,7 +19,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import maru.config.P2PConfig
 import maru.config.SyncingConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkIdHashManager
@@ -27,6 +26,7 @@ import maru.consensus.ForkIdHashManagerImpl
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.core.BeaconBlockHeader
 import maru.core.BeaconState
 import maru.core.SealedBeaconBlock

--- a/p2p/src/test/kotlin/maru/p2p/QbftForkIdComputerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/QbftForkIdComputerTest.kt
@@ -9,13 +9,13 @@
 package maru.p2p
 
 import kotlin.random.Random
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkId
 import maru.consensus.ForkIdHashManagerImpl
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.core.ext.DataGenerators
 import maru.crypto.Hashing
 import maru.database.InMemoryBeaconChain

--- a/p2p/src/test/kotlin/maru/p2p/discovery/MaruDiscoveryServiceTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/discovery/MaruDiscoveryServiceTest.kt
@@ -17,7 +17,6 @@ import kotlin.time.toJavaDuration
 import linea.kotlin.decodeHex
 import linea.kotlin.toULong
 import maru.config.P2PConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkId
@@ -25,6 +24,7 @@ import maru.consensus.ForkIdHashManagerImpl
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.core.ext.DataGenerators
 import maru.crypto.Hashing
 import maru.database.InMemoryBeaconChain

--- a/serialization/src/main/kotlin/maru/serialization/ForkSpecSerializer.kt
+++ b/serialization/src/main/kotlin/maru/serialization/ForkSpecSerializer.kt
@@ -9,9 +9,9 @@
 package maru.serialization
 
 import java.nio.ByteBuffer
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ForkSpec
+import maru.consensus.QbftConsensusConfig
 import maru.extensions.encodeHex
 
 object QbftConsensusConfigSerializer : Serializer<QbftConsensusConfig> {

--- a/serialization/src/test/kotlin/maru/serialization/DifficultyAwareQbftConfigSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/DifficultyAwareQbftConfigSerializerTest.kt
@@ -8,9 +8,9 @@
  */
 package maru.serialization
 
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
+import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat

--- a/serialization/src/test/kotlin/maru/serialization/ForkSpecSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/ForkSpecSerializerTest.kt
@@ -9,10 +9,10 @@
 package maru.serialization
 
 import java.nio.ByteBuffer
-import maru.config.consensus.qbft.DifficultyAwareQbftConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
+import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkSpec
+import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat

--- a/serialization/src/test/kotlin/maru/serialization/QbftConsensusConfigSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/QbftConsensusConfigSerializerTest.kt
@@ -8,8 +8,8 @@
  */
 package maru.serialization
 
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ElFork
+import maru.consensus.QbftConsensusConfig
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/serialization/src/test/kotlin/maru/serialization/QbftForkIdSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/QbftForkIdSerializerTest.kt
@@ -9,10 +9,10 @@
 package maru.serialization
 
 import kotlin.random.Random
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkId
 import maru.consensus.ForkSpec
+import maru.consensus.QbftConsensusConfig
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
@@ -18,7 +18,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import maru.config.P2PConfig
 import maru.config.SyncingConfig
-import maru.config.consensus.qbft.QbftConsensusConfig
 import maru.consensus.ConsensusConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkIdHashManager
@@ -26,6 +25,7 @@ import maru.consensus.ForkIdHashManagerImpl
 import maru.consensus.ForkIdHasher
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
 import maru.consensus.StaticValidatorProvider
 import maru.consensus.qbft.DelayedQbftBlockCreator
 import maru.core.BeaconState


### PR DESCRIPTION
relates to #402 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relocates `QbftConsensusConfig` and `DifficultyAwareQbftConfig` into `maru.consensus` (core) and updates all usages, decoders, and serializers across modules.
> 
> - **Core**:
>   - Add `maru.consensus.QbftConsensusConfig` and `maru.consensus.DifficultyAwareQbftConfig` (`QbftConsensusConfigs.kt`).
> - **Config**:
>   - Update `JsonFriendlyForksSchedule` decoder and tests to use new `maru.consensus.*` types.
> - **Consensus**:
>   - Update `ProtocolFactory`, `ElForkAwareBlockImporter`, `qbft` factories/implementations to reference new QBFT config types.
> - **Serialization**:
>   - Adjust `ForkSpecSerializer` and related tests to serialize the new QBFT config types.
> - **App/P2P/Syncing (tests and wiring)**:
>   - Replace imports/usages of `maru.config.consensus.qbft.*` with `maru.consensus.*` in factories, tests, and helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb4e73d5200eca2de57f11c971b42e48ae55bfb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->