### PR TITLE
Fix bug when p2p Port and discovery port set to 0

### DIFF
--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
@@ -143,18 +143,12 @@ class P2PNetworkImpl(
 
   private val builtNetwork: TekuLibP2PNetwork = buildP2PNetwork(privateKeyBytes, p2pConfig, metricsSystem)
   internal val p2pNetwork = builtNetwork.p2PNetwork
-  private val discoveryService: MaruDiscoveryService? =
-    p2pConfig.discovery?.let {
-      MaruDiscoveryService(
-        privateKeyBytes = privateKeyBytesWithoutPrefix(privateKeyBytes),
-        p2pConfig = p2pConfig,
-        forkIdHashManager = forkIdHashManager,
-        p2PState = p2PState,
-      )
-    }
+  private var discoveryService: MaruDiscoveryService? = null
 
   override val localNodeRecord: NodeRecord?
     get() = discoveryService?.getLocalNodeRecord()
+  override val enr: String?
+    get() = localNodeRecord?.asEnr()
 
   // TODO: We need to call the updateForkId method on the discovery service when the forkId changes internal
   private val peerLookup = builtNetwork.peerLookup
@@ -169,7 +163,6 @@ class P2PNetworkImpl(
   override val nodeId: String = p2pNetwork.nodeId.toBase58()
   override val discoveryAddresses: List<String>
     get() = p2pNetwork.discoveryAddresses.getOrElse { emptyList() }
-  override val enr: String? = discoveryService?.getLocalNodeRecord()?.asEnr()
   override val nodeAddresses: List<String> = p2pNetwork.nodeAddresses
 
   private fun logEnr(nodeRecord: NodeRecord) {
@@ -194,6 +187,15 @@ class P2PNetworkImpl(
             .createPeerAddress(peer)
             ?.let { address -> addStaticPeer(address as MultiaddrPeerAddress) }
         }
+        discoveryService =
+          p2pConfig.discovery?.let {
+            MaruDiscoveryService(
+              privateKeyBytes = privateKeyBytesWithoutPrefix(privateKeyBytes),
+              p2pConfig = if (p2pConfig.port == 0u) p2pConfig.copy(port = port) else p2pConfig,
+              forkIdHashManager = forkIdHashManager,
+              p2PState = p2PState,
+            )
+          }
         discoveryService?.start()
         maruPeerManager.start(discoveryService, p2pNetwork)
         metricsFacade.createGauge(
@@ -214,11 +216,11 @@ class P2PNetworkImpl(
             privateKeyBytes = privateKeyBytes,
             seq = 0,
             ipv4 = it,
-            ipv4UdpPort = p2pConfig.discovery?.port?.toInt() ?: p2pConfig.port.toInt(),
-            ipv4TcpPort = p2pConfig.port.toInt(),
+            ipv4UdpPort = p2pConfig.discovery?.port?.toInt() ?: port.toInt(),
+            ipv4TcpPort = port.toInt(),
           )
         }
-    return enrs + listOfNotNull(discoveryService?.getLocalNodeRecord())
+    return enrs + listOfNotNull(localNodeRecord)
   }
 
   override fun stop(): SafeFuture<Unit> {

--- a/p2p/src/main/kotlin/maru/p2p/discovery/MaruDiscoveryService.kt
+++ b/p2p/src/main/kotlin/maru/p2p/discovery/MaruDiscoveryService.kt
@@ -45,6 +45,12 @@ class MaruDiscoveryService(
     require(p2pConfig.discovery != null) {
       "MaruDiscoveryService is being initialized without the discovery section in the P2P config!"
     }
+    require(p2pConfig.discovery!!.port != 0u) {
+      "MaruDiscoveryService requires discovery port to be set to a non zero value!"
+    }
+    require(p2pConfig.port != 0u) {
+      "MaruDiscoveryService requires p2p port to be set to a non zero value!"
+    }
   }
 
   companion object {

--- a/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
@@ -13,6 +13,7 @@ import io.libp2p.etc.types.fromHex
 import java.lang.Thread.sleep
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.stream.Stream
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -44,6 +45,9 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito.RETURNS_DEEP_STUBS
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
@@ -73,6 +77,13 @@ class P2PTest {
     private const val PORT4 = 9237u
     private const val PORT5 = 9238u
     private const val PORT6 = 9239u
+
+    @JvmStatic
+    fun p2pPorts(): Stream<Arguments> =
+      Stream.of(
+        Arguments.of(PORT1.toInt(), PORT3.toInt(), PORT5.toInt()),
+        Arguments.of(0, 0, 0),
+      )
 
     private const val PEER_ID_NODE_1: String = "16Uiu2HAmPRfinavM2jE9BSkCagBGStJ2SEkPPm6fxFVMdCQebzt6"
     private const val PEER_ID_NODE_2: String = "16Uiu2HAmVXtqhevTAJqZucPbR2W4nCMpetrQASgjZpcxDEDaUPPt"
@@ -199,9 +210,9 @@ class P2PTest {
     val p2pNetworkImpl1 = createP2PNetwork(privateKey = key1, port = PORT1)
     val p2pNetworkImpl2 = createP2PNetwork(privateKey = key2, port = PORT2)
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
 
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl2.start().get()
 
       p2pNetworkImpl1.addStaticPeer(peerAddress = MultiaddrPeerAddress.fromAddress(PEER_ADDRESS_NODE_2))
 
@@ -219,8 +230,8 @@ class P2PTest {
     val p2pNetworkImpl2 = createP2PNetwork(privateKey = key2, port = PORT2)
 
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
 
       p2pNetworkImpl1.addStaticPeer(peerAddress = MultiaddrPeerAddress.fromAddress(PEER_ADDRESS_NODE_2))
 
@@ -242,9 +253,9 @@ class P2PTest {
     val p2pNetworkImpl1 = createP2PNetwork(privateKey = key1, port = PORT1)
     val p2pNetworkImpl2 = createP2PNetwork(privateKey = key2, port = PORT2, staticPeers = listOf(PEER_ADDRESS_NODE_1))
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
 
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl2.start().get()
 
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl1, peers = 1) }
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl2, peers = 1) }
@@ -271,9 +282,9 @@ class P2PTest {
       )
 
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
 
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl2.start().get()
 
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl1, peers = 1) }
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl2, peers = 1) }
@@ -300,10 +311,10 @@ class P2PTest {
         beaconChain = beaconChain2,
       )
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
 
       val blocksReceived = mutableListOf<SealedBeaconBlock>()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl2.start().get()
       p2pNetworkImpl2.subscribeToBlocks {
         updateBeaconChainState(beaconChain2, it.beaconBlock.beaconBlockHeader)
         blocksReceived.add(it)
@@ -342,15 +353,15 @@ class P2PTest {
     val p2pNetworkImpl3 =
       createP2PNetwork(privateKey = key3, port = PORT3, staticPeers = emptyList(), beaconChain = beaconChain3)
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
       p2pNetworkImpl2.subscribeToBlocks {
         updateBeaconChainState(beaconChain = beaconChain2, beaconBlockHeader = it.beaconBlock.beaconBlockHeader)
         SafeFuture.completedFuture(ValidationResult.Companion.Valid)
       }
 
       val blockReceived = SafeFuture<SealedBeaconBlock>()
-      p2pNetworkImpl3.start()
+      p2pNetworkImpl3.start().get()
       p2pNetworkImpl3.subscribeToBlocks {
         updateBeaconChainState(beaconChain3, it.beaconBlock.beaconBlockHeader)
         blockReceived.complete(it)
@@ -399,8 +410,8 @@ class P2PTest {
     val p2pNetworkImpl1 = createP2PNetwork(privateKey = key1, port = PORT1)
     val p2pNetworkImpl2 = createP2PNetwork(privateKey = key2, port = PORT2, staticPeers = listOf(PEER_ADDRESS_NODE_1))
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
 
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl1, peers = 1) }
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl2, peers = 1) }
@@ -459,8 +470,8 @@ class P2PTest {
     val p2pNetworkImpl2 = createP2PNetwork(privateKey = key2, port = PORT2, staticPeers = listOf(PEER_ADDRESS_NODE_1))
 
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
 
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl1, peers = 1) }
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl2, peers = 1) }
@@ -494,8 +505,8 @@ class P2PTest {
     val p2pNetworkImpl1 = createP2PNetwork(privateKey = key1, port = PORT1, beaconChain = getMockedBeaconChain())
     val p2pNetworkImpl2 = createP2PNetwork(privateKey = key2, port = PORT2, staticPeers = listOf(PEER_ADDRESS_NODE_1))
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
 
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl1, peers = 1) }
       awaitUntilAsserted { assertNetworkHasPeers(network = p2pNetworkImpl2, peers = 1) }
@@ -528,7 +539,7 @@ class P2PTest {
         discovery = null,
       )
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
       val enr =
         ENR.factory.fromEnr(
           p2pNetworkImpl1
@@ -562,7 +573,7 @@ class P2PTest {
           ),
       )
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
       val enr = ENR.factory.fromEnr(p2pNetworkImpl1.enr)
       assertThat(enr.tcpAddress.get().port).isEqualTo(PORT1.toInt())
       assertThat(enr.udpAddress.get().port).isEqualTo(PORT2.toInt())
@@ -577,13 +588,18 @@ class P2PTest {
     }
   }
 
-  @Test
-  fun `peer can be discovered and disconnected peers can be rediscovered`() {
+  @ParameterizedTest
+  @MethodSource("p2pPorts")
+  fun `peer can be discovered and disconnected peers can be rediscovered`(
+    p2pPort1: Int,
+    p2pPort2: Int,
+    p2pPort3: Int,
+  ) {
     val refreshInterval = 5.seconds
     val p2pNetworkImpl1 =
       createP2PNetwork(
         privateKey = key1,
-        port = PORT1,
+        port = p2pPort1.toUInt(),
         discovery =
           P2PConfig.Discovery(
             port = PORT2,
@@ -599,12 +615,12 @@ class P2PTest {
     var p2pNetworkImpl2: P2PNetworkImpl? = null
     var p2pNetworkImpl3: P2PNetworkImpl? = null
     try {
-      p2pNetworkImpl1.start()
+      p2pNetworkImpl1.start().get()
 
       p2pNetworkImpl2 =
         createP2PNetwork(
           privateKey = key2,
-          port = PORT3,
+          port = p2pPort2.toUInt(),
           beaconChain =
             InMemoryBeaconChain(
               initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
@@ -625,7 +641,7 @@ class P2PTest {
       p2pNetworkImpl3 =
         createP2PNetwork(
           privateKey = key3,
-          port = PORT5,
+          port = p2pPort3.toUInt(),
           beaconChain =
             InMemoryBeaconChain(
               initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
@@ -643,8 +659,8 @@ class P2PTest {
             ),
         )
 
-      p2pNetworkImpl2.start()
-      p2pNetworkImpl3.start()
+      p2pNetworkImpl2.start().get()
+      p2pNetworkImpl3.start().get()
 
       val awaitTimeoutInSeconds = 30L
       awaitUntilAsserted(timeout = awaitTimeoutInSeconds, timeUnit = TimeUnit.SECONDS) {
@@ -729,8 +745,8 @@ class P2PTest {
       )
 
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
 
       val awaitTimeoutInSeconds = 30L
       awaitUntilAsserted(timeout = awaitTimeoutInSeconds, timeUnit = TimeUnit.SECONDS) {
@@ -802,8 +818,8 @@ class P2PTest {
       )
 
     try {
-      p2pNetworkImpl1.start()
-      p2pNetworkImpl2.start()
+      p2pNetworkImpl1.start().get()
+      p2pNetworkImpl2.start().get()
 
       val awaitTimeoutInSeconds = 30L
       awaitUntilAsserted(timeout = awaitTimeoutInSeconds, timeUnit = TimeUnit.SECONDS) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Defers discovery initialization until after the node binds to get the actual port, fixes ENR/NodeRecord port selection, enforces non-zero ports for discovery, and updates tests (await starts, parameterize zero-port cases).
> 
> - **P2P**:
>   - Defer `MaruDiscoveryService` creation to `start()` and pass actual bound `port` when `p2pConfig.port == 0`.
>   - Expose `enr` via `localNodeRecord` and generate `nodeRecords()` using bound `port` for `ipv4TcpPort`/`ipv4UdpPort`.
> - **Discovery**:
>   - Add validation requiring non-zero `p2pConfig.port` and `discovery.port`.
> - **Tests**:
>   - Await `start().get()` across tests to ensure readiness.
>   - Parameterize discovery test to run with fixed ports and with `0` ports; adapt to dynamic port handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e232b4427c717e6d8af6b5ced842e90ddd8ebf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->