### PR TITLE
adds support for allowAnyForkConnection

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -358,6 +358,7 @@ class MaruAppFactory {
           forks = forkSchedule.forks.toList(),
           peeringForkMismatchLeewayTime = p2pConfig.peeringForkMismatchLeewayTime,
           clock = clock,
+          allowAnyForkConnection = p2pConfig.allowAnyForkConnection,
         )
       val statusManager = StatusManager(beaconChain, forkIdHashManager)
 

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -49,6 +49,7 @@ data class P2PConfig(
   val statusUpdate: StatusUpdate = StatusUpdate(),
   val reputation: Reputation = Reputation(),
   val peeringForkMismatchLeewayTime: Duration = 20.seconds,
+  val allowAnyForkConnection: Boolean = false,
   val gossiping: Gossiping = Gossiping(),
 ) {
   init {

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -43,6 +43,7 @@ class HopliteFriendlinessTest {
     static-peers = ["/dns4/bootnode.linea.build/tcp/3322/p2p/16Uiu2HAmFjVuJoKD6sobrxwyJyysM1rgCsfWKzFLwvdB2HKuHwTg"]
     reconnect-delay = "500 ms"
     peering-fork-mismatch-leeway-time = "10 seconds"
+    allow-any-fork-connection = true
 
     [p2p.discovery]
     port = 3324
@@ -108,6 +109,7 @@ class HopliteFriendlinessTest {
         ),
       reconnectDelay = 500.milliseconds,
       peeringForkMismatchLeewayTime = 10.seconds,
+      allowAnyForkConnection = true,
       discovery =
         P2PConfig.Discovery(
           port = 3324u,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `allowAnyForkConnection` config and wiring to let the P2P layer accept connections when a peer’s fork ID is unknown.
> 
> - **P2P / Fork Peering**:
>   - `LenientForkPeeringManager` now accepts `allowAnyForkConnection` and, when true, allows peering with unknown fork IDs (logs a warning instead of rejecting).
>   - `create(...)` updated to propagate `allowAnyForkConnection`.
> - **App Wiring**:
>   - `MaruAppFactory` passes `p2pConfig.allowAnyForkConnection` into `LenientForkPeeringManager.create`.
> - **Config**:
>   - Add `P2PConfig.allowAnyForkConnection` (default `false`).
> - **Tests**:
>   - Update `HopliteFriendlinessTest` to parse/set `p2p.allow-any-fork-connection` and expected domain config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c0b80c98cb1ca7d0f9f97bff62871d4374c861b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->