### PR TITLE
feat: update genesis blocktime to 2 sec

### DIFF
--- a/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
+++ b/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
@@ -3,7 +3,7 @@
   "config": {
     "0": {
       "type": "difficultyAwareQbft",
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "postTtdConfig": {
         "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
         "elFork": "Paris"
@@ -13,19 +13,19 @@
     "1761213600": {
       "type": "qbft",
       "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "elFork": "Shanghai"
     },
     "1761645600": {
       "type": "qbft",
       "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "elFork": "Cancun"
     },
     "1761646200": {
       "type": "qbft",
       "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "elFork": "Prague"
     }
   }

--- a/app/src/main/resources/beacon-genesis-files/linea-sepolia-genesis.json
+++ b/app/src/main/resources/beacon-genesis-files/linea-sepolia-genesis.json
@@ -3,7 +3,7 @@
   "config": {
     "0": {
       "type": "difficultyAwareQbft",
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "postTtdConfig": {
         "validatorSet": ["0x20e2654209c3f5a7b4728fb228778f1261f1013f"],
         "elFork": "Paris"
@@ -13,19 +13,19 @@
     "1759147200": {
       "type": "qbft",
       "validatorSet": ["0x20e2654209c3f5a7b4728fb228778f1261f1013f"],
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "elFork": "Shanghai"
     },
     "1759233600": {
       "type": "qbft",
       "validatorSet": ["0x20e2654209c3f5a7b4728fb228778f1261f1013f"],
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "elFork": "Cancun"
     },
     "1760004000": {
       "type": "qbft",
       "validatorSet": ["0x20e2654209c3f5a7b4728fb228778f1261f1013f"],
-      "blockTimeSeconds": 1,
+      "blockTimeSeconds": 2,
       "elFork": "Prague"
     }
   }


### PR DESCRIPTION
This implements Consensys/maru#407

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Increase block time from 1s to 2s across Linea mainnet and Sepolia genesis configurations.
> 
> - **Config updates**:
>   - `app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json`
>     - Set `blockTimeSeconds` to `2` for entries: `"0"`, `"1761213600"` (Shanghai), `"1761645600"` (Cancun), `"1761646200"` (Prague).
>   - `app/src/main/resources/beacon-genesis-files/linea-sepolia-genesis.json`
>     - Set `blockTimeSeconds` to `2` for entries: `"0"`, `"1759147200"` (Shanghai), `"1759233600"` (Cancun), `"1760004000"` (Prague).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2602e0b2421aacbf5e4c4e2f691fa36d85ce4860. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->