### PR TITLE
support for osaka

### DIFF
--- a/app/src/integrationTest/kotlin/maru/app/MaruSupportsOsakaTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruSupportsOsakaTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.app
+
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.time.toJavaDuration
+import maru.consensus.ChainFork
+import maru.consensus.ClFork
+import maru.consensus.ElFork
+import maru.test.cluster.MaruCluster
+import maru.test.cluster.NodeRole
+import maru.test.cluster.configureLoggers
+import maru.test.extensions.headBeaconBlockNumber
+import maru.test.extensions.headElBlock
+import org.apache.logging.log4j.Level
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class MaruSupportsOsakaTest {
+  private lateinit var cluster: MaruCluster
+
+  @BeforeEach
+  fun beforeEach() {
+    configureLoggers(
+      rootLevel = Level.WARN,
+      logLevels =
+        listOf(
+          "maru" to Level.INFO,
+          "maru.clients" to Level.DEBUG,
+        ),
+    )
+  }
+
+  @AfterEach
+  fun afterEach() {
+    if (::cluster.isInitialized) {
+      cluster.stop()
+    }
+  }
+
+  @Test
+  fun `should run network starting from Osaka`() {
+    cluster =
+      MaruCluster(
+        blockTimeSeconds = 1u,
+        chainForks =
+          mapOf(
+            Instant.fromEpochSeconds(0) to ChainFork(clFork = ClFork.QBFT_PHASE0, elFork = ElFork.Osaka),
+          ),
+      ).addNode(NodeRole.Sequencer, withBesuEl = true)
+        .addNode(NodeRole.Follower, withBesuEl = true) {
+          it.staticPeers(listOf("sequencer"))
+        }.start()
+
+    // Assert Maru is creating Blocks and Synced
+    await().atMost(20.seconds.toJavaDuration()).untilAsserted {
+      assertThat(cluster.node("sequencer").maru.headBeaconBlockNumber()).isGreaterThan(5UL)
+    }
+    await().atMost(5.seconds.toJavaDuration()).untilAsserted {
+      assertThat(cluster.node("follower").maru.headBeaconBlockNumber()).isGreaterThan(5UL)
+    }
+  }
+
+  @Test
+  fun `should switch from Prague to Osaka`() {
+    val osakaTimestamp = Clock.System.now().plus(30.seconds)
+    cluster =
+      MaruCluster(
+        chainForks =
+          mapOf(
+            Instant.fromEpochSeconds(0) to
+              ChainFork(
+                ClFork.QBFT_PHASE0,
+                ElFork.Prague,
+              ),
+            osakaTimestamp to
+              ChainFork(
+                ClFork.QBFT_PHASE0,
+                ElFork.Osaka,
+              ),
+          ),
+      ).addNode("sequencer", addBesu = true)
+        .addNode(NodeRole.Follower, withBesuEl = true) {
+          it.staticPeers(listOf("sequencer"))
+        }.start()
+    // Assert Maru is creating Blocks and Synced
+    await().atMost(60.seconds.toJavaDuration()).untilAsserted {
+      assertThat(
+        cluster
+          .node("sequencer")
+          .maru
+          .headElBlock()
+          .timestamp,
+      ).isGreaterThan(osakaTimestamp.epochSeconds.toULong())
+    }
+    await().atMost(5.seconds.toJavaDuration()).untilAsserted {
+      assertThat(
+        cluster
+          .node("follower")
+          .maru
+          .headElBlock()
+          .timestamp,
+      ).isGreaterThan(osakaTimestamp.epochSeconds.toULong())
+    }
+  }
+}

--- a/app/src/integrationTest/kotlin/maru/app/MaruSupportsOsakaTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruSupportsOsakaTest.kt
@@ -67,7 +67,7 @@ class MaruSupportsOsakaTest {
     await().atMost(20.seconds.toJavaDuration()).untilAsserted {
       assertThat(cluster.node("sequencer").maru.headBeaconBlockNumber()).isGreaterThan(5UL)
     }
-    await().atMost(5.seconds.toJavaDuration()).untilAsserted {
+    await().atMost(20.seconds.toJavaDuration()).untilAsserted {
       assertThat(cluster.node("follower").maru.headBeaconBlockNumber()).isGreaterThan(5UL)
     }
   }
@@ -104,7 +104,7 @@ class MaruSupportsOsakaTest {
           .timestamp,
       ).isGreaterThan(osakaTimestamp.epochSeconds.toULong())
     }
-    await().atMost(5.seconds.toJavaDuration()).untilAsserted {
+    await().atMost(20.seconds.toJavaDuration()).untilAsserted {
       assertThat(
         cluster
           .node("follower")

--- a/app/src/main/kotlin/maru/app/Helpers.kt
+++ b/app/src/main/kotlin/maru/app/Helpers.kt
@@ -15,13 +15,7 @@ import maru.consensus.NewBlockHandlerMultiplexer
 import maru.consensus.blockimport.ElForkAwareBlockImporter
 import maru.consensus.blockimport.FollowerBeaconBlockImporter
 import maru.consensus.state.FinalizationProvider
-import maru.executionlayer.client.CancunWeb3JJsonRpcExecutionLayerEngineApiClient
-import maru.executionlayer.client.ExecutionLayerEngineApiClient
-import maru.executionlayer.client.ParisWeb3JJsonRpcExecutionLayerEngineApiClient
-import maru.executionlayer.client.PragueWeb3JJsonRpcExecutionLayerEngineApiClient
-import maru.executionlayer.client.ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient
-import maru.executionlayer.manager.ExecutionLayerManager
-import maru.executionlayer.manager.JsonRpcExecutionLayerManager
+import maru.executionlayer.ExecutionLayerFactory.buildExecutionLayerManager
 import maru.web3j.TekuWeb3JClientFactory
 import net.consensys.linea.metrics.MetricsFacade
 import org.apache.logging.log4j.Logger
@@ -39,51 +33,6 @@ object Helpers {
         timeout = apiEndpointConfig.timeout,
         log = log,
       )
-
-  fun buildExecutionLayerManager(
-    web3JEngineApiClient: Web3JClient,
-    elFork: ElFork,
-    metricsFacade: MetricsFacade,
-  ): ExecutionLayerManager =
-    JsonRpcExecutionLayerManager(
-      executionLayerEngineApiClient =
-        buildExecutionEngineClient(
-          web3JEngineApiClient = web3JEngineApiClient,
-          elFork = elFork,
-          metricsFacade = metricsFacade,
-        ),
-    )
-
-  fun buildExecutionEngineClient(
-    web3JEngineApiClient: Web3JClient,
-    elFork: ElFork,
-    metricsFacade: MetricsFacade,
-  ): ExecutionLayerEngineApiClient =
-    when (elFork) {
-      ElFork.Paris ->
-        ParisWeb3JJsonRpcExecutionLayerEngineApiClient(
-          web3jClient = web3JEngineApiClient,
-          metricsFacade = metricsFacade,
-        )
-
-      ElFork.Shanghai ->
-        ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient(
-          web3jClient = web3JEngineApiClient,
-          metricsFacade = metricsFacade,
-        )
-
-      ElFork.Cancun ->
-        CancunWeb3JJsonRpcExecutionLayerEngineApiClient(
-          web3jClient = web3JEngineApiClient,
-          metricsFacade = metricsFacade,
-        )
-
-      ElFork.Prague ->
-        PragueWeb3JJsonRpcExecutionLayerEngineApiClient(
-          web3jClient = web3JEngineApiClient,
-          metricsFacade = metricsFacade,
-        )
-    }
 
   fun createBlockImportHandlers(
     elFork: ElFork,

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -45,6 +45,7 @@ import maru.core.SealedBeaconBlock
 import maru.database.BeaconChain
 import maru.database.P2PState
 import maru.database.kv.KvDatabaseFactory
+import maru.executionlayer.ExecutionLayerFactory.buildExecutionEngineClient
 import maru.executionlayer.manager.JsonRpcExecutionLayerManager
 import maru.finalization.LineaFinalizationProvider
 import maru.metrics.BesuMetricsCategoryAdapter
@@ -197,7 +198,7 @@ class MaruAppFactory : MaruAppFactoryCreator {
       if (engineApiWeb3jClient != null) {
         ElFork.entries.associateWith {
           val engineApiClient =
-            Helpers.buildExecutionEngineClient(
+            buildExecutionEngineClient(
               web3JEngineApiClient = engineApiWeb3jClient,
               elFork = it,
               metricsFacade = metricsFacade,

--- a/app/src/main/kotlin/maru/app/QbftFollowerFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftFollowerFactory.kt
@@ -24,6 +24,7 @@ import maru.consensus.validation.QuorumOfSealsVerifier
 import maru.consensus.validation.SCEP256SealVerifier
 import maru.core.Protocol
 import maru.database.BeaconChain
+import maru.executionlayer.ExecutionLayerFactory.buildExecutionLayerManager
 import maru.p2p.P2PNetwork
 import net.consensys.linea.metrics.MetricsFacade
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
@@ -44,7 +45,7 @@ class QbftFollowerFactory(
 
     val elManager =
       validatorELNodeEngineApiWeb3JClient?.let {
-        Helpers.buildExecutionLayerManager(
+        buildExecutionLayerManager(
           web3JEngineApiClient = it,
           elFork = qbftConsensusConfig.elFork,
           metricsFacade = metricsFacade,

--- a/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
@@ -21,6 +21,7 @@ import maru.consensus.qbft.QbftValidatorFactory
 import maru.consensus.state.FinalizationProvider
 import maru.core.Protocol
 import maru.database.BeaconChain
+import maru.executionlayer.ExecutionLayerFactory.buildExecutionLayerManager
 import maru.p2p.P2PNetwork
 import maru.p2p.SealedBeaconBlockBroadcaster
 import maru.syncing.CLSyncStatus
@@ -56,7 +57,7 @@ class QbftProtocolValidatorFactory(
     val qbftConsensusConfig = forkSpec.configuration as QbftConsensusConfig
 
     val payloadValidatorExecutionLayerManager =
-      Helpers.buildExecutionLayerManager(
+      buildExecutionLayerManager(
         web3JEngineApiClient = validatorELNodeEngineApiWeb3JClient,
         elFork = qbftConsensusConfig.elFork,
         metricsFacade = metricsFacade,

--- a/chaos-testing/helm/charts/besu/values.yaml
+++ b/chaos-testing/helm/charts/besu/values.yaml
@@ -89,6 +89,7 @@ configFiles:
         "shanghaiTime": 0,
         "cancunTime": 0,
         "pragueTime": 0,
+        "osakaTime": 0,
         "depositContractAddress": "0x4242424242424242424242424242424242424242",
         "withdrawalRequestContractAddress": "0x00000961ef480eb55e80d19ad83579a64c007002",
         "consolidationRequestContractAddress": "0x0000bbddc7ce488642fb579f8b00f3a590007251",

--- a/chaos-testing/helm/charts/maru/values.yaml
+++ b/chaos-testing/helm/charts/maru/values.yaml
@@ -97,20 +97,11 @@ configFiles:
       "chainId": 1337,
       "config": {
         "0": {
-          "type": "difficultyAwareQbft",
-          "blockTimeSeconds": 1,
-          "postTtdConfig": {
-            "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
-            "elFork": "Paris"
-          },
-          "terminalTotalDifficulty": 10
-        },
-        "1683325137": {
           "type": "qbft",
           "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
           "blockTimeSeconds": 1,
           "feeRecipient": "0x0000000000000000000000000000000000000000",
-          "elFork": "Prague"
+          "elFork": "Osaka"
         }
       }
     }

--- a/chaos-testing/helm/values/maru-sequencer-0.yaml
+++ b/chaos-testing/helm/values/maru-sequencer-0.yaml
@@ -19,20 +19,11 @@ configFiles:
       "chainId": 1337,
       "config": {
         "0": {
-          "type": "difficultyAwareQbft",
-          "blockTimeSeconds": 2,
-          "postTtdConfig": {
-            "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
-            "elFork": "Paris"
-          },
-          "terminalTotalDifficulty": 10
-        },
-        "1683325137": {
           "type": "qbft",
           "validatorSet": ["0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0"],
           "blockTimeSeconds": 2,
           "feeRecipient": "0x0000000000000000000000000000000000000000",
-          "elFork": "Prague"
+          "elFork": "Osaka"
         }
       }
     }

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
@@ -9,6 +9,7 @@
 package maru.consensus.qbft
 
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
 import maru.core.Protocol
 import org.hyperledger.besu.consensus.common.bft.BftExecutors
 import org.hyperledger.besu.consensus.qbft.core.statemachine.QbftController
@@ -19,17 +20,24 @@ class QbftConsensusValidator(
   private val bftExecutors: BftExecutors,
   private val eventQueueExecutor: Executor,
 ) : Protocol {
+  private val isRunning = AtomicBoolean(false)
+
   override fun start() {
+    if (isRunning.get()) {
+      return
+    }
     eventProcessor.start()
     bftExecutors.start()
     qbftController.start()
     eventQueueExecutor.execute(eventProcessor)
+    isRunning.set(true)
   }
 
   override fun pause() {
     eventProcessor.stop()
     bftExecutors.stop()
     qbftController.stop()
+    isRunning.set(false)
   }
 
   override fun close() {

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
@@ -9,7 +9,6 @@
 package maru.consensus.qbft
 
 import java.util.concurrent.Executor
-import java.util.concurrent.atomic.AtomicBoolean
 import maru.core.Protocol
 import org.hyperledger.besu.consensus.common.bft.BftExecutors
 import org.hyperledger.besu.consensus.qbft.core.statemachine.QbftController
@@ -20,24 +19,26 @@ class QbftConsensusValidator(
   private val bftExecutors: BftExecutors,
   private val eventQueueExecutor: Executor,
 ) : Protocol {
-  private val isRunning = AtomicBoolean(false)
+  private var isRunning = false
 
+  @Synchronized
   override fun start() {
-    if (isRunning.get()) {
+    if (isRunning) {
       return
     }
     eventProcessor.start()
     bftExecutors.start()
     qbftController.start()
     eventQueueExecutor.execute(eventProcessor)
-    isRunning.set(true)
+    isRunning = true
   }
 
+  @Synchronized
   override fun pause() {
     eventProcessor.stop()
     bftExecutors.stop()
     qbftController.stop()
-    isRunning.set(false)
+    isRunning = false
   }
 
   override fun close() {

--- a/core/src/main/kotlin/maru/consensus/ForkSchedule.kt
+++ b/core/src/main/kotlin/maru/consensus/ForkSchedule.kt
@@ -28,7 +28,7 @@ enum class ElFork(
   Shanghai(0x2),
   Cancun(0x3),
   Prague(0x4),
-  // Osaka(0x5),
+  Osaka(0x5),
 }
 
 data class ChainFork(

--- a/executionlayer/src/main/kotlin/maru/executionlayer/ExecutionLayerFactory.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/ExecutionLayerFactory.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.executionlayer
+
+import maru.consensus.ElFork
+import maru.executionlayer.client.CancunWeb3JJsonRpcExecutionLayerEngineApiClient
+import maru.executionlayer.client.ExecutionLayerEngineApiClient
+import maru.executionlayer.client.OsakaWeb3JJsonRpcExecutionLayerEngineApiClient
+import maru.executionlayer.client.ParisWeb3JJsonRpcExecutionLayerEngineApiClient
+import maru.executionlayer.client.PragueWeb3JJsonRpcExecutionLayerEngineApiClient
+import maru.executionlayer.client.ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient
+import maru.executionlayer.manager.ExecutionLayerManager
+import maru.executionlayer.manager.JsonRpcExecutionLayerManager
+import net.consensys.linea.metrics.MetricsFacade
+import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
+
+object ExecutionLayerFactory {
+  fun buildExecutionLayerManager(
+    web3JEngineApiClient: Web3JClient,
+    elFork: ElFork,
+    metricsFacade: MetricsFacade,
+  ): ExecutionLayerManager =
+    JsonRpcExecutionLayerManager(
+      executionLayerEngineApiClient =
+        buildExecutionEngineClient(
+          web3JEngineApiClient = web3JEngineApiClient,
+          elFork = elFork,
+          metricsFacade = metricsFacade,
+        ),
+    )
+
+  fun buildExecutionEngineClient(
+    web3JEngineApiClient: Web3JClient,
+    elFork: ElFork,
+    metricsFacade: MetricsFacade,
+  ): ExecutionLayerEngineApiClient =
+    when (elFork) {
+      ElFork.Paris ->
+        ParisWeb3JJsonRpcExecutionLayerEngineApiClient(
+          web3jClient = web3JEngineApiClient,
+          metricsFacade = metricsFacade,
+        )
+
+      ElFork.Shanghai ->
+        ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient(
+          web3jClient = web3JEngineApiClient,
+          metricsFacade = metricsFacade,
+        )
+
+      ElFork.Cancun ->
+        CancunWeb3JJsonRpcExecutionLayerEngineApiClient(
+          web3jClient = web3JEngineApiClient,
+          metricsFacade = metricsFacade,
+        )
+
+      ElFork.Prague ->
+        PragueWeb3JJsonRpcExecutionLayerEngineApiClient(
+          web3jClient = web3JEngineApiClient,
+          metricsFacade = metricsFacade,
+        )
+      ElFork.Osaka ->
+        OsakaWeb3JJsonRpcExecutionLayerEngineApiClient(
+          web3jClient = web3JEngineApiClient,
+          metricsFacade = metricsFacade,
+        )
+    }
+}

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/OsakaWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/OsakaWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.executionlayer.client
+
+import maru.consensus.ElFork
+import maru.core.ExecutionPayload
+import maru.extensions.captureTimeSafeFuture
+import maru.mappers.Mappers.toDomainExecutionPayload
+import net.consensys.linea.metrics.MetricsFacade
+import tech.pegasys.teku.ethereum.executionclient.schema.Response
+import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
+import tech.pegasys.teku.infrastructure.async.SafeFuture
+import tech.pegasys.teku.infrastructure.bytes.Bytes8
+
+class OsakaWeb3JJsonRpcExecutionLayerEngineApiClient(
+  web3jClient: Web3JClient,
+  metricsFacade: MetricsFacade,
+) : PragueWeb3JJsonRpcExecutionLayerEngineApiClient(web3jClient = web3jClient, metricsFacade = metricsFacade) {
+  override fun getFork(): ElFork = ElFork.Osaka
+
+  override fun getPayload(payloadId: Bytes8): SafeFuture<Response<ExecutionPayload>> =
+    createRequestTimer<ExecutionPayload>(method = "getPayload").captureTimeSafeFuture(
+      web3jEngineClient.getPayloadV5(payloadId).thenApply {
+        when {
+          it.payload != null ->
+            Response.fromPayloadReceivedAsJson(it.payload.executionPayload.toDomainExecutionPayload())
+
+          it.errorMessage != null ->
+            Response.fromErrorMessage(it.errorMessage)
+
+          else ->
+            throw IllegalStateException("Failed to get payload!")
+        }
+      },
+    )
+}

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/PragueWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/PragueWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -26,7 +26,7 @@ import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
 
-class PragueWeb3JJsonRpcExecutionLayerEngineApiClient(
+open class PragueWeb3JJsonRpcExecutionLayerEngineApiClient(
   web3jClient: Web3JClient,
   metricsFacade: MetricsFacade,
 ) : BaseWeb3JJsonRpcExecutionLayerEngineApiClient(web3jClient = web3jClient, metricsFacade = metricsFacade) {

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/BesuGenesisFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/BesuGenesisFactory.kt
@@ -130,7 +130,7 @@ class BesuGenesisFactory(
       )
     }
 
-    fun calculateForkTimestampOrNull(
+    private fun calculateForkTimestampOrNull(
       forks: List<ForkSpec>,
       elFork: ElFork,
     ): ULong? {
@@ -206,11 +206,7 @@ class BesuGenesisFactory(
 
       configNode.set<ObjectNode>("clique", cliqueNode)
 
-      return jsonObjectMapper.writeValueAsString(rootNode).also {
-        println("\n\n\n")
-        println(it)
-        println("\n\n\n")
-      }
+      return jsonObjectMapper.writeValueAsString(rootNode)
     }
 
     private fun setGenesisConfigProperty(

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/BesuGenesisFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/BesuGenesisFactory.kt
@@ -11,6 +11,7 @@ package maru.test.genesis
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import linea.kotlin.isSortedBy
 import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ElFork
 import maru.consensus.ForkSpec
@@ -100,18 +101,22 @@ class BesuGenesisFactory(
               pragueTimestamp = calculateForkTimestampOrNull(forksInAscendingOrder, ElFork.Prague) ?: 0UL
               osakaTimestamp = forkSpec.timestampSeconds
             }
+
             ElFork.Prague -> {
               shanghaiTimestamp = calculateForkTimestampOrNull(forksInAscendingOrder, ElFork.Shanghai) ?: 0UL
               cancunTimestamp = calculateForkTimestampOrNull(forksInAscendingOrder, ElFork.Cancun) ?: 0UL
               pragueTimestamp = forkSpec.timestampSeconds
             }
+
             ElFork.Cancun -> {
               shanghaiTimestamp = calculateForkTimestampOrNull(forksInAscendingOrder, ElFork.Shanghai) ?: 0UL
               cancunTimestamp = forkSpec.timestampSeconds
             }
+
             ElFork.Shanghai -> {
               shanghaiTimestamp = forkSpec.timestampSeconds
             }
+
             ElFork.Paris -> {} // nothing to do, terminalTotalDifficulty already set
           }
         }
@@ -134,6 +139,9 @@ class BesuGenesisFactory(
       forks: List<ForkSpec>,
       elFork: ElFork,
     ): ULong? {
+      require(forks.isSortedBy { it.timestampSeconds }) {
+        "forks must be sorted in ascending order by timestampSeconds"
+      }
       val forkTimestamp =
         forks
           .firstOrNull { it.configuration.fork.elFork == elFork }

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/MaruClusterTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/MaruClusterTest.kt
@@ -101,7 +101,7 @@ class MaruClusterTest {
     val forkTimeGap = 10.seconds
     cluster =
       MaruCluster(
-        terminalTotalDifficulty = 20UL,
+        terminalTotalDifficulty = terminalTotalDifficulty,
         chainForks =
           mapOf(
             Instant.fromEpochSeconds(0) to

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/AssertionHelper.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/AssertionHelper.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.test.genesis
+
+import com.fasterxml.jackson.databind.JsonNode
+import org.assertj.core.api.Assertions
+
+fun assertIsNumberWithValue(
+  node: JsonNode,
+  expectedValue: Long,
+) {
+  Assertions.assertThat(node.isNumber).isTrue
+  Assertions.assertThat(node.asLong()).isEqualTo(expectedValue)
+}
+
+fun assertIsNumberWithValue(
+  node: JsonNode,
+  expectedValue: ULong,
+) = assertIsNumberWithValue(node, expectedValue.toLong())
+
+fun assertIsBooleanWithValue(
+  node: JsonNode,
+  expectedValue: Boolean,
+) {
+  Assertions.assertThat(node.isBoolean).isTrue
+  Assertions.assertThat(node.asBoolean()).isEqualTo(expectedValue)
+}

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/BeaconGenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/BeaconGenesisFactoryTest.kt
@@ -151,6 +151,8 @@ class BeaconGenesisFactoryTest {
         Instant.fromEpochSeconds(1000) to ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
         Instant.fromEpochSeconds(2000) to ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
         Instant.fromEpochSeconds(3000) to ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+        Instant.fromEpochSeconds(4000) to ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+        Instant.fromEpochSeconds(5000) to ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
       )
 
     val result =
@@ -205,6 +207,24 @@ class BeaconGenesisFactoryTest {
                 QbftConsensusConfig(
                   validatorSet = validators.toSet(),
                   fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+                ),
+            ),
+            ForkSpec(
+              timestampSeconds = 4000UL,
+              blockTimeSeconds = 1U,
+              configuration =
+                QbftConsensusConfig(
+                  validatorSet = validators.toSet(),
+                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+                ),
+            ),
+            ForkSpec(
+              timestampSeconds = 5000UL,
+              blockTimeSeconds = 1U,
+              configuration =
+                QbftConsensusConfig(
+                  validatorSet = validators.toSet(),
+                  fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
                 ),
             ),
           ),

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.test.genesis
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kotlin.random.Random
+import kotlin.time.Instant
+import maru.consensus.ChainFork
+import maru.consensus.ClFork
+import maru.consensus.ElFork
+import maru.consensus.ForkSpec
+import maru.consensus.ForksSchedule
+import maru.consensus.QbftConsensusConfig
+import maru.core.Validator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GenesisFactoryTest {
+  val objectMapper = jacksonObjectMapper()
+  val validator = Random.nextBytes(20)
+  val validators = listOf(Random.nextBytes(20))
+  private lateinit var genesisFactory: GenesisFactory
+
+  @BeforeEach
+  fun setup() {
+    genesisFactory =
+      GenesisFactory(
+        chainId = 13U,
+        blockTimeSeconds = 1U,
+      )
+  }
+
+  @Test
+  fun `should create genesis with ttd and all chain forks from Paris to Osaka`() {
+    val parisTime = Instant.fromEpochSeconds(0)
+    val shanghaiTimestamp = Instant.parse("2025-01-01T00:00:00Z")
+    val cancunTimestamp = Instant.parse("2025-02-02T00:00:00Z")
+    val pragueTimestamp = Instant.parse("2025-03-03T00:00:00Z")
+    val osakaTimestamp = Instant.parse("2025-04-04T00:00:00Z")
+
+    val forks =
+      mapOf(
+        parisTime to ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
+        shanghaiTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
+        cancunTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
+        pragueTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+        osakaTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+      )
+
+    genesisFactory.initForkSchedule(
+      sequencersAddresses = validators,
+      terminalTotalDifficulty = 10UL,
+      chainForks = forks,
+    )
+    genesisFactory.maruForkSchedule().also { forksSchedule ->
+      assertThat(
+        forksSchedule,
+      ).isEqualTo(MaruGenesisFactory().create(13U, validators, terminalTotalDifficulty = 10u, forks = forks))
+    }
+
+    val jsonNode = objectMapper.readTree(genesisFactory.besuGenesis())
+    val config = jsonNode.get("config")
+
+    assertIsNumberWithValue(config.get("chainId"), 13L)
+    assertIsNumberWithValue(
+      config.get("terminalTotalDifficulty"),
+      10L,
+    )
+    assertIsNumberWithValue(config.get("shanghaiTime"), shanghaiTimestamp.epochSeconds)
+    assertIsNumberWithValue(config.get("cancunTime"), cancunTimestamp.epochSeconds)
+    assertIsNumberWithValue(config.get("pragueTime"), pragueTimestamp.epochSeconds)
+    assertIsNumberWithValue(config.get("osakaTime"), osakaTimestamp.epochSeconds)
+  }
+
+  @Test
+  fun `should create genesis without ttd and subset of forks `() {
+    val epochTimestamp = Instant.fromEpochSeconds(0)
+    val osakaTimestamp = Instant.parse("2025-04-04T00:00:00Z")
+
+    val forks =
+      mapOf(
+        epochTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+        osakaTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+      )
+
+    genesisFactory.initForkSchedule(
+      sequencersAddresses = validators,
+      chainForks = forks,
+    )
+
+    genesisFactory.maruForkSchedule().also { forksSchedule ->
+      val expected =
+        ForksSchedule(
+          chainId = 13U,
+          forks =
+            listOf(
+              ForkSpec(
+                timestampSeconds = epochTimestamp.epochSeconds.toULong(),
+                blockTimeSeconds = 1U,
+                configuration =
+                  QbftConsensusConfig(
+                    validatorSet = validators.map { Validator(it) }.toSet(),
+                    fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+                  ),
+              ),
+              ForkSpec(
+                timestampSeconds = osakaTimestamp.epochSeconds.toULong(),
+                blockTimeSeconds = 1U,
+                configuration =
+                  QbftConsensusConfig(
+                    validatorSet = validators.map { Validator(it) }.toSet(),
+                    fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+                  ),
+              ),
+            ),
+        )
+
+      assertThat(forksSchedule).isEqualTo(expected)
+    }
+
+    val jsonNode = objectMapper.readTree(genesisFactory.besuGenesis())
+    val config = jsonNode.get("config")
+
+    assertIsNumberWithValue(config.get("chainId"), 13L)
+    assertIsNumberWithValue(config.get("terminalTotalDifficulty"), 0L)
+    assertIsNumberWithValue(config.get("shanghaiTime"), epochTimestamp.epochSeconds)
+    assertIsNumberWithValue(config.get("cancunTime"), epochTimestamp.epochSeconds)
+    assertIsNumberWithValue(config.get("pragueTime"), epochTimestamp.epochSeconds)
+    assertIsNumberWithValue(config.get("osakaTime"), osakaTimestamp.epochSeconds)
+  }
+}

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
@@ -40,17 +40,19 @@ class GenesisFactoryTest {
   fun `should create genesis with ttd and all chain forks from Paris to Osaka`() {
     val parisTime = Instant.fromEpochSeconds(0)
     val shanghaiTimestamp = Instant.parse("2025-01-01T00:00:00Z")
-    val cancunTimestamp = Instant.parse("2025-02-02T00:00:00Z")
-    val pragueTimestamp = Instant.parse("2025-03-03T00:00:00Z")
-    val osakaTimestamp = Instant.parse("2025-04-04T00:00:00Z")
-    val osakaTimestamp2 = Instant.parse("2025-04-05T00:00:00Z")
+    val cancunTimestamp = Instant.parse("2025-02-01T00:00:00Z")
+    val cancunTimestamp2 = Instant.parse("2025-02-02T00:00:00Z")
+    val pragueTimestamp = Instant.parse("2025-03-01T00:00:00Z")
+    val osakaTimestamp = Instant.parse("2025-04-01T00:00:00Z")
+    val osakaTimestamp2 = Instant.parse("2025-04-02T00:00:00Z")
 
     val forks =
       mapOf(
         parisTime to ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
         shanghaiTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
         cancunTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
-        pragueTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+        cancunTimestamp2 to ChainFork(ClFork.QBFT_PHASE1, ElFork.Cancun),
+        pragueTimestamp to ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
         osakaTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
         osakaTimestamp2 to ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
       )

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test
 
 class GenesisFactoryTest {
   val objectMapper = jacksonObjectMapper()
-  val validator = Random.nextBytes(20)
   val validators = listOf(Random.nextBytes(20))
   private lateinit var genesisFactory: GenesisFactory
 
@@ -44,6 +43,7 @@ class GenesisFactoryTest {
     val cancunTimestamp = Instant.parse("2025-02-02T00:00:00Z")
     val pragueTimestamp = Instant.parse("2025-03-03T00:00:00Z")
     val osakaTimestamp = Instant.parse("2025-04-04T00:00:00Z")
+    val osakaTimestamp2 = Instant.parse("2025-04-05T00:00:00Z")
 
     val forks =
       mapOf(
@@ -52,6 +52,7 @@ class GenesisFactoryTest {
         cancunTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
         pragueTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
         osakaTimestamp to ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+        osakaTimestamp2 to ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
       )
 
     genesisFactory.initForkSchedule(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable Osaka fork across execution layer, config/genesis, and tests, including new engine client (getPayloadV5) and related factory/refactor; add idempotent QBFT validator start and update Helm to Osaka.
> 
> - **Core/Config**:
>   - Enable `ElFork.Osaka` in `ForkSchedule` and propagate fork-aware handling.
> - **Execution Layer**:
>   - Add `ExecutionLayerFactory` and wire usage across app factories.
>   - Implement `OsakaWeb3JJsonRpcExecutionLayerEngineApiClient` using `getPayloadV5`.
>   - Extend factory/client selection to handle `Osaka`.
> - **App/Factories**:
>   - Use factory-built EL clients/managers in `MaruAppFactory`, `QbftProtocolValidatorFactory`, and `QbftFollowerFactory`.
>   - Create fork-aware block import handlers.
> - **Consensus**:
>   - Make `QbftConsensusValidator` start/pause idempotent with `isRunning` guard.
> - **Genesis/Tooling**:
>   - Update `BesuGenesisFactory` to compute and set `osakaTime`; add helpers and assertions.
> - **Tests**:
>   - Add integration test `MaruSupportsOsakaTest` (start at Osaka; switch Prague→Osaka).
>   - Expand genesis tests to include Osaka and interleaved forks; add new `GenesisFactoryTest` and helpers.
> - **Helm/Config**:
>   - Set `osakaTime` in Besu genesis and switch Maru/Besu charts to `elFork: "Osaka"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062784c60091f6b3769c5d9b4543b076df3cc8b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->