### PR TITLE
Fix MaruCluster config after merge regression

### DIFF
--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/MaruConfigHelper.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/MaruConfigHelper.kt
@@ -34,11 +34,7 @@ val configTemplate: MaruConfig =
     allowEmptyBlocks = true,
     persistence = Persistence(dataPath = Path.of("maru-data")),
     forkTransition = ForkTransition(),
-    validatorElNode =
-      ValidatorElNode(
-        payloadValidationEnabled = false,
-        engineApiEndpoint = ApiEndpointConfig(URI.create("http://replace-me:8551").toURL()),
-      ),
+    validatorElNode = null,
     api = ApiConfig(port = 0u),
     qbft = null, // Followers by default
     p2p =
@@ -128,11 +124,14 @@ internal fun setValidatorConfig(
   if (elNode == null) return config
 
   val updatedValidatorConfig =
-    config.validatorElNode!!.copy(
+    config.validatorElNode?.copy(
       engineApiEndpoint =
         config.validatorElNode!!.engineApiEndpoint.copy(
           endpoint = URI.create(elNode.engineApiUrl()).toURL(),
         ),
+    ) ?: ValidatorElNode(
+      payloadValidationEnabled = false,
+      engineApiEndpoint = ApiEndpointConfig(endpoint = URI.create(elNode.engineApiUrl()).toURL()),
     )
   val updatedForkTransition =
     config.forkTransition.copy(

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/TestMaruAppFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/TestMaruAppFactory.kt
@@ -25,10 +25,10 @@ fun createMaru(
 ): MaruApp {
   initPersistence(config.persistence, nodeKeyData)
   var effectiveConfig = config
+  effectiveConfig = setValidatorConfig(effectiveConfig, elNode)
   effectiveConfig =
     setQbftConfigIfSequencer(effectiveConfig, isSequencer = nodeRole == NodeRole.Sequencer, nodeKeyData)
   effectiveConfig = setP2pConfig(effectiveConfig, bootnodes, staticpeers)
-  effectiveConfig = setValidatorConfig(effectiveConfig, elNode)
 
   return MaruAppFactory().create(
     config = effectiveConfig,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make validator EL optional and wire engine/L2 ETH endpoints from ElNode via ForkTransition and updated defaults.
> 
> - **test-utils**:
>   - **Config defaults (`MaruConfigHelper.kt`)**:
>     - Add `forkTransition = ForkTransition()`.
>     - Remove default `validatorElNode`; now `null` by default.
>   - **Validator/EL setup**:
>     - `setValidatorConfig` is a no-op when `elNode` is `null`.
>     - When present, updates `validatorElNode.engineApiEndpoint` and `forkTransition.l2EthApiEndpoint` from `elNode` URLs; creates `ValidatorElNode` if missing.
> - **App factory (`TestMaruAppFactory.kt`)**:
>   - Call `setValidatorConfig` earlier in `createMaru` before other config mutations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42dfe7d4c2ce79662cf32f7479b039c450c33f4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->