### PR TITLE
Fixed automatic merge

### DIFF
--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -274,7 +274,7 @@ data class MaruConfig(
   val linea: LineaConfig? = null,
   val api: ApiConfig,
   val syncing: SyncingConfig,
-  val forkTransition: ForkTransition,
+  val forkTransition: ForkTransition = ForkTransition(),
 ) {
   init {
     if (qbft != null) {

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/TestMaruAppFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/TestMaruAppFactory.kt
@@ -28,7 +28,7 @@ fun createMaru(
   effectiveConfig =
     setQbftConfigIfSequencer(effectiveConfig, isSequencer = nodeRole == NodeRole.Sequencer, nodeKeyData)
   effectiveConfig = setP2pConfig(effectiveConfig, bootnodes, staticpeers)
-  effectiveConfig = setValidatorConfig(effectiveConfig, elNode)
+  effectiveConfig = setElValidatorConfig(effectiveConfig, elNode)
 
   return MaruAppFactory().create(
     config = effectiveConfig,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set a default `forkTransition` in `MaruConfig` and update test configs/helpers to use `forkTransition.l2EthApiEndpoint` (not `validatorElNode.ethApiEndpoint`), with a renamed helper and added validations.
> 
> - **Config**
>   - Set default value for `MaruConfig.forkTransition` (`ForkTransition()`).
> - **Test Utils**
>   - `configTemplate`: remove `validatorElNode.ethApiEndpoint`; add `forkTransition.l2EthApiEndpoint`.
>   - Helper: rename `setValidatorConfig` → `setElValidatorConfig`; add checks requiring `validatorElNode` and `forkTransition.l2EthApiEndpoint` when `ElNode` is provided; update logic to set `validatorElNode.engineApiEndpoint` and `forkTransition.l2EthApiEndpoint`.
>   - Factory: call `setElValidatorConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86b8b7c5cbc997840ff9fc2e369a95f1510be7c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->