### PR TITLE
Added a directory creation to fix a failure when there is no private …

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -106,18 +106,17 @@ class MaruAppFactory {
     log.info("beaconGenesisConfig={}", beaconGenesisConfig)
     config.persistence.dataPath.createDirectories()
     val privateKey = getOrGeneratePrivateKey(config.persistence.privateKeyPath)
-    val vertx =
-      VertxFactory.createVertx(
-        jvmMetricsEnabled = config.observability.jvmMetricsEnabled,
-        prometheusMetricsEnabled = config.observability.prometheusMetricsEnabled,
-      )
-
     val nodeId = PeerId.fromPubKey(unmarshalPrivateKey(privateKey).publicKey())
     val metricsFacade =
       MicrometerMetricsFacade(
         registry = getMetricsRegistry(),
         metricsPrefix = "maru",
         allMetricsCommonTags = listOf(Tag("nodeid", nodeId.toBase58())),
+      )
+    val vertx =
+      VertxFactory.createVertx(
+        jvmMetricsEnabled = config.observability.jvmMetricsEnabled,
+        prometheusMetricsEnabled = config.observability.prometheusMetricsEnabled,
       )
     val besuMetricsSystemAdapter =
       BesuMetricsSystemAdapter(


### PR DESCRIPTION
…key and a directory to generate it in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Create the data directory before generating/reading the private key and adjust Vertx initialization order.
> 
> - **App initialization (`maru/app/MaruAppFactory.kt`)**:
>   - Ensure `config.persistence.dataPath` is created (`createDirectories()`) before generating/loading the private key.
>   - Reorder Vertx initialization to occur after metrics setup.
>   - Add `kotlin.io.path.createDirectories` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e54d853d4218136b819c894c69689d679d15b9d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->