### PR TITLE
move PrivateKeyGenerator to crypto module

### DIFF
--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'maru.kotlin-library-conventions'
+  id 'java-test-fixtures'
 }
 
 dependencies {
@@ -10,4 +11,10 @@ dependencies {
   implementation("org.hyperledger.besu.internal:besu-crypto-services")
   implementation("org.hyperledger.besu.internal:besu-ethereum-core")
   implementation "io.tmio:tuweni-bytes"
+
+  testFixturesImplementation "io.libp2p:jvm-libp2p"
+  testFixturesImplementation "tech.pegasys.teku.internal:p2p"
+  testFixturesImplementation "build.linea.internal:kotlin"
+
+  testImplementation "build.linea.internal:kotlin"
 }

--- a/crypto/src/test/kotlin/maru/crypto/PrivateKeyGeneratorTest.kt
+++ b/crypto/src/test/kotlin/maru/crypto/PrivateKeyGeneratorTest.kt
@@ -6,12 +6,12 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package linea.maru
+package maru.crypto
 
 import linea.kotlin.decodeHex
-import linea.maru.PrivateKeyGenerator.generatePrivateKey
-import linea.maru.PrivateKeyGenerator.getKeyData
-import linea.maru.PrivateKeyGenerator.getKeyDataByPrefixedKey
+import maru.crypto.PrivateKeyGenerator.generatePrivateKey
+import maru.crypto.PrivateKeyGenerator.getKeyData
+import maru.crypto.PrivateKeyGenerator.getKeyDataByPrefixedKey
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.RepeatedTest
 

--- a/crypto/src/testFixtures/kotlin/maru/crypto/PrivateKeyGenerator.kt
+++ b/crypto/src/testFixtures/kotlin/maru/crypto/PrivateKeyGenerator.kt
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
-package linea.maru
+package maru.crypto
 
 import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.KeyType
@@ -15,7 +15,6 @@ import io.libp2p.core.crypto.marshalPrivateKey
 import io.libp2p.core.crypto.unmarshalPrivateKey
 import io.libp2p.crypto.keys.unmarshalSecp256k1PrivateKey
 import linea.kotlin.encodeHex
-import maru.crypto.Crypto
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId
 
 /**
@@ -87,7 +86,7 @@ object PrivateKeyGenerator {
       else -> privateKey.takeLast(32).toByteArray()
     }
 
-  internal fun getKeyDataByPrefixedKey(prefixedPrivateKey: ByteArray): KeyData {
+  fun getKeyDataByPrefixedKey(prefixedPrivateKey: ByteArray): KeyData {
     val privateKeyTyped = unmarshalPrivateKey(prefixedPrivateKey)
     return getKeyData(privateKeyTyped.raw())
   }

--- a/jvm-libs/utils/build.gradle
+++ b/jvm-libs/utils/build.gradle
@@ -18,7 +18,7 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":crypto"))
+  implementation(testFixtures(project(":crypto")))
   implementation "io.libp2p:jvm-libp2p"
   implementation "tech.pegasys.teku.internal:p2p"
   implementation "build.linea.internal:kotlin"

--- a/jvm-libs/utils/src/main/kotlin/linea/maru/KeyTool.kt
+++ b/jvm-libs/utils/src/main/kotlin/linea/maru/KeyTool.kt
@@ -10,9 +10,10 @@ package linea.maru
 
 import kotlin.system.exitProcess
 import linea.kotlin.decodeHex
-import linea.maru.PrivateKeyGenerator.getKeyData
-import linea.maru.PrivateKeyGenerator.getKeyDataByPrefixedKey
-import linea.maru.PrivateKeyGenerator.logKeyData
+import maru.crypto.PrivateKeyGenerator
+import maru.crypto.PrivateKeyGenerator.getKeyData
+import maru.crypto.PrivateKeyGenerator.getKeyDataByPrefixedKey
+import maru.crypto.PrivateKeyGenerator.logKeyData
 import picocli.CommandLine
 
 @CommandLine.Command(


### PR DESCRIPTION
Ideally, we should have `fun generateSECP256K1PrivKey(): ByteArray` inside the prod crypto package and tested, but I can't afftor the time to do it now. So moving as testFixture so can be used the same way in all the the tests. 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves `PrivateKeyGenerator` into crypto test fixtures, exposes prefixed-key helper, and updates builds/imports to consume it from utils.
> 
> - **Crypto module**:
>   - Move `PrivateKeyGenerator` to `crypto/src/testFixtures/kotlin/maru/crypto` and change package to `maru.crypto`.
>   - Make `getKeyDataByPrefixedKey` public.
>   - Enable test fixtures: add `java-test-fixtures` plugin and `testFixturesImplementation` deps in `crypto/build.gradle`.
> - **Utils module**:
>   - Switch dependency to `implementation(testFixtures(project(":crypto")))` in `jvm-libs/utils/build.gradle`.
>   - Update `KeyTool` to import and use `maru.crypto.PrivateKeyGenerator` APIs.
> - **Tests**:
>   - Update `PrivateKeyGeneratorTest` package/imports to `maru.crypto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 881619b9dfd93cb0b6227022d37bdb6cd1aa54be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->