### PR TITLE
Fixed metrics exposure, added max peers metric

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruApp.kt
+++ b/app/src/main/kotlin/maru/app/MaruApp.kt
@@ -88,6 +88,17 @@ class MaruApp(
           .toLong()
       },
     )
+
+    if (config.p2p != null) {
+      metricsFacade.createGauge(
+        category = MaruMetricsCategory.P2P_NETWORK,
+        name = "peers.max",
+        description = "Max peers configuration",
+        measurementSupplier = {
+          config.p2p!!.maxPeers
+        },
+      )
+    }
   }
 
   private val followerELNodeEngineApiWeb3JClients: Map<String, Web3JClient> =

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -147,16 +147,16 @@ class MaruAppFactory : MaruAppFactoryCreator {
     config.persistence.dataPath.createDirectories()
     val privateKey = getOrGeneratePrivateKey(config.persistence.privateKeyPath)
     val nodeId = PeerId.fromPubKey(unmarshalPrivateKey(privateKey).publicKey())
+    val vertx =
+      VertxFactory.createVertx(
+        jvmMetricsEnabled = config.observability.jvmMetricsEnabled,
+        prometheusMetricsEnabled = config.observability.prometheusMetricsEnabled,
+      )
     val metricsFacade =
       MicrometerMetricsFacade(
         registry = getMetricsRegistry(),
         metricsPrefix = "maru",
         allMetricsCommonTags = listOf(Tag("nodeid", nodeId.toBase58())),
-      )
-    val vertx =
-      VertxFactory.createVertx(
-        jvmMetricsEnabled = config.observability.jvmMetricsEnabled,
-        prometheusMetricsEnabled = config.observability.prometheusMetricsEnabled,
       )
     val besuMetricsSystemAdapter =
       BesuMetricsSystemAdapter(
@@ -335,7 +335,7 @@ class MaruAppFactory : MaruAppFactoryCreator {
     private fun getMetricsRegistry(): MeterRegistry =
       BackendRegistries.getDefaultNow() ?: BackendRegistries
         .setupBackend(
-          MicrometerMetricsOptions(),
+          MicrometerMetricsOptions().setEnabled(true),
           null,
         ).let { BackendRegistries.getDefaultNow() }
 

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -335,7 +335,7 @@ class MaruAppFactory : MaruAppFactoryCreator {
     private fun getMetricsRegistry(): MeterRegistry =
       BackendRegistries.getDefaultNow() ?: BackendRegistries
         .setupBackend(
-          MicrometerMetricsOptions().setEnabled(true),
+          MicrometerMetricsOptions(),
           null,
         ).let { BackendRegistries.getDefaultNow() }
 

--- a/docker/compose.dev.yaml
+++ b/docker/compose.dev.yaml
@@ -6,17 +6,22 @@ services:
   maru:
     # make build-local-image
     # MARU_TAG=local make docker-run-stack
-    # command: [ 'java', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005','-Dvertx.configurationFile=/path/to/vertx-options.json', '-Dlog4j2.configurationFile=/path/to/log4j2-dev.xml']
     image: consensys/maru:${MARU_TAG:-dbb6c73}
     container_name: maru
     depends_on:
       - sequencer
       - follower-geth
-    command: [ 'java', '-Dlog4j2.configurationFile=configs/log4j.xml', '-jar', "maru.jar", '--maru-genesis-file', 'configs/genesis.json', '--config', 'configs/config.dev.toml']
-#    command: [ 'echo' , 'Forced exit to run in IntellIJ' ]
+    command: [ 'java',
+#               '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
+#               '-Dvertx.configurationFile=/opt/consensys/maru/configs/vertx-options.json',
+               '-Dlog4j2.configurationFile=configs/log4j.xml',
+               '-jar', "maru.jar",
+               '--maru-genesis-file', 'configs/genesis.json',
+               '--config', 'configs/config.dev.toml' ]
     volumes:
       - ./maru/config.dev.toml:/opt/consensys/maru/configs/config.dev.toml:ro
       - ./maru/log4j.xml:/opt/consensys/maru/configs/log4j.xml:ro
+#      - ./maru/vertx-options.json:/opt/consensys/maru/configs/vertx-options.json
       - ./initialization/genesis-maru.json:/opt/consensys/maru/configs/genesis.json:ro
       - ./maru/0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0.key:/tmp/maru-db/private-key
       - ./jwt:/opt/consensys/docker/jwt:ro
@@ -24,6 +29,7 @@ services:
       # Attach the IDE's remote java debugger to localhost:5005 to debug maru
       - "5005:5005"
       - "8080:8080"
+      - "9191:9090"
     networks:
       - linea
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `P2P_NETWORK.peers.max` gauge, reorders Vertx init to ensure metrics exposure, and extends dev docker-compose with Prometheus/Grafana and ports.
> 
> - **Metrics**:
>   - Add `P2P_NETWORK.peers.max` gauge in `app/src/main/kotlin/maru/app/MaruApp.kt` (only when `config.p2p` is set).
>   - Reorder Vertx initialization before metrics wiring in `app/src/main/kotlin/maru/app/MaruAppFactory.kt` to ensure metrics are exposed correctly.
> - **Dev environment (docker-compose)**:
>   - Update `docker/compose.dev.yaml` to expose Maru metrics port `9191:9090`.
>   - Add `prometheus` and `grafana` services with basic configs and port mappings (`9090`, `3000`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ed7c9aaaad08492e5943f9acdca61ee1632571d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->