### PR TITLE
Fixed an address representation

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruApp.kt
+++ b/app/src/main/kotlin/maru/app/MaruApp.kt
@@ -25,6 +25,7 @@ import maru.core.Protocol
 import maru.core.Validator
 import maru.crypto.Crypto
 import maru.database.BeaconChain
+import maru.extensions.encodeHex
 import maru.finalization.LineaFinalizationProvider
 import maru.metrics.MaruMetricsCategory
 import maru.p2p.P2PNetwork
@@ -66,7 +67,7 @@ class MaruApp(
       log.info("Qbft options are not defined. nodeRole=follower")
     } else {
       val localValidator = Crypto.privateKeyToValidator(getPrivateKeyWithoutPrefix())
-      log.info("Qbft options are defined. nodeRole=validator with address={}", localValidator.address)
+      log.info("Qbft options are defined. nodeRole=validator with address={}", localValidator.address.encodeHex())
       // TODO: This may be not needed when we use dynamic validator set from a smart contract
       warnIfValidatorIsNotInTheGenesis(localValidator)
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Hex-encode the validator address in the QBFT startup log message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a7e708c010e27b0a28cfb5c20de45d26ee0d6a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->