### PR TITLE
Update teku version

### DIFF
--- a/app/src/integrationTest/kotlin/testutils/SpyingP2PNetwork.kt
+++ b/app/src/integrationTest/kotlin/testutils/SpyingP2PNetwork.kt
@@ -11,8 +11,8 @@ package testutils
 import java.util.concurrent.CopyOnWriteArrayList
 import maru.consensus.qbft.adapters.QbftBlockCodecAdapter
 import maru.core.SealedBeaconBlock
-import maru.p2p.BroadcastMessage
 import maru.p2p.GossipMessageType
+import maru.p2p.Message
 import maru.p2p.P2PNetwork
 import maru.p2p.SealedBeaconBlockHandler
 import maru.p2p.ValidationResult
@@ -29,7 +29,7 @@ class SpyingP2PNetwork(
   val p2pNetwork: P2PNetwork,
 ) : P2PNetwork by p2pNetwork {
   companion object {
-    private fun BroadcastMessage<*, *>.toBesuMessageData(): BesuMessageData {
+    private fun Message<*, *>.toBesuMessageData(): BesuMessageData {
       require(this.type == GossipMessageType.QBFT) {
         "Unsupported message type: ${this.type}"
       }
@@ -58,7 +58,7 @@ class SpyingP2PNetwork(
 
   override fun stop(): SafeFuture<Unit> = SafeFuture.completedFuture(Unit)
 
-  override fun broadcastMessage(message: BroadcastMessage<*, GossipMessageType>): SafeFuture<Unit> {
+  override fun broadcastMessage(message: Message<*, GossipMessageType>): SafeFuture<Unit> {
     when (message.type) {
       GossipMessageType.QBFT -> {
         val decodedMessage = decodedMessage(message.toBesuMessageData())

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adapters/BesuConverters.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adapters/BesuConverters.kt
@@ -11,8 +11,9 @@ package maru.consensus.qbft.adapters
 import maru.core.BeaconBlock
 import maru.core.BeaconBlockHeader
 import maru.core.SealedBeaconBlock
-import maru.p2p.BroadcastMessage
 import maru.p2p.GossipMessageType
+import maru.p2p.Message
+import maru.p2p.MessageData
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData as BesuMessageData
@@ -53,8 +54,8 @@ fun QbftBlockHeader.toBeaconBlockHeader(): BeaconBlockHeader {
   return this.beaconBlockHeader
 }
 
-fun BesuMessageData.toDomain(): BroadcastMessage<BesuMessageData, GossipMessageType> =
-  BroadcastMessage(
+fun BesuMessageData.toDomain(): Message<BesuMessageData, GossipMessageType> =
+  MessageData(
     type = GossipMessageType.QBFT,
     payload = this,
   )

--- a/p2p/src/main/kotlin/maru/p2p/MaruIncomingRpcRequestHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruIncomingRpcRequestHandler.kt
@@ -17,8 +17,8 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream
 
 class MaruIncomingRpcRequestHandler<
-  TRequest : RequestMessage<*, RpcMessageType>,
-  TResponse : ResponseMessage<*, RpcMessageType>,
+  TRequest : RequestMessageAdapter<*, RpcMessageType>,
+  TResponse : Message<*, RpcMessageType>,
 >(
   private val rpcMessageHandler: RpcMessageHandler<TRequest, TResponse>,
   private val requestMessageSerDe: SerDe<TRequest>,

--- a/p2p/src/main/kotlin/maru/p2p/MaruPeer.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPeer.kt
@@ -101,9 +101,9 @@ class DefaultMaruPeer(
 
   override fun sendStatus(): SafeFuture<Unit> {
     try {
-      val statusMessage = statusManager.createStatusRequestMessage()
-      val sendRpcMessage: SafeFuture<ResponseMessage<Status, RpcMessageType>> =
-        sendRpcMessage(statusMessage, rpcMethods.status())
+      val statusMessage = statusManager.createStatusMessage()
+      val sendRpcMessage: SafeFuture<Message<Status, RpcMessageType>> =
+        sendRpcMessage(RequestMessageAdapter(statusMessage), rpcMethods.status())
       scheduleDisconnectIfStatusNotReceived(p2pConfig.statusUpdate.timeout)
       return sendRpcMessage
         .thenApply { message -> message.payload }
@@ -183,12 +183,12 @@ class DefaultMaruPeer(
     count: ULong,
   ): SafeFuture<BeaconBlocksByRangeResponse> {
     val request = BeaconBlocksByRangeRequest(startBlockNumber, count)
-    val message = RequestMessage(RpcMessageType.BEACON_BLOCKS_BY_RANGE, Version.V1, request)
+    val message = RequestMessageAdapter(MessageData(RpcMessageType.BEACON_BLOCKS_BY_RANGE, Version.V1, request))
     return sendRpcMessage(message, rpcMethods.beaconBlocksByRange())
       .thenApply { responseMessage -> responseMessage.payload }
   }
 
-  fun <TRequest : RequestMessage<*, RpcMessageType>, TResponse : ResponseMessage<*, RpcMessageType>> sendRpcMessage(
+  fun <TRequest : RequestMessageAdapter<*, RpcMessageType>, TResponse : Message<*, RpcMessageType>> sendRpcMessage(
     message: TRequest,
     rpcMethod: MaruRpcMethod<TRequest, TResponse>,
   ): SafeFuture<TResponse> {

--- a/p2p/src/main/kotlin/maru/p2p/MaruRpcMethod.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruRpcMethod.kt
@@ -13,14 +13,14 @@ import org.apache.tuweni.bytes.Bytes
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler
 
-class MaruRpcMethod<TRequest : RequestMessage<*, RpcMessageType>, TResponse : ResponseMessage<*, RpcMessageType>>(
+class MaruRpcMethod<TRequest : RequestMessageAdapter<*, RpcMessageType>, TResponse : Message<*, RpcMessageType>>(
   private val messageType: RpcMessageType,
   private val rpcMessageHandler: RpcMessageHandler<TRequest, TResponse>,
   private val requestMessageSerDe: SerDe<TRequest>,
   private val responseMessageSerDe: SerDe<TResponse>,
   peerLookup: () -> PeerLookup,
   private val version: Version,
-  private val encoding: Encoding = Encoding.RLP,
+  encoding: Encoding = Encoding.RLP,
   protocolIdGenerator: MessageIdGenerator,
 ) : RpcMethod<MaruOutgoingRpcRequestHandler<TResponse>, TRequest, MaruRpcResponseHandler<TResponse>> {
   private val protocolId = protocolIdGenerator.id(messageType.name, version, encoding)

--- a/p2p/src/main/kotlin/maru/p2p/MaruRpcResponseCallback.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruRpcResponseCallback.kt
@@ -22,7 +22,7 @@ import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException
 
-class MaruRpcResponseCallback<TResponse : ResponseMessage<*, *>>(
+class MaruRpcResponseCallback<TResponse : Message<*, *>>(
   private val rpcStream: RpcStream,
   private val messageSerializer: Serializer<TResponse>,
   private val rpcExceptionSerializer: Serializer<RpcException> = RpcExceptionSerDe(),

--- a/p2p/src/main/kotlin/maru/p2p/Message.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Message.kt
@@ -35,36 +35,35 @@ enum class Encoding {
 
 sealed interface MessageType
 
-data class BroadcastMessage<TPayload, TMessageType : MessageType>(
-  val type: TMessageType,
-  val version: Version = Version.V1,
-  val payload: TPayload,
-)
+interface Message<TPayload, TMessageType : MessageType> {
+  val type: TMessageType
+  val version: Version
+  val payload: TPayload
+}
 
-data class ResponseMessage<TPayload, TMessageType : MessageType>(
-  val type: TMessageType,
-  val version: Version = Version.V1,
-  val payload: TPayload,
-)
+data class MessageData<TPayload, TMessageType : MessageType>(
+  override val type: TMessageType,
+  override val version: Version = Version.V1,
+  override val payload: TPayload,
+) : Message<TPayload, TMessageType>
 
-data class RequestMessage<TPayload, TMessageType : MessageType>(
-  val type: TMessageType,
-  val version: Version = Version.V1,
-  val payload: TPayload,
-) : RpcRequest {
+data class RequestMessageAdapter<TPayload, TMessageType : MessageType>(
+  val message: Message<TPayload, TMessageType>,
+) : RpcRequest,
+  Message<TPayload, TMessageType> by message {
   override fun getMaximumResponseChunks(): Int {
     TODO("Not yet implemented")
   }
 
-  override fun createWritableCopy(): SszMutableData? {
+  override fun createWritableCopy(): SszMutableData {
     TODO("Not yet implemented")
   }
 
-  override fun getSchema(): SszSchema<out SszData?>? {
+  override fun getSchema(): SszSchema<out SszData?> {
     TODO("Not yet implemented")
   }
 
-  override fun getBackingNode(): TreeNode? {
+  override fun getBackingNode(): TreeNode {
     TODO("Not yet implemented")
   }
 }

--- a/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
+++ b/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
@@ -30,7 +30,7 @@ object NoOpP2PNetwork : P2PNetwork {
         log.debug("NoopP2PNetwork stopped")
       }.thenApply { }
 
-  override fun broadcastMessage(message: BroadcastMessage<*, GossipMessageType>): SafeFuture<Unit> {
+  override fun broadcastMessage(message: Message<*, GossipMessageType>): SafeFuture<Unit> {
     log.debug("Doing nothing for message={}", message)
     return SafeFuture.completedFuture(Unit)
   }

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetwork.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetwork.kt
@@ -85,7 +85,7 @@ interface P2PNetwork : Closeable {
    */
   fun stop(): SafeFuture<Unit>
 
-  fun broadcastMessage(message: BroadcastMessage<*, GossipMessageType>): SafeFuture<*>
+  fun broadcastMessage(message: Message<*, GossipMessageType>): SafeFuture<*>
 
   /**
    * @return subscription id

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
@@ -236,7 +236,7 @@ class P2PNetworkImpl(
     executor.shutdown()
   }
 
-  override fun broadcastMessage(message: BroadcastMessage<*, GossipMessageType>): SafeFuture<*> {
+  override fun broadcastMessage(message: Message<*, GossipMessageType>): SafeFuture<*> {
     log.trace("Broadcasting message={}", message)
     broadcastMessageCounterFactory
       .create(

--- a/p2p/src/main/kotlin/maru/p2p/RpcMethods.kt
+++ b/p2p/src/main/kotlin/maru/p2p/RpcMethods.kt
@@ -18,8 +18,8 @@ import maru.p2p.messages.BlockRetrievalStrategy
 import maru.p2p.messages.SizeLimitBlockRetrievalStrategy
 import maru.p2p.messages.StatusHandler
 import maru.p2p.messages.StatusManager
+import maru.p2p.messages.StatusMessageSerDe
 import maru.p2p.messages.StatusRequestMessageSerDe
-import maru.p2p.messages.StatusResponseMessageSerDe
 import maru.p2p.messages.StatusSerDe
 import maru.serialization.rlp.MaruCompressorRLPSerDe
 import maru.serialization.rlp.RLPSerializers
@@ -31,15 +31,14 @@ open class RpcMethods(
   beaconChain: BeaconChain,
   blockRetrievalStrategy: BlockRetrievalStrategy = SizeLimitBlockRetrievalStrategy(),
 ) {
-  val statusRequestMessageSerDe = StatusRequestMessageSerDe(StatusSerDe())
-  val statusResponseMessageSerDe = StatusResponseMessageSerDe(StatusSerDe())
+  val statusMessageSerDe = StatusMessageSerDe(StatusSerDe())
 
   val statusRpcMethod =
     MaruRpcMethod(
       messageType = RpcMessageType.STATUS,
       rpcMessageHandler = StatusHandler(statusManager = statusManager),
-      requestMessageSerDe = statusRequestMessageSerDe,
-      responseMessageSerDe = statusResponseMessageSerDe,
+      requestMessageSerDe = StatusRequestMessageSerDe(statusMessageSerDe),
+      responseMessageSerDe = statusMessageSerDe,
       peerLookup = peerLookup,
       protocolIdGenerator = lineaRpcProtocolIdGenerator,
       version = Version.V1,

--- a/p2p/src/main/kotlin/maru/p2p/SealedBeaconBlockBroadcaster.kt
+++ b/p2p/src/main/kotlin/maru/p2p/SealedBeaconBlockBroadcaster.kt
@@ -16,7 +16,7 @@ class SealedBeaconBlockBroadcaster(
 ) : SealedBeaconBlockHandler<Unit> {
   override fun handleSealedBlock(sealedBeaconBlock: SealedBeaconBlock): SafeFuture<Unit> {
     // TODO: New block message might need an intermediary wrapper in the future
-    val message = BroadcastMessage(GossipMessageType.BEACON_BLOCK, payload = sealedBeaconBlock)
+    val message = MessageData(GossipMessageType.BEACON_BLOCK, payload = sealedBeaconBlock)
     p2PNetwork.broadcastMessage(message)
     return SafeFuture.completedFuture(Unit)
   }

--- a/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandler.kt
@@ -10,8 +10,9 @@ package maru.p2p.messages
 
 import maru.database.BeaconChain
 import maru.p2p.MaruPeer
-import maru.p2p.RequestMessage
-import maru.p2p.ResponseMessage
+import maru.p2p.Message
+import maru.p2p.MessageData
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageHandler
 import maru.p2p.RpcMessageType
 import org.apache.logging.log4j.LogManager
@@ -27,8 +28,8 @@ class BeaconBlocksByRangeHandler(
   private val beaconChain: BeaconChain,
   private val blockRetrievalStrategy: BlockRetrievalStrategy = DefaultBlockRetrievalStrategy(),
 ) : RpcMessageHandler<
-    RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType>,
-    ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>,
+    RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>,
+    Message<BeaconBlocksByRangeResponse, RpcMessageType>,
   > {
   private val log = LogManager.getLogger(this.javaClass)
 
@@ -38,8 +39,8 @@ class BeaconBlocksByRangeHandler(
 
   override fun handleIncomingMessage(
     peer: MaruPeer,
-    message: RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType>,
-    callback: ResponseCallback<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>>,
+    message: RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>,
+    callback: ResponseCallback<Message<BeaconBlocksByRangeResponse, RpcMessageType>>,
   ) {
     try {
       val request = message.payload
@@ -51,7 +52,7 @@ class BeaconBlocksByRangeHandler(
 
       val response = BeaconBlocksByRangeResponse(blocks = blocks)
       val responseMessage =
-        ResponseMessage(
+        MessageData(
           type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
           payload = response,
         )

--- a/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeRequestMessageSerDe.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeRequestMessageSerDe.kt
@@ -8,7 +8,8 @@
  */
 package maru.p2p.messages
 
-import maru.p2p.RequestMessage
+import maru.p2p.MessageData
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import maru.serialization.rlp.RLPSerDe
@@ -17,28 +18,32 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput
 
 class BeaconBlocksByRangeRequestMessageSerDe(
   private val beaconBlocksByRangeRequestSerDe: RLPSerDe<BeaconBlocksByRangeRequest>,
-) : RLPSerDe<RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType>> {
+) : RLPSerDe<RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>> {
   override fun writeTo(
-    value: RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType>,
+    value: RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>,
     rlpOutput: RLPOutput,
   ) {
     beaconBlocksByRangeRequestSerDe.writeTo(value.payload, rlpOutput)
   }
 
-  override fun readFrom(rlpInput: RLPInput): RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType> =
-    RequestMessage(
-      RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-      Version.V1,
-      beaconBlocksByRangeRequestSerDe.readFrom(rlpInput),
+  override fun readFrom(rlpInput: RLPInput): RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType> =
+    RequestMessageAdapter(
+      MessageData(
+        RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+        Version.V1,
+        beaconBlocksByRangeRequestSerDe.readFrom(rlpInput),
+      ),
     )
 
-  override fun serialize(value: RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType>): ByteArray =
+  override fun serialize(value: RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>): ByteArray =
     beaconBlocksByRangeRequestSerDe.serialize(value.payload)
 
-  override fun deserialize(bytes: ByteArray): RequestMessage<BeaconBlocksByRangeRequest, RpcMessageType> =
-    RequestMessage(
-      RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-      Version.V1,
-      beaconBlocksByRangeRequestSerDe.deserialize(bytes),
+  override fun deserialize(bytes: ByteArray): RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType> =
+    RequestMessageAdapter(
+      MessageData(
+        RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+        Version.V1,
+        beaconBlocksByRangeRequestSerDe.deserialize(bytes),
+      ),
     )
 }

--- a/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeResponseMessageSerDe.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeResponseMessageSerDe.kt
@@ -8,7 +8,8 @@
  */
 package maru.p2p.messages
 
-import maru.p2p.ResponseMessage
+import maru.p2p.Message
+import maru.p2p.MessageData
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import maru.serialization.rlp.RLPSerDe
@@ -17,26 +18,26 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput
 
 class BeaconBlocksByRangeResponseMessageSerDe(
   private val beaconBlocksByRangeResponseSerDe: RLPSerDe<BeaconBlocksByRangeResponse>,
-) : RLPSerDe<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>> {
+) : RLPSerDe<Message<BeaconBlocksByRangeResponse, RpcMessageType>> {
   override fun writeTo(
-    value: ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>,
+    value: Message<BeaconBlocksByRangeResponse, RpcMessageType>,
     rlpOutput: RLPOutput,
   ) {
     beaconBlocksByRangeResponseSerDe.writeTo(value.payload, rlpOutput)
   }
 
-  override fun readFrom(rlpInput: RLPInput): ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType> =
-    ResponseMessage(
+  override fun readFrom(rlpInput: RLPInput): Message<BeaconBlocksByRangeResponse, RpcMessageType> =
+    MessageData(
       RpcMessageType.BEACON_BLOCKS_BY_RANGE,
       Version.V1,
       beaconBlocksByRangeResponseSerDe.readFrom(rlpInput),
     )
 
-  override fun serialize(value: ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>): ByteArray =
+  override fun serialize(value: Message<BeaconBlocksByRangeResponse, RpcMessageType>): ByteArray =
     beaconBlocksByRangeResponseSerDe.serialize(value.payload)
 
-  override fun deserialize(bytes: ByteArray): ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType> =
-    ResponseMessage(
+  override fun deserialize(bytes: ByteArray): Message<BeaconBlocksByRangeResponse, RpcMessageType> =
+    MessageData(
       RpcMessageType.BEACON_BLOCKS_BY_RANGE,
       Version.V1,
       beaconBlocksByRangeResponseSerDe.deserialize(bytes),

--- a/p2p/src/main/kotlin/maru/p2p/messages/StatusHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/StatusHandler.kt
@@ -9,8 +9,8 @@
 package maru.p2p.messages
 
 import maru.p2p.MaruPeer
-import maru.p2p.RequestMessage
-import maru.p2p.ResponseMessage
+import maru.p2p.Message
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageHandler
 import maru.p2p.RpcMessageType
 import org.apache.logging.log4j.LogManager
@@ -21,13 +21,13 @@ import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 
 class StatusHandler(
   private val statusManager: StatusManager,
-) : RpcMessageHandler<RequestMessage<Status, RpcMessageType>, ResponseMessage<Status, RpcMessageType>> {
+) : RpcMessageHandler<RequestMessageAdapter<Status, RpcMessageType>, Message<Status, RpcMessageType>> {
   private val log = LogManager.getLogger(this.javaClass)
 
   override fun handleIncomingMessage(
     peer: MaruPeer,
-    message: RequestMessage<Status, RpcMessageType>,
-    callback: ResponseCallback<ResponseMessage<Status, RpcMessageType>>,
+    message: RequestMessageAdapter<Status, RpcMessageType>,
+    callback: ResponseCallback<Message<Status, RpcMessageType>>,
   ) {
     try {
       if (!statusManager.isValidForPeering(message.payload)) {
@@ -38,7 +38,7 @@ class StatusHandler(
         return
       }
       peer.updateStatus(message.payload)
-      callback.respondAndCompleteSuccessfully(statusManager.createStatusResponseMessage())
+      callback.respondAndCompleteSuccessfully(statusManager.createStatusMessage())
     } catch (e: RpcException) {
       log.error("handling request failed with RpcException", e)
       callback.completeWithErrorResponse(e)

--- a/p2p/src/main/kotlin/maru/p2p/messages/StatusManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/StatusManager.kt
@@ -9,8 +9,8 @@
 package maru.p2p.messages
 
 import maru.database.BeaconChain
-import maru.p2p.RequestMessage
-import maru.p2p.ResponseMessage
+import maru.p2p.Message
+import maru.p2p.MessageData
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import maru.p2p.fork.ForkPeeringManager
@@ -19,30 +19,16 @@ class StatusManager(
   private val beaconChain: BeaconChain,
   private val forkIdHashManager: ForkPeeringManager,
 ) {
-  fun createStatusPayload(): Status {
+  fun createStatusMessage(): Message<Status, RpcMessageType> {
     val latestBeaconBlockHeader = beaconChain.getLatestBeaconState().beaconBlockHeader
-    return Status(
-      forkIdHash = forkIdHashManager.currentForkHash(),
-      latestStateRoot = latestBeaconBlockHeader.hash,
-      latestBlockNumber = latestBeaconBlockHeader.number,
-    )
-  }
-
-  fun createStatusResponseMessage(): ResponseMessage<Status, RpcMessageType> {
-    val statusPayload = createStatusPayload()
-    val statusMessage =
-      ResponseMessage(
-        type = RpcMessageType.STATUS,
-        version = Version.V1,
-        payload = statusPayload,
+    val statusPayload =
+      Status(
+        forkIdHash = forkIdHashManager.currentForkHash(),
+        latestStateRoot = latestBeaconBlockHeader.hash,
+        latestBlockNumber = latestBeaconBlockHeader.number,
       )
-    return statusMessage
-  }
-
-  fun createStatusRequestMessage(): RequestMessage<Status, RpcMessageType> {
-    val statusPayload = createStatusPayload()
     val statusMessage =
-      RequestMessage(
+      MessageData(
         type = RpcMessageType.STATUS,
         version = Version.V1,
         payload = statusPayload,

--- a/p2p/src/main/kotlin/maru/p2p/messages/StatusMessageSerDe.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/StatusMessageSerDe.kt
@@ -8,27 +8,28 @@
  */
 package maru.p2p.messages
 
-import maru.p2p.RequestMessage
-import maru.p2p.ResponseMessage
+import maru.p2p.Message
+import maru.p2p.MessageData
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import maru.serialization.rlp.RLPSerDe
 import org.hyperledger.besu.ethereum.rlp.RLPInput
 import org.hyperledger.besu.ethereum.rlp.RLPOutput
 
-class StatusResponseMessageSerDe(
+class StatusMessageSerDe(
   val statusSerDe: RLPSerDe<Status>,
-) : RLPSerDe<ResponseMessage<Status, RpcMessageType>> {
+) : RLPSerDe<Message<Status, RpcMessageType>> {
   override fun writeTo(
-    value: ResponseMessage<Status, RpcMessageType>,
+    value: Message<Status, RpcMessageType>,
     rlpOutput: RLPOutput,
   ) {
     statusSerDe.writeTo(value.payload, rlpOutput)
   }
 
-  override fun readFrom(rlpInput: RLPInput): ResponseMessage<Status, RpcMessageType> {
+  override fun readFrom(rlpInput: RLPInput): Message<Status, RpcMessageType> {
     val status = statusSerDe.readFrom(rlpInput)
-    return ResponseMessage(
+    return MessageData(
       RpcMessageType.STATUS,
       Version.V1,
       status,
@@ -37,21 +38,15 @@ class StatusResponseMessageSerDe(
 }
 
 class StatusRequestMessageSerDe(
-  val statusSerDe: RLPSerDe<Status>,
-) : RLPSerDe<RequestMessage<Status, RpcMessageType>> {
+  val statusMessageSerDe: RLPSerDe<Message<Status, RpcMessageType>>,
+) : RLPSerDe<RequestMessageAdapter<Status, RpcMessageType>> {
   override fun writeTo(
-    value: RequestMessage<Status, RpcMessageType>,
+    value: RequestMessageAdapter<Status, RpcMessageType>,
     rlpOutput: RLPOutput,
   ) {
-    statusSerDe.writeTo(value.payload, rlpOutput)
+    statusMessageSerDe.writeTo(value.message, rlpOutput)
   }
 
-  override fun readFrom(rlpInput: RLPInput): RequestMessage<Status, RpcMessageType> {
-    val status = statusSerDe.readFrom(rlpInput)
-    return RequestMessage(
-      RpcMessageType.STATUS,
-      Version.V1,
-      status,
-    )
-  }
+  override fun readFrom(rlpInput: RLPInput): RequestMessageAdapter<Status, RpcMessageType> =
+    RequestMessageAdapter(statusMessageSerDe.readFrom(rlpInput))
 }

--- a/p2p/src/test/kotlin/maru/p2p/DefaultMaruPeerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/DefaultMaruPeerTest.kt
@@ -137,8 +137,9 @@ class DefaultMaruPeerTest {
 
   @Test
   fun `sendRequest delegates to underlying peer`() {
-    val rpcMethod = mock<RpcMethod<RpcRequestHandler, RequestMessage<String, RpcMessageType>, RpcResponseHandler<*>>>()
-    val request = RequestMessage(RpcMessageType.STATUS, Version.V1, "test-request")
+    val rpcMethod =
+      mock<RpcMethod<RpcRequestHandler, RequestMessageAdapter<String, RpcMessageType>, RpcResponseHandler<*>>>()
+    val request = RequestMessageAdapter(MessageData(RpcMessageType.STATUS, Version.V1, "test-request"))
     val responseHandler = mock<RpcResponseHandler<*>>()
     val expectedController = mock<RpcStreamController<RpcRequestHandler>>()
 
@@ -180,7 +181,7 @@ class DefaultMaruPeerTest {
 
   @Test
   fun `sendStatus returns failed future when exception is thrown`() {
-    whenever(statusManager.createStatusRequestMessage()).thenThrow(RuntimeException("fail"))
+    whenever(statusManager.createStatusMessage()).thenThrow(RuntimeException("fail"))
     whenever(delegatePeer.address).thenReturn(mock())
     val future = maruPeer.sendStatus()
     assertThat(future).isNotNull()

--- a/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandlerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandlerTest.kt
@@ -11,8 +11,9 @@ package maru.p2p.messages
 import maru.core.ext.DataGenerators
 import maru.database.BeaconChain
 import maru.p2p.MaruPeer
-import maru.p2p.RequestMessage
-import maru.p2p.ResponseMessage
+import maru.p2p.Message
+import maru.p2p.MessageData
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import maru.p2p.messages.BeaconBlocksByRangeHandler.Companion.MAX_BLOCKS_PER_REQUEST
@@ -33,7 +34,7 @@ class BeaconBlocksByRangeHandlerTest {
   private lateinit var beaconChain: BeaconChain
   private lateinit var handler: BeaconBlocksByRangeHandler
   private lateinit var peer: MaruPeer
-  private lateinit var callback: ResponseCallback<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>>
+  private lateinit var callback: ResponseCallback<Message<BeaconBlocksByRangeResponse, RpcMessageType>>
 
   @BeforeEach
   fun setup() {
@@ -47,17 +48,19 @@ class BeaconBlocksByRangeHandlerTest {
   fun `handles request with no blocks available`() {
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 100UL, count = 10UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     whenever(beaconChain.getSealedBeaconBlocks(100UL, 10UL)).thenReturn(emptyList())
 
     handler.handleIncomingMessage(peer, message, callback)
 
-    val responseCaptor = argumentCaptor<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>>()
+    val responseCaptor = argumentCaptor<Message<BeaconBlocksByRangeResponse, RpcMessageType>>()
     verify(callback).respondAndCompleteSuccessfully(responseCaptor.capture())
 
     val response = responseCaptor.firstValue
@@ -69,10 +72,12 @@ class BeaconBlocksByRangeHandlerTest {
   fun `handles request with blocks available`() {
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 100UL, count = 3UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     val blocks =
@@ -86,7 +91,7 @@ class BeaconBlocksByRangeHandlerTest {
 
     handler.handleIncomingMessage(peer, message, callback)
 
-    val responseCaptor = argumentCaptor<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>>()
+    val responseCaptor = argumentCaptor<Message<BeaconBlocksByRangeResponse, RpcMessageType>>()
     verify(callback).respondAndCompleteSuccessfully(responseCaptor.capture())
 
     val response = responseCaptor.firstValue
@@ -99,10 +104,12 @@ class BeaconBlocksByRangeHandlerTest {
   fun `handles large count request`() {
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 0UL, count = 1000UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     // Handler should limit to MAX_BLOCKS_PER_REQUEST
@@ -116,7 +123,7 @@ class BeaconBlocksByRangeHandlerTest {
 
     handler.handleIncomingMessage(peer, message, callback)
 
-    val responseCaptor = argumentCaptor<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>>()
+    val responseCaptor = argumentCaptor<Message<BeaconBlocksByRangeResponse, RpcMessageType>>()
     verify(callback).respondAndCompleteSuccessfully(responseCaptor.capture())
 
     val response = responseCaptor.firstValue
@@ -136,10 +143,12 @@ class BeaconBlocksByRangeHandlerTest {
 
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 0UL, count = 10UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     val limitedBlocks =
@@ -155,7 +164,7 @@ class BeaconBlocksByRangeHandlerTest {
 
     handler.handleIncomingMessage(peer, message, callback)
 
-    val responseCaptor = argumentCaptor<ResponseMessage<BeaconBlocksByRangeResponse, RpcMessageType>>()
+    val responseCaptor = argumentCaptor<Message<BeaconBlocksByRangeResponse, RpcMessageType>>()
     verify(callback).respondAndCompleteSuccessfully(responseCaptor.capture())
 
     // The response should return 4 blocks out of 10, given that the compressed serialized size of
@@ -179,10 +188,12 @@ class BeaconBlocksByRangeHandlerTest {
   fun `handles request with Rpc exception`() {
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 0UL, count = 1000UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     whenever(beaconChain.getSealedBeaconBlocks(0UL, MAX_BLOCKS_PER_REQUEST))
@@ -204,10 +215,12 @@ class BeaconBlocksByRangeHandlerTest {
   fun `handles request with, Missing sealed beacon block, exception`() {
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 0UL, count = 1000UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     whenever(beaconChain.getSealedBeaconBlocks(0UL, MAX_BLOCKS_PER_REQUEST))
@@ -229,10 +242,12 @@ class BeaconBlocksByRangeHandlerTest {
   fun `handles request with exception`() {
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 0UL, count = 1000UL)
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     whenever(beaconChain.getSealedBeaconBlocks(0UL, MAX_BLOCKS_PER_REQUEST))

--- a/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeRequestMessageSerDeTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeRequestMessageSerDeTest.kt
@@ -8,7 +8,8 @@
  */
 package maru.p2p.messages
 
-import maru.p2p.RequestMessage
+import maru.p2p.MessageData
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import org.assertj.core.api.Assertions.assertThat
@@ -28,10 +29,12 @@ class BeaconBlocksByRangeRequestMessageSerDeTest {
         count = 10UL,
       )
     val message =
-      RequestMessage(
-        type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
-        version = Version.V1,
-        payload = request,
+      RequestMessageAdapter(
+        MessageData(
+          type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
+          version = Version.V1,
+          payload = request,
+        ),
       )
 
     val serialized = messageSerDe.serialize(message)

--- a/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeResponseMessageSerDeTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeResponseMessageSerDeTest.kt
@@ -9,7 +9,7 @@
 package maru.p2p.messages
 
 import maru.core.ext.DataGenerators
-import maru.p2p.ResponseMessage
+import maru.p2p.MessageData
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import maru.serialization.rlp.RLPSerializers
@@ -30,7 +30,7 @@ class BeaconBlocksByRangeResponseMessageSerDeTest {
         blocks = listOf(DataGenerators.randomSealedBeaconBlock(number = 5UL)),
       )
     val message =
-      ResponseMessage(
+      MessageData(
         type = RpcMessageType.BEACON_BLOCKS_BY_RANGE,
         version = Version.V1,
         payload = response,

--- a/p2p/src/test/kotlin/maru/p2p/messages/StatusMessageSerDeTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/StatusMessageSerDeTest.kt
@@ -9,24 +9,26 @@
 package maru.p2p.messages
 
 import maru.core.ext.DataGenerators.randomStatus
-import maru.p2p.RequestMessage
-import maru.p2p.ResponseMessage
+import maru.p2p.MessageData
+import maru.p2p.RequestMessageAdapter
 import maru.p2p.RpcMessageType
 import maru.p2p.Version
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class StatusMessageSerDeTest {
-  private val requestMessageSerDe = StatusRequestMessageSerDe(StatusSerDe())
-  private val responseMessageSerDe = StatusResponseMessageSerDe(StatusSerDe())
+  private val responseMessageSerDe = StatusMessageSerDe(StatusSerDe())
+  private val requestMessageSerDe = StatusRequestMessageSerDe(responseMessageSerDe)
 
   @Test
   fun `can serialize and deserialize same request value`() {
     val testValue =
-      RequestMessage(
-        RpcMessageType.STATUS,
-        Version.V1,
-        randomStatus(100U),
+      RequestMessageAdapter(
+        MessageData(
+          RpcMessageType.STATUS,
+          Version.V1,
+          randomStatus(100U),
+        ),
       )
 
     val serializedData = requestMessageSerDe.serialize(testValue)
@@ -38,7 +40,7 @@ class StatusMessageSerDeTest {
   @Test
   fun `can serialize and deserialize same response value`() {
     val testValue =
-      ResponseMessage(
+      MessageData(
         RpcMessageType.STATUS,
         Version.V1,
         randomStatus(100U),

--- a/p2p/src/testFixtures/kotlin/maru/p2p/ext/DataGenerators.kt
+++ b/p2p/src/testFixtures/kotlin/maru/p2p/ext/DataGenerators.kt
@@ -10,13 +10,14 @@ package maru.p2p.ext
 
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators
-import maru.p2p.BroadcastMessage
 import maru.p2p.GossipMessageType
+import maru.p2p.Message
+import maru.p2p.MessageData
 import maru.p2p.Version
 
 object DataGenerators {
-  fun randomBlockMessage(blockNumber: ULong = 1uL): BroadcastMessage<SealedBeaconBlock, GossipMessageType> {
+  fun randomBlockMessage(blockNumber: ULong = 1uL): Message<SealedBeaconBlock, GossipMessageType> {
     val sealedBeaconBlock = DataGenerators.randomSealedBeaconBlock(blockNumber)
-    return BroadcastMessage(GossipMessageType.BEACON_BLOCK, Version.V1, sealedBeaconBlock)
+    return MessageData(GossipMessageType.BEACON_BLOCK, Version.V1, sealedBeaconBlock)
   }
 }


### PR DESCRIPTION
#426 #427 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates P2P/RPC messaging to new Message/Request wrappers compatible with updated Teku APIs and bumps Teku to 25.9.3, updating handlers, SerDes, and tests.
> 
> - **P2P/RPC**:
>   - Introduce `Message` interface with `MessageData` implementation and `RequestMessageAdapter` (implements Teku `RpcRequest`).
>   - Refactor RPC generics and methods to use `RequestMessageAdapter<*, RpcMessageType>`; add `sendRequest` overload with `RpcRequestBodySelector`.
>   - Update handlers (`MaruIncomingRpcRequestHandler`, `MaruPeer.sendStatus`/`sendBeaconBlocksByRange`, `MaruRpcMethod`) to the new types.
>   - Replace `ifExceptionGetsHereRaiseABug()` with `finishWarn(log)` in `MaruRpcResponseCallback`.
> - **Serialization**:
>   - Update SerDes to produce/consume `MessageData` and wrap requests with `RequestMessageAdapter` (e.g., `StatusRequestMessageSerDe`, `BeaconBlocksByRange*MessageSerDe`).
> - **Gossip/Broadcast**:
>   - Switch to `MessageData` for gossip messages (`SealedBeaconBlockBroadcaster`, `BesuConverters`); minor serialization cast in `P2PNetworkImpl`.
> - **Discovery**:
>   - Adjust `MaruDiscoveryPeer` constructor to new `DiscoveryPeer` API (additional `Optional` args).
> - **Dependencies**:
>   - Bump `tech.pegasys.teku.internal` to `25.9.3` in `gradle/versions.gradle`.
> - **Tests**:
>   - Update unit tests to the new message/request wrappers and SerDes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b14050aa283220a65ce8a241ad13b97b1870d4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->