### PR TITLE
exclude nethermind from the end2end tests post merge

### DIFF
--- a/e2e/src/acceptanceTest/kotlin/maru/e2e/TestEnvironment.kt
+++ b/e2e/src/acceptanceTest/kotlin/maru/e2e/TestEnvironment.kt
@@ -82,7 +82,10 @@ object TestEnvironment {
     ) + gethExecutionEngineClients
 
   val followerExecutionClientsPostMerge =
-    (mapOf("follower-geth" to geth1ExecutionEngineClient) + followerExecutionEngineClients - "follower-geth-2")
+    (
+      mapOf("follower-geth" to geth1ExecutionEngineClient) +
+        (followerExecutionEngineClients - "follower-geth-2" - "follower-nethermind")
+    )
 
   private fun buildWeb3Client(
     rpcUrl: String,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `follower-nethermind` from `followerExecutionClientsPostMerge` in `e2e/src/acceptanceTest/kotlin/maru/e2e/TestEnvironment.kt`.
> 
> - **E2E Test Environment** (`TestEnvironment.kt`):
>   - Update `followerExecutionClientsPostMerge` to exclude `follower-nethermind` (still removing `follower-geth-2`, adding `follower-geth`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b88ba3093671c13860e117766e25a53f2357d83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->