### PR TITLE
feat: update built-in genesis file mainnet for Osaka

### DIFF
--- a/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
+++ b/app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json
@@ -27,6 +27,12 @@
       "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
       "blockTimeSeconds": 1,
       "elFork": "Prague"
+    },
+    "1764798551": {
+      "type": "qbft",
+      "validatorSet": ["0x9f31730181441beb67b10efaed5773767ea959bc"],
+      "blockTimeSeconds": 1,
+      "elFork": "Osaka"
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Osaka fork entry to Linea mainnet genesis config at timestamp 1764798551.
> 
> - **Genesis config (`app/src/main/resources/beacon-genesis-files/linea-mainnet-genesis.json`)**:
>   - Add `1764798551` config entry using `qbft` with existing `validatorSet`, `blockTimeSeconds: 1`, and `elFork: "Osaka"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92d318daaad3014d7104e792743b5772db8d31bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->