### PR TITLE
Besu version bump

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -24,7 +24,7 @@ services:
     depends_on:
       initialization:
         condition: service_completed_successfully
-    image: hyperledger/besu:25.8.0
+    image: hyperledger/besu:25.11.0
     container_name: sequencer
     healthcheck:
       test: [ "CMD-SHELL", "bash -c \"[ -f /tmp/pid ]\"" ]
@@ -105,7 +105,7 @@ services:
     depends_on:
       sequencer:
         condition: service_healthy
-    image: hyperledger/besu:25.8.0
+    image: hyperledger/besu:25.11.0
     container_name: follower-besu
     healthcheck:
       test: [ "CMD-SHELL", "bash -c \"[ -f /tmp/pid ]\"" ]

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -166,7 +166,7 @@ dependencyManagement {
       entry 'log4j-slf4j2-impl'
     }
 
-    def besuVersion = "25.10.0"
+    def besuVersion = "25.11.0"
 
     imports {
       mavenBom "org.hyperledger.besu:bom:$besuVersion"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Hyperledger Besu to 25.11.0 in Docker images and Gradle dependency management.
> 
> - **Infrastructure**:
>   - Update Docker images to `hyperledger/besu:25.11.0` for `sequencer` and `follower-besu` in `docker/compose.yaml`.
> - **Build**:
>   - Bump `besuVersion` to `25.11.0` in `gradle/versions.gradle` and align BOM/plugins accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac71de2fc0777671a301af19065b7a1d02f3770e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->