### PR TITLE
feat: update genesis file for Osaka on sepolia

### DIFF
--- a/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
+++ b/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
@@ -27,12 +27,6 @@
       "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
       "blockTimeSeconds": 1,
       "elFork": "Prague"
-    },
-    "1764798551": {
-      "type": "qbft",
-      "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
-      "blockTimeSeconds": 1,
-      "elFork": "Osaka"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `elFork: "Osaka"` at timestamp `1764583200` to `app/src/main/resources/beacon-genesis-files/linea-sepolia-genesis.json`.
> 
> - **Genesis config (`linea-sepolia-genesis.json`)**:
>   - Add new fork entry at `1764583200` with `type: qbft`, same `validatorSet`, `blockTimeSeconds: 1`, and `elFork: "Osaka"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a63e8338ed1b16cb8f0ab4a6bc9958488deb2963. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->