### PR TITLE
Added Osaka fork to the mainnet genesis file

### DIFF
--- a/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
+++ b/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
@@ -30,7 +30,7 @@
     },
     "1764798551": {
       "type": "qbft",
-      "validatorSet": ["0x20e2654209c3f5a7b4728fb228778f1261f1013f"],
+      "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
       "blockTimeSeconds": 1,
       "elFork": "Osaka"
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an Osaka EL fork entry to the Linea mainnet genesis config at timestamp 1764798551.
> 
> - **Config update** (`app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json`):
>   - Add new fork entry at `"1764798551"` with `type: "qbft"`, `validatorSet: ["0x9f31730181441beb67b10efaed5773767ea959bc"]`, `blockTimeSeconds: 1`, and `elFork: "Osaka"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f6dd175cba319ffb154971c05ba100562160b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->