### PR TITLE
Add config option for dns caching, default: no caching

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -101,6 +101,16 @@ class MaruAppFactory {
       () -> SyncStatusProvider,
     ) -> P2PNetworkImpl = ::P2PNetworkImpl,
   ): MaruApp {
+    java.security.Security.setProperty(
+      "networkaddress.cache.ttl",
+      config.networkAddressCacheTTLSeconds.toString(),
+    )
+
+    java.security.Security.setProperty(
+      "networkaddress.cache.negative.ttl",
+      config.networkAddressCacheNegativeTTLSeconds.toString(),
+    )
+
     log.info("configs={}", config)
     log.info("beaconGenesisConfig={}", beaconGenesisConfig)
     val privateKey = getOrGeneratePrivateKey(config.persistence.privateKeyPath)

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -237,6 +237,8 @@ data class SyncingConfig(
 }
 
 data class MaruConfig(
+  val networkAddressCacheTTLSeconds: Int = 0,
+  val networkAddressCacheNegativeTTLSeconds: Int = 0,
   val protocolTransitionPollingInterval: Duration = 1.seconds,
   val allowEmptyBlocks: Boolean = false,
   val persistence: Persistence,

--- a/config/src/main/kotlin/maru/config/HopliteTomlFriendly.kt
+++ b/config/src/main/kotlin/maru/config/HopliteTomlFriendly.kt
@@ -9,6 +9,7 @@
 package maru.config
 
 import java.net.URL
+import kotlin.Int
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -145,6 +146,8 @@ data class LineaConfigDtoToml(
 }
 
 data class MaruConfigDtoToml(
+  private val networkAddressCacheTTLSeconds: Int = 0,
+  private val networkAddressCacheNegativeTTLSeconds: Int = 0,
   private val linea: LineaConfigDtoToml? = null,
   private val protocolTransitionPollingInterval: Duration = 1.seconds,
   private val allowEmptyBlocks: Boolean = false,
@@ -159,6 +162,8 @@ data class MaruConfigDtoToml(
 ) {
   fun domainFriendly(): MaruConfig =
     MaruConfig(
+      networkAddressCacheTTLSeconds = networkAddressCacheTTLSeconds,
+      networkAddressCacheNegativeTTLSeconds = networkAddressCacheNegativeTTLSeconds,
       linea = linea?.domainFriendly(),
       protocolTransitionPollingInterval = protocolTransitionPollingInterval,
       allowEmptyBlocks = allowEmptyBlocks,

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -28,6 +28,9 @@ class HopliteFriendlinessTest {
   private val protocolTransitionPollingInterval = 2.seconds
   private val emptyFollowersConfigToml =
     """
+    network-address-cache-ttl-seconds = -1
+    network-address-cache-negative-ttl-seconds = 10
+
     protocol-transition-polling-interval = "2s"
 
     [persistence]
@@ -222,6 +225,8 @@ class HopliteFriendlinessTest {
     )
   private val expectedEmptyFollowersBase =
     MaruConfigDtoToml(
+      networkAddressCacheTTLSeconds = -1,
+      networkAddressCacheNegativeTTLSeconds = 10,
       protocolTransitionPollingInterval = protocolTransitionPollingInterval,
       allowEmptyBlocks = false,
       persistence = persistence,
@@ -255,6 +260,8 @@ class HopliteFriendlinessTest {
     val exception =
       assertThrows<IllegalArgumentException> {
         MaruConfig(
+          networkAddressCacheTTLSeconds = -1,
+          networkAddressCacheNegativeTTLSeconds = 10,
           protocolTransitionPollingInterval = protocolTransitionPollingInterval,
           allowEmptyBlocks = false,
           persistence = persistence,
@@ -276,6 +283,8 @@ class HopliteFriendlinessTest {
     val config = parseConfig<MaruConfigDtoToml>(rawConfigToml)
     assertThat(config.domainFriendly()).isEqualTo(
       MaruConfig(
+        networkAddressCacheTTLSeconds = -1,
+        networkAddressCacheNegativeTTLSeconds = 10,
         protocolTransitionPollingInterval = protocolTransitionPollingInterval,
         allowEmptyBlocks = false,
         persistence = persistence,
@@ -300,6 +309,8 @@ class HopliteFriendlinessTest {
     val config = parseConfig<MaruConfigDtoToml>(emptyFollowersConfigToml)
     assertThat(config.domainFriendly()).isEqualTo(
       MaruConfig(
+        networkAddressCacheTTLSeconds = -1,
+        networkAddressCacheNegativeTTLSeconds = 10,
         protocolTransitionPollingInterval = protocolTransitionPollingInterval,
         allowEmptyBlocks = false,
         persistence = persistence,
@@ -460,6 +471,8 @@ class HopliteFriendlinessTest {
 
     assertThat(config.domainFriendly()).isEqualTo(
       MaruConfig(
+        networkAddressCacheTTLSeconds = -1,
+        networkAddressCacheNegativeTTLSeconds = 10,
         protocolTransitionPollingInterval = protocolTransitionPollingInterval,
         allowEmptyBlocks = true,
         persistence = persistence,
@@ -522,6 +535,8 @@ class HopliteFriendlinessTest {
 
     assertThat(config.domainFriendly()).isEqualTo(
       MaruConfig(
+        networkAddressCacheTTLSeconds = -1,
+        networkAddressCacheNegativeTTLSeconds = 10,
         linea = expectedLineaConfig,
         protocolTransitionPollingInterval = protocolTransitionPollingInterval,
         persistence = persistence,


### PR DESCRIPTION
From https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/doc-files/net-properties.html

> Since these 3 properties are part of the security policy, they are not set by either the -D option or the System.setProperty() API, instead they are set as security properties.
> 
> The three properties that control dns cache are:
> - networkaddress.cache.ttl
> - networkaddress.cache.stale.ttl
> - networkaddress.cache.negative.ttl
> 


Default values for networkaddress.cache.ttl and networkaddress.cache.negative.ttl is set to zero ie no caching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `networkAddressCacheTTLSeconds` and `networkAddressCacheNegativeTTLSeconds` config options (default 0) and sets corresponding Java DNS cache security properties at startup; updates TOML DTO/mapping and tests.
> 
> - **Config**:
>   - Add `MaruConfig` fields: `networkAddressCacheTTLSeconds`, `networkAddressCacheNegativeTTLSeconds` (defaults 0).
>   - Extend `MaruConfigDtoToml` with matching fields and map them in `domainFriendly()`.
> - **App Startup**:
>   - Set Java security properties `networkaddress.cache.ttl` and `networkaddress.cache.negative.ttl` from config in `MaruAppFactory`.
> - **Tests**:
>   - Update Hoplite tests to include and assert the new fields in TOML parsing and domain conversion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7c068b8939855c0833b445d968e366fe3b0defa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->