### PR TITLE
chaos-testing: different block time on sequencer to validate follower…

### DIFF
--- a/chaos-testing/helm/charts/maru/values.yaml
+++ b/chaos-testing/helm/charts/maru/values.yaml
@@ -108,7 +108,7 @@ configFiles:
         "1683325137": {
           "type": "qbft",
           "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
-          "blockTimeSeconds": 2,
+          "blockTimeSeconds": 1,
           "feeRecipient": "0x0000000000000000000000000000000000000000",
           "elFork": "Prague"
         }
@@ -127,7 +127,7 @@ configFiles:
       <Logger name="tech.pegasys.teku" level="INFO"/>
       <Logger name="maru" level="INFO"/>
       <Logger name="maru.syncing" level="DEBUG"/>
-      <Logger name="maru.clients" level="TRACE"/>
+      <Logger name="maru.clients" level="DEBUG"/>
       <Root level="INFO">
         <AppenderRef ref="Console"/>
       </Root>

--- a/chaos-testing/helm/values/maru-sequencer-0.yaml
+++ b/chaos-testing/helm/values/maru-sequencer-0.yaml
@@ -11,3 +11,26 @@ configFiles:
     [payload-validator]
     engine-api-endpoint = { endpoint = "http://besu-sequencer-0-0.besu-sequencer-0.default.svc.cluster.local:8550" }
     eth-api-endpoint = { endpoint = "http://besu-sequencer-0-0.besu-sequencer-0.default.svc.cluster.local:8545" }
+
+  genesisJson: |
+    {
+      "chainId": 1337,
+      "config": {
+        "0": {
+          "type": "difficultyAwareQbft",
+          "blockTimeSeconds": 2,
+          "postTtdConfig": {
+            "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
+            "elFork": "Paris"
+          },
+          "terminalTotalDifficulty": 10
+        },
+        "1683325137": {
+          "type": "qbft",
+          "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
+          "blockTimeSeconds": 2,
+          "feeRecipient": "0x0000000000000000000000000000000000000000",
+          "elFork": "Prague"
+        }
+      }
+    }


### PR DESCRIPTION
… connect with lower

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets maru block time to 1s for fork 1683325137, lowers maru.clients log verbosity, and adds explicit qbft genesis to sequencer values.
> 
> - **Helm values**:
>   - **maru (`charts/maru/values.yaml`)**:
>     - Set `genesisJson.config["1683325137"].blockTimeSeconds` from `2` to `1`.
>     - Change logger `maru.clients` level from `TRACE` to `DEBUG` in `log4j`.
>   - **sequencer (`values/maru-sequencer-0.yaml`)**:
>     - Add `genesisJson` with qbft configuration:
>       - At `"0"`: `difficultyAwareQbft` with `blockTimeSeconds: 2`, `postTtdConfig`, `terminalTotalDifficulty: 10`.
>       - At `"1683325137"`: `qbft` with `validatorSet`, `blockTimeSeconds: 2`, `feeRecipient`, `elFork: "Prague"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bb76958b953a00d6763903346eeaab754bcbac2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->