### PR TITLE
Updating Maru default tag in the local stack

### DIFF
--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -7,7 +7,7 @@ services:
     # make build-local-image
     # MARU_TAG=local make docker-run-stack
     # command: [ 'java', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005','-Dvertx.configurationFile=/path/to/vertx-options.json', '-Dlog4j2.configurationFile=/path/to/log4j2-dev.xml']
-    image: consensys/maru:${MARU_TAG:-0ad2e75}
+    image: consensys/maru:${MARU_TAG:-dbb6c73}
     container_name: maru
     depends_on:
       - sequencer


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update `docker/compose.dev.yaml` to use `consensys/maru` image tag `dbb6c73` instead of `0ad2e75`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f7410ef9b1a95fd5df51b9cf0cb96417e8b8f31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->