### PR TITLE
Update timer refactor

### DIFF
--- a/app/src/main/kotlin/maru/app/MaruApp.kt
+++ b/app/src/main/kotlin/maru/app/MaruApp.kt
@@ -133,11 +133,11 @@ class MaruApp(
 
   override fun start(): CompletableFuture<Unit> {
     if (finalizationProvider is LineaFinalizationProvider) {
-      start("Finalization Provider", { finalizationProvider.start().get() })
+      start("Finalization Provider") { finalizationProvider.start().get() }
     }
     start("P2P Network") { p2pNetwork.start().get() }
-    start("Sync Service", { syncControllerManager.start().get() })
-    start("Beacon Api", { apiServer.start().get() })
+    start("Sync Service") { syncControllerManager.start().get() }
+    start("Beacon Api") { apiServer.start().get() }
     // observability shall be the last to start because of liveness/readiness probe
     start("Observability Server") {
       ObservabilityServer(
@@ -149,13 +149,13 @@ class MaruApp(
   }
 
   override fun stop(): CompletableFuture<Unit> {
-    stop("Sync service", { syncControllerManager.stop().get() })
+    stop("Sync service") { syncControllerManager.stop().get() }
     stop("P2P Network") { p2pNetwork.stop().get() }
     if (finalizationProvider is LineaFinalizationProvider) {
-      stop("Finalization Provider", { finalizationProvider.stop().get() })
+      stop("Finalization Provider") { finalizationProvider.stop().get() }
     }
-    stop("Beacon API", { apiServer.stop().get() })
-    stop("Protocol", { protocolStarter.pause() })
+    stop("Beacon API") { apiServer.stop().get() }
+    stop("Protocol") { protocolStarter.pause() }
     stop("vertx verticles") {
       vertx.deploymentIDs().forEach {
         vertx.undeploy(it).get()
@@ -242,6 +242,7 @@ class MaruApp(
       DifficultyAwareQbftFactory(
         ethereumJsonRpcClient = l2EthWeb3j,
         postTtdProtocolFactory = qbftFactory,
+        timerFactory = timerFactory,
       )
     val protocolStarter =
       ProtocolStarter.create(

--- a/linea-finalization-provider/src/main/kotlin/maru/finalization/LineaFinalizationProvider.kt
+++ b/linea-finalization-provider/src/main/kotlin/maru/finalization/LineaFinalizationProvider.kt
@@ -8,7 +8,6 @@
  */
 package maru.finalization
 
-import java.util.Timer
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
@@ -85,8 +84,6 @@ class LineaFinalizationProvider(
           )
       }
   }
-
-  private var poller: Timer? = null
 
   override fun start(): SafeFuture<Unit> {
     log.debug("Starting LineaFinalizationProvider with polling interval: {}", pollingUpdateInterval)

--- a/p2p/src/main/kotlin/maru/p2p/discovery/MaruDiscoveryService.kt
+++ b/p2p/src/main/kotlin/maru/p2p/discovery/MaruDiscoveryService.kt
@@ -12,12 +12,14 @@ import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import linea.kotlin.encodeHex
 import linea.kotlin.toBigInteger
 import linea.kotlin.toULong
 import linea.timer.Timer
 import linea.timer.TimerFactory
 import linea.timer.TimerSchedule
+import linea.timer.VertxTimerFactory
 import maru.config.P2PConfig
 import maru.database.P2PState
 import maru.p2p.fork.ForkPeeringManager
@@ -150,7 +152,7 @@ class MaruDiscoveryService(
         poller =
           timerFactory.createTimer(
             name = "boot-node-refresher",
-            initialDelay = Duration.ZERO,
+            initialDelay = if (timerFactory is VertxTimerFactory) 1.milliseconds else Duration.ZERO,
             period = p2pConfig.discovery!!.refreshInterval,
             timerSchedule = TimerSchedule.FIXED_RATE,
             errorHandler = { e -> log.warn("Failed to ping bootnodes", e) },

--- a/syncing/src/main/kotlin/maru/syncing/PeerChainTracker.kt
+++ b/syncing/src/main/kotlin/maru/syncing/PeerChainTracker.kt
@@ -8,7 +8,6 @@
  */
 package maru.syncing
 
-import java.util.Timer
 import kotlin.time.Duration
 import linea.timer.PeriodicPollingService
 import linea.timer.TimerFactory
@@ -48,9 +47,6 @@ class PeerChainTracker(
 
   private var lastNotifiedTarget: ULong? = null // 0 is an Ok magic number, since it represents Genesis
   private var isRunning = false
-
-  // Marked as volatile to ensure visibility across threads
-  private var poller: Timer? = null
 
   /**
    * Updates the peer view and triggers sync target updates if needed


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes polling on the new TimerFactory (with Vertx-friendly initial delays) across QBFT, discovery, finalization, and syncing; also cleans up start/stop call sites.
> 
> - **Timer refactor**:
>   - Replace `java.util.Timer` usage with `linea.timer.TimerFactory`/`Timer` and `TimerSchedule.FIXED_RATE` in `DifficultyAwareQbft`, `MaruDiscoveryService`, `PeerChainTracker`, and `LineaFinalizationProvider`.
>   - Add Vertx-aware `initialDelay` (1ms) when using `VertxTimerFactory`.
>   - Switch poller control to `start()`/`stop()` (from `cancel()`).
> - **QBFT**:
>   - Pass `timerFactory` into `DifficultyAwareQbftFactory` and through to `DifficultyAwareQbft`.
>   - Use factory-created periodic timer for EL total difficulty polling and post-TTD transition.
> - **App lifecycle**:
>   - Minor lambda cleanup for `start(...)`/`stop(...)` invocations in `MaruApp`.
> - **Misc**:
>   - `LineaFinalizationProvider` relies on `PeriodicPollingService` (removed local `Timer` field).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a79941cd1583f51cf03b8b39a7acdd6727f4630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->