### PR TITLE
make QbftConsensusValidator.start idempotent

### DIFF
--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
@@ -9,7 +9,6 @@
 package maru.consensus.qbft
 
 import java.util.concurrent.Executor
-import java.util.concurrent.atomic.AtomicBoolean
 import maru.core.Protocol
 import org.hyperledger.besu.consensus.common.bft.BftExecutors
 import org.hyperledger.besu.consensus.qbft.core.statemachine.QbftController
@@ -20,24 +19,26 @@ class QbftConsensusValidator(
   private val bftExecutors: BftExecutors,
   private val eventQueueExecutor: Executor,
 ) : Protocol {
-  private val isRunning = AtomicBoolean(false)
+  private var isRunning = false
 
+  @Synchronized
   override fun start() {
-    if (isRunning.get()) {
+    if (isRunning) {
       return
     }
     eventProcessor.start()
     bftExecutors.start()
     qbftController.start()
     eventQueueExecutor.execute(eventProcessor)
-    isRunning.set(true)
+    isRunning = true
   }
 
+  @Synchronized
   override fun pause() {
     eventProcessor.stop()
     bftExecutors.stop()
     qbftController.stop()
-    isRunning.set(false)
+    isRunning = false
   }
 
   override fun close() {


### PR DESCRIPTION
This aims to fix startup exceptions throw by QBFT

```
2025-11-26 23:15:54 [ERROR] - errorMessage=Attempt to start new height manager without stopping previous manager from subscriber=maru.app.QbftProtocolValidatorFactory$$Lambda/0x000000d00185b058@4eed5a11 handling data=kotlin.Unit | maru.subscription.InOrderFanoutSubscriptionManager
java.lang.IllegalStateException: Attempt to start new height manager without stopping previous manager
	at org.hyperledger.besu.consensus.qbft.core.statemachine.QbftController.start(QbftController.java:170) ~[besu-consensus-qbft-core-25.11.0.jar:25.11.0]
	at maru.consensus.qbft.QbftConsensusValidator.start(QbftConsensusValidator.kt:31) ~[consensus.jar:?]
	at maru.app.QbftProtocolValidatorFactory.create$lambda$1(QbftProtocolValidatorFactory.kt:98) ~[maru.jar:?]
	at maru.syncing.BeaconSyncControllerImpl.onFullSyncComplete$lambda$0(SyncController.kt:82) ~[syncing.jar:?]
	at maru.subscription.InOrderFanoutSubscriptionManager.notifySubscribers(SubscriptionManager.kt:190) ~[core.jar:?]
	at maru.syncing.BeaconSyncControllerImpl.addNodeFullInSyncNotification$lambda$0(SyncController.kt:160) ~[syncing.jar:?]
	at maru.syncing.BeaconSyncControllerImpl.updateElSyncStatus(SyncController.kt:154) ~[syncing.jar:?]
	at maru.syncing.BeaconSyncControllerImpl$Companion$create$elSyncService$1.invoke(SyncController.kt:230) ~[syncing.jar:?]
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `QbftConsensusValidator` start/stop idempotent and thread-safe by adding `isRunning` guard and synchronization.
> 
> - **Consensus (QBFT)**:
>   - Make `QbftConsensusValidator.start()` idempotent by tracking `isRunning` and returning early if already started.
>   - Add `@Synchronized` to `start()` and `pause()` for thread-safety.
>   - Set `isRunning` appropriately on start/stop; preserve existing start/stop order and execution of `eventProcessor` via `eventQueueExecutor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83d6abde3b02c6068a57f5cc38d8892f9729418b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->