### PR TITLE
maru-cluster-support no EL node

### DIFF
--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/MaruClusterTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/MaruClusterTest.kt
@@ -28,15 +28,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
-import org.junit.jupiter.api.parallel.Execution
-import org.junit.jupiter.api.parallel.ExecutionMode
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-@Execution(ExecutionMode.SAME_THREAD)
 class MaruClusterTest {
   private lateinit var cluster: MaruCluster
 
@@ -60,12 +54,11 @@ class MaruClusterTest {
   }
 
   @Test
-  @Order(1)
   fun `should allow to retrieve nodes by label`() {
     cluster =
       MaruCluster()
         .addNode(NodeRole.Follower)
-        .addNode(NodeRole.Sequencer)
+        .addNode(NodeRole.Sequencer, withBesuEl = true)
         .addNode("follower-special")
         .start()
 
@@ -88,7 +81,7 @@ class MaruClusterTest {
                 ElFork.Prague,
               ),
           ),
-      ).addNode(NodeRole.Sequencer) { nodeBuilder ->
+      ).addNode(NodeRole.Sequencer, withBesuEl = true) { nodeBuilder ->
         nodeBuilder.withLabel("sequencer")
       }.start()
 
@@ -132,7 +125,7 @@ class MaruClusterTest {
                 ElFork.Prague,
               ),
           ),
-      ).addNode("sequencer")
+      ).addNode("sequencer", addBesu = true)
         .start()
 
     await()
@@ -153,7 +146,7 @@ class MaruClusterTest {
   fun `should instantiate multiple nodes in the cluster with static peering and sync`() {
     cluster =
       MaruCluster()
-        .addNode("sequencer")
+        .addNode("sequencer", addBesu = true)
         .addNode("follower-internal-0") { nodeBuilder ->
           nodeBuilder
             .staticPeers(listOf("sequencer"))
@@ -163,10 +156,11 @@ class MaruClusterTest {
         }.start()
 
     await()
+      .apply { }
       .pollInterval(1.seconds.toJavaDuration())
       .atMost(120.seconds.toJavaDuration())
       .untilAsserted {
-        cluster.assertNodesAreSyncedUpTo(targetBlockNumber = 5UL)
+        cluster.assertNodesAreSyncedUpTo(targetBlockNumber = 3UL)
       }
   }
 
@@ -176,7 +170,7 @@ class MaruClusterTest {
     cluster =
       MaruCluster()
         .addNode("bootnode-1")
-        .addNode("sequencer")
+        .addNode("sequencer", addBesu = true)
         .addNode("follower-internal-0")
         .start()
     val followers = cluster.nodes(NodeRole.Follower)
@@ -203,7 +197,7 @@ class MaruClusterTest {
     cluster =
       MaruCluster()
         .addNode("bootnode-0")
-        .addNode("sequencer")
+        .addNode("sequencer", addBesu = true)
         .addNode("follower-internal-0")
         .start()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce addBesu/withBesuEl flags to optionally create a default Besu EL; require EL for sequencer nodes; update tests accordingly.
> 
> - **Cluster/Builder API**:
>   - Add optional `addBesu`/`withBesuEl` flags to `MaruCluster.addNode(...)` and `createNodeBuilder(...)` to control default EL (Besu) creation.
>   - `NodeBuilder` now accepts `createDefaultElBesuNode` and provides `withElNode(...)` to inject custom EL.
>   - Only auto-create Besu EL when the flag is set; add validation requiring EL for `Sequencer` nodes.
> - **Runtime**:
>   - Node startup paths updated to pass EL config through and start Besu when present.
> - **Tests**:
>   - Update tests to explicitly enable Besu for sequencer nodes and adjust expectations (e.g., sync target reduced in one case).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60321404b4ff972e0fd4fae8b47a4072314b01dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->