### PR TITLE
chaos tests update images

### DIFF
--- a/chaos-testing/helm/charts/besu/values.yaml
+++ b/chaos-testing/helm/charts/besu/values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 3
 image:
-  name: hyperledger/besu:25.8.0
+  name: hyperledger/besu:25.11.0
   pullPolicy: IfNotPresent
 service:
   name: besu

--- a/chaos-testing/k3s.mk
+++ b/chaos-testing/k3s.mk
@@ -14,7 +14,7 @@ k3s-run:
 		-p 80:80 \
 		-p 443:443 \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		rancher/k3s:v1.33.2-k3s1 \
+		rancher/k3s:v1.34.1-k3s1 \
 		server --token a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p
 
 k3s-setup-kubeconfig:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps Besu and k3s images used for chaos testing to newer versions.
> 
> - **Infrastructure**:
>   - Update Besu image in `chaos-testing/helm/charts/besu/values.yaml` to `hyperledger/besu:25.11.0`.
>   - Update k3s server image in `chaos-testing/k3s.mk` to `rancher/k3s:v1.34.1-k3s1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a16a561a3b017b3765d9d563b2501fd10388fa4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->