### PR TITLE
Replace --Xsnapsync-server-enabled deprecated option

### DIFF
--- a/chaos-testing/helm/charts/besu/values.yaml
+++ b/chaos-testing/helm/charts/besu/values.yaml
@@ -66,7 +66,7 @@ configFiles:
     data-storage-format="BONSAI"
     bonsai-limit-trie-logs-enabled=false
     bonsai-historical-block-limit=1024
-    Xsnapsync-server-enabled=true
+    snapsync-server-enabled=true
 
     # mining
     Xpos-block-creation-repetition-min-duration=100

--- a/docker/sequencer/config.toml
+++ b/docker/sequencer/config.toml
@@ -37,7 +37,7 @@ metrics-port=9545
 data-storage-format="BONSAI"
 bonsai-limit-trie-logs-enabled=false
 bonsai-historical-block-limit=1024
-Xsnapsync-server-enabled=true
+snapsync-server-enabled=true
 
 # mining
 Xpos-block-creation-repetition-min-duration=100


### PR DESCRIPTION
This is an upcoming breaking change in Besu: 
  - Remove `--Xsnapsync-server-enabled` deprecated since 25.7.0. Use `--snapsync-server-enabled` instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace deprecated `Xsnapsync-server-enabled` with `snapsync-server-enabled` in Besu configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6db9c129dc8cc5def5c47214b141012d44e846ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->