### PR TITLE
fix(test): Fixed a test that was relying on an actual DNS instead of a client si…

### DIFF
--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -775,7 +775,7 @@ class HopliteFriendlinessTest {
   fun `p2p config with valid dns instead of IP format should fail`() {
     val p2pConfigToml =
       """
-      ip-address = "test.com"
+      ip-address = "localhost"
       """.trimIndent()
 
     assertThatThrownBy {
@@ -783,7 +783,7 @@ class HopliteFriendlinessTest {
     }.isInstanceOf(ConfigException::class.java)
       .hasMessageContaining("IllegalArgumentException")
       .hasMessageContaining("Invalid IP address format")
-      .hasMessageContaining("test.com")
+      .hasMessageContaining("localhost")
   }
 
   @Test


### PR DESCRIPTION
…de validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the P2P IP address validation test to use `localhost` instead of an external DNS name and adjusts expected error message accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e09888ac474dc82bed4ce8a081099ea318c16e9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->