### PR TITLE
chore: Adding a test to test if it allows longer rounds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,6 +57,8 @@ dependencies {
   integrationTestImplementation(group: 'org.hyperledger.besu.internal', name: 'besu-ethereum-core', classifier: 'test-support')
   integrationTestImplementation("org.hyperledger.besu.internal:besu-ethereum-p2p")
   integrationTestImplementation("org.hyperledger.besu.internal:besu-consensus-qbft-core")
+  integrationTestImplementation("com.squareup.okhttp3:okhttp")
+  integrationTestImplementation("io.javalin:javalin")
   testImplementation(testFixtures(project(":core")))
 }
 

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -12,7 +12,6 @@ import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import maru.config.QbftConfig
-import maru.consensus.qbft.EagerQbftBlockCreator
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.Appender
@@ -24,7 +23,6 @@ import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.Property
 import org.apache.logging.log4j.core.config.plugins.Plugin
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute
-import org.apache.logging.log4j.core.config.plugins.PluginElement
 import org.apache.logging.log4j.core.config.plugins.PluginFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -71,6 +71,8 @@ class MaruLongRunningTransactionTest {
   private val maruFactory = testutils.maru.MaruFactory()
   private lateinit var listAppender: ListAppender
 
+  private val expectedMinBuildTime = 1700L
+
   @BeforeEach
   fun setUp() {
     // Setup Log4j2 Appender
@@ -112,7 +114,7 @@ class MaruLongRunningTransactionTest {
           qbftOptions =
             QbftConfig(
               feeRecipient = maruFactory.qbftValidator.address.reversedArray(),
-              minBlockBuildTime = 1700.milliseconds,
+              minBlockBuildTime = expectedMinBuildTime.milliseconds,
               roundExpiry = 2.seconds,
             ),
         )
@@ -153,33 +155,27 @@ class MaruLongRunningTransactionTest {
       )
     }
 
-    val blocks = networkParticipantStack.besuNode.getMinedBlocks(1)
-    assertThat(blocks).hasSize(1)
+    assertThat(networkParticipantStack.besuNode.getMinedBlocks(1)).hasSize(1)
 
     // 2. Clear logs to only capture Block 2 building
     listAppender.clear()
 
     // 3. Wait for Maru to attempt to build Block 2.
-    // In Round 0, it will create an empty block (since we send no transactions) and it will be rejected (allowEmptyBlocks = false).
-    // Then it will transition to Round 1 and use EagerQbftBlockCreator.
+    // In Round 0, it will create an empty block (since we send no transactions) and it will be rejected.
+    // Then it will transition to Round 1 and use EagerQbftBlockCreator, which sleeps for minBlockBuildTime.
     await.untilAsserted {
-      val fcuLogs =
-        listAppender.events.filter { it.message.formattedMessage.contains("FCU(VALID)") }
-      val getPayloadLogs =
-        listAppender.events.filter {
-          it.message.formattedMessage.contains("Produced #")
+      val fcuLogs = listAppender.events.filter { it.message.formattedMessage.contains("FCU(VALID)") }
+      val getPayloadLogs = listAppender.events.filter { it.message.formattedMessage.contains("Produced #") }
+
+      val hasLongRunningBlock =
+        getPayloadLogs.any { getPayloadLog ->
+          val precedingFcu = fcuLogs.lastOrNull { it.timeMillis <= getPayloadLog.timeMillis }
+          precedingFcu != null && (getPayloadLog.timeMillis - precedingFcu.timeMillis >= expectedMinBuildTime)
         }
 
-      assertThat(fcuLogs).isNotEmpty()
-      assertThat(getPayloadLogs).isNotEmpty()
-
-      // We might have multiple FCU logs (e.g. for Round 0 and Round 1).
-      // The last FCU log corresponds to Round 1.
-      val lastFcuTime = fcuLogs.last().timeMillis
-      val lastGetPayloadTime = getPayloadLogs.last().timeMillis
-
-      val timeDiff = lastGetPayloadTime - lastFcuTime
-      assertThat(timeDiff).isGreaterThanOrEqualTo(1700L)
+      assertThat(hasLongRunningBlock)
+        .withFailMessage("No block building process took >= \$expectedMinBuildTime ms")
+        .isTrue()
     }
 
     // 4. Send a transaction so Block 2 is not empty and gets successfully mined
@@ -191,7 +187,6 @@ class MaruLongRunningTransactionTest {
       )
     }
 
-    val blocksAfterRound1 = networkParticipantStack.besuNode.getMinedBlocks(2)
-    assertThat(blocksAfterRound1).hasSize(2)
+    assertThat(networkParticipantStack.besuNode.getMinedBlocks(2)).hasSize(2)
   }
 }

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -174,7 +174,7 @@ class MaruLongRunningTransactionTest {
         }
 
       assertThat(hasLongRunningBlock)
-        .withFailMessage("No block building process took >= \$expectedMinBuildTime ms")
+        .withFailMessage("No block building process took >= $expectedMinBuildTime ms")
         .isTrue()
     }
 

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -9,23 +9,10 @@
 package maru.app
 
 import java.time.Duration
-import java.util.UUID
-import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import maru.config.QbftConfig
-import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.core.Appender
-import org.apache.logging.log4j.core.Core
-import org.apache.logging.log4j.core.Filter
-import org.apache.logging.log4j.core.LogEvent
-import org.apache.logging.log4j.core.Logger
-import org.apache.logging.log4j.core.appender.AbstractAppender
-import org.apache.logging.log4j.core.config.Property
-import org.apache.logging.log4j.core.config.plugins.Plugin
-import org.apache.logging.log4j.core.config.plugins.PluginAttribute
-import org.apache.logging.log4j.core.config.plugins.PluginFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.hyperledger.besu.tests.acceptance.dsl.blockchain.Amount
@@ -38,33 +25,10 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testutils.Checks.getMinedBlocks
+import testutils.RecordingEngineProxy
 import testutils.SingleNodeNetworkStack
 import testutils.besu.BesuTransactionsHelper
 import testutils.maru.MaruFactory
-
-@Plugin(name = "ListAppender", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
-class ListAppender(
-  name: String,
-  filter: Filter?,
-) : AbstractAppender(name, filter, null, true, Property.EMPTY_ARRAY) {
-  val events: MutableList<LogEvent> = CopyOnWriteArrayList()
-
-  override fun append(event: LogEvent) {
-    events.add(event.toImmutable())
-  }
-
-  fun clear() {
-    events.clear()
-  }
-
-  companion object {
-    @JvmStatic
-    @PluginFactory
-    fun createAppender(
-      @PluginAttribute("name") name: String,
-    ): ListAppender = ListAppender(name, null)
-  }
-}
 
 class MaruLongRunningTransactionTest {
   private lateinit var cluster: Cluster
@@ -72,30 +36,12 @@ class MaruLongRunningTransactionTest {
   private lateinit var transactionsHelper: BesuTransactionsHelper
   private val log = LogManager.getLogger(this.javaClass)
   private val maruFactory = MaruFactory()
-  private lateinit var listAppender: ListAppender
+  private lateinit var proxy: RecordingEngineProxy
 
   private val expectedMinBuildTime = 1700L
 
   @BeforeEach
   fun setUp() {
-    // Setup Log4j2 Appender
-    listAppender = ListAppender.createAppender("ListAppender-${UUID.randomUUID()}")
-    listAppender.start()
-
-    val fcuLogger =
-      LogManager.getLogger(
-        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
-      ) as Logger
-    fcuLogger.addAppender(listAppender)
-    fcuLogger.level = Level.INFO
-
-    val getPayloadLogger =
-      LogManager.getLogger(
-        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
-      ) as Logger
-    getPayloadLogger.addAppender(listAppender)
-    getPayloadLogger.level = Level.INFO
-
     transactionsHelper = BesuTransactionsHelper()
     cluster =
       Cluster(
@@ -106,9 +52,12 @@ class MaruLongRunningTransactionTest {
 
     networkParticipantStack =
       SingleNodeNetworkStack(cluster = cluster) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
+        proxy = RecordingEngineProxy(engineRpcUrl)
+        proxy.start()
+
         maruFactory.buildTestMaruValidatorWithoutP2pPeering(
           ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
-          engineApiRpc = engineRpcUrl,
+          engineApiRpc = proxy.url(),
           dataDir = tmpDir,
           allowEmptyBlocks = false,
           syncingConfig =
@@ -130,33 +79,19 @@ class MaruLongRunningTransactionTest {
   fun tearDown() {
     networkParticipantStack.maruApp.stop().get()
     networkParticipantStack.maruApp.close()
+    proxy.stop()
     cluster.close()
-
-    val fcuLogger =
-      LogManager.getLogger(
-        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
-      ) as Logger
-    fcuLogger.removeAppender(listAppender)
-
-    val getPayloadLogger =
-      LogManager.getLogger(
-        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
-      ) as Logger
-    getPayloadLogger.removeAppender(listAppender)
-
-    listAppender.stop()
   }
 
   @Test
   fun `Maru waits for minBlockBuildTime in Round 1 when empty blocks are rejected`() {
     mineBlockWithTransaction(expectedBlockNumber = 1)
 
-    // Clear logs to only capture Block 2 building
-    listAppender.clear()
+    proxy.clear()
 
-    // In Round 0, it will create an empty block (since we send no transactions) and it will be rejected.
-    // Then it will transition to Round 1 and use EagerQbftBlockCreator, which sleeps for minBlockBuildTime.
-    waitForBlockBuildingGapToExceed(expectedMinBuildTime - 50L)
+    // In Round 0, Maru creates an empty block (no pending transactions) which gets rejected.
+    // It transitions to Round 1 and uses EagerQbftBlockCreator, which sends FCU then sleeps for minBlockBuildTime.
+    waitForFcuToGetPayloadGapToExceed(expectedMinBuildTime - 100L)
 
     mineBlockWithTransaction(expectedBlockNumber = 2)
   }
@@ -172,47 +107,33 @@ class MaruLongRunningTransactionTest {
     assertThat(networkParticipantStack.besuNode.getMinedBlocks(expectedBlockNumber)).hasSize(expectedBlockNumber)
   }
 
-  private fun waitForBlockBuildingGapToExceed(minimumGapMs: Long) {
+  private fun waitForFcuToGetPayloadGapToExceed(minimumGapMs: Long) {
     var maxGap = 0L
     await.atMost(Duration.ofSeconds(30)).untilAsserted {
-      val fcuLogs = listAppender.events.filter { it.message.formattedMessage.contains("FCU(VALID)") }
-      val getPayloadLogs = listAppender.events.filter { it.message.formattedMessage.contains("Produced #") }
+      val fcuCalls = proxy.calls.filter { it.method.startsWith("engine_forkchoiceUpdated") }
+      val getPayloadCalls = proxy.calls.filter { it.method.startsWith("engine_getPayload") }
 
-      val hasLongRunningBlock =
-        getPayloadLogs.any { getPayloadLog ->
-          val precedingFcu = fcuLogs.lastOrNull { it.timeMillis <= getPayloadLog.timeMillis }
+      val hasLongGap =
+        getPayloadCalls.any { getPayload ->
+          val precedingFcu = fcuCalls.lastOrNull { it.timestampMs <= getPayload.timestampMs }
           if (precedingFcu != null) {
-            val gap = getPayloadLog.timeMillis - precedingFcu.timeMillis
-            if (gap > maxGap) {
-              maxGap = gap
-            }
+            val gap = getPayload.timestampMs - precedingFcu.timestampMs
+            if (gap > maxGap) maxGap = gap
             gap >= minimumGapMs
           } else {
             false
           }
         }
 
-      assertThat(hasLongRunningBlock)
+      assertThat(hasLongGap)
         .withFailMessage {
-          val fcuDump = fcuLogs.joinToString("\n") { "FCU at ${it.timeMillis}: ${it.message.formattedMessage}" }
-          val payloadDump =
-            getPayloadLogs.joinToString("\n") { "Payload at ${it.timeMillis}: ${it.message.formattedMessage}" }
-          val allLogsDump =
-            listAppender.events.joinToString("\n") {
-              "[${it.threadName}] ${it.timeMillis}: ${it.message.formattedMessage}"
-            }
+          val callsDump = proxy.calls.joinToString("\n") { "${it.timestampMs}: ${it.method}" }
 
           """
-          No block building process took >= $minimumGapMs ms. Max gap found so far: $maxGap ms
-
-          FCU Logs:
-          $fcuDump
-
-          Payload Logs:
-          $payloadDump
-
-          All Logs:
-          $allLogsDump
+          No FCU-to-getPayload gap took >= $minimumGapMs ms. Max gap: $maxGap ms
+          
+          All Engine API calls:
+          $callsDump
           """.trimIndent()
         }.isTrue()
     }

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package maru.app
+
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import maru.config.QbftConfig
+import maru.consensus.qbft.EagerQbftBlockCreator
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.Core
+import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.Property
+import org.apache.logging.log4j.core.config.plugins.Plugin
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute
+import org.apache.logging.log4j.core.config.plugins.PluginElement
+import org.apache.logging.log4j.core.config.plugins.PluginFactory
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.hyperledger.besu.tests.acceptance.dsl.blockchain.Amount
+import org.hyperledger.besu.tests.acceptance.dsl.condition.net.NetConditions
+import org.hyperledger.besu.tests.acceptance.dsl.node.ThreadBesuNodeRunner
+import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster
+import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.ClusterConfigurationBuilder
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.net.NetTransactions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testutils.Checks.getMinedBlocks
+import testutils.SingleNodeNetworkStack
+import testutils.besu.BesuTransactionsHelper
+
+@Plugin(name = "ListAppender", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
+class ListAppender(
+  name: String,
+  filter: Filter?,
+) : AbstractAppender(name, filter, null, true, Property.EMPTY_ARRAY) {
+  val events: MutableList<LogEvent> = CopyOnWriteArrayList()
+
+  override fun append(event: LogEvent) {
+    events.add(event.toImmutable())
+  }
+
+  fun clear() {
+    events.clear()
+  }
+
+  companion object {
+    @JvmStatic
+    @PluginFactory
+    fun createAppender(
+      @PluginAttribute("name") name: String,
+    ): ListAppender = ListAppender(name, null)
+  }
+}
+
+class MaruLongRunningTransactionTest {
+  private lateinit var cluster: Cluster
+  private lateinit var networkParticipantStack: SingleNodeNetworkStack
+  private lateinit var transactionsHelper: BesuTransactionsHelper
+  private val log = LogManager.getLogger(this.javaClass)
+  private val maruFactory = testutils.maru.MaruFactory()
+  private lateinit var listAppender: ListAppender
+
+  @BeforeEach
+  fun setUp() {
+    // Setup Log4j2 Appender
+    listAppender = ListAppender.createAppender("ListAppender")
+    listAppender.start()
+    val loggerContext = LogManager.getContext(false) as LoggerContext
+    val configuration = loggerContext.configuration
+    val fcuLoggerConfig =
+      configuration.getLoggerConfig(
+        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
+      )
+    fcuLoggerConfig.addAppender(listAppender, Level.INFO, null)
+    fcuLoggerConfig.level = Level.INFO
+
+    val getPayloadLoggerConfig =
+      configuration.getLoggerConfig(
+        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
+      )
+    getPayloadLoggerConfig.addAppender(listAppender, Level.INFO, null)
+    getPayloadLoggerConfig.level = Level.INFO
+
+    loggerContext.updateLoggers()
+
+    transactionsHelper = BesuTransactionsHelper()
+    cluster =
+      Cluster(
+        ClusterConfigurationBuilder().build(),
+        NetConditions(NetTransactions()),
+        ThreadBesuNodeRunner(),
+      )
+
+    networkParticipantStack =
+      SingleNodeNetworkStack(cluster = cluster) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
+        maruFactory.buildTestMaruValidatorWithoutP2pPeering(
+          ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
+          engineApiRpc = engineRpcUrl,
+          dataDir = tmpDir,
+          allowEmptyBlocks = false,
+          qbftOptions =
+            QbftConfig(
+              feeRecipient = maruFactory.qbftValidator.address.reversedArray(),
+              minBlockBuildTime = 1700.milliseconds,
+              roundExpiry = 2.seconds,
+            ),
+        )
+      }
+    networkParticipantStack.maruApp.start().get()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    networkParticipantStack.maruApp.stop().get()
+    networkParticipantStack.maruApp.close()
+    cluster.close()
+
+    val loggerContext = LogManager.getContext(false) as LoggerContext
+    val configuration = loggerContext.configuration
+    val fcuLoggerConfig =
+      configuration.getLoggerConfig(
+        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
+      )
+    fcuLoggerConfig.removeAppender(listAppender.name)
+    val getPayloadLoggerConfig =
+      configuration.getLoggerConfig(
+        "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
+      )
+    getPayloadLoggerConfig.removeAppender(listAppender.name)
+    loggerContext.updateLoggers()
+    listAppender.stop()
+  }
+
+  @Test
+  fun `Maru waits for minBlockBuildTime in Round 1 when empty blocks are rejected`() {
+    // 1. Mine Block 1 successfully to transition out of the initial state
+    transactionsHelper.run {
+      networkParticipantStack.besuNode.sendTransactionAndAssertExecution(
+        logger = log,
+        recipient = createAccount("another account"),
+        amount = Amount.ether(100),
+      )
+    }
+
+    val blocks = networkParticipantStack.besuNode.getMinedBlocks(1)
+    assertThat(blocks).hasSize(1)
+
+    // 2. Clear logs to only capture Block 2 building
+    listAppender.clear()
+
+    // 3. Wait for Maru to attempt to build Block 2.
+    // In Round 0, it will create an empty block (since we send no transactions) and it will be rejected (allowEmptyBlocks = false).
+    // Then it will transition to Round 1 and use EagerQbftBlockCreator.
+    await.untilAsserted {
+      val fcuLogs =
+        listAppender.events.filter { it.message.formattedMessage.contains("FCU(VALID)") }
+      val getPayloadLogs =
+        listAppender.events.filter {
+          it.message.formattedMessage.contains("Produced #")
+        }
+
+      assertThat(fcuLogs).isNotEmpty()
+      assertThat(getPayloadLogs).isNotEmpty()
+
+      // We might have multiple FCU logs (e.g. for Round 0 and Round 1).
+      // The last FCU log corresponds to Round 1.
+      val lastFcuTime = fcuLogs.last().timeMillis
+      val lastGetPayloadTime = getPayloadLogs.last().timeMillis
+
+      val timeDiff = lastGetPayloadTime - lastFcuTime
+      assertThat(timeDiff).isGreaterThanOrEqualTo(1700L)
+    }
+
+    // 4. Send a transaction so Block 2 is not empty and gets successfully mined
+    transactionsHelper.run {
+      networkParticipantStack.besuNode.sendTransactionAndAssertExecution(
+        logger = log,
+        recipient = createAccount("another account"),
+        amount = Amount.ether(100),
+      )
+    }
+
+    val blocksAfterRound1 = networkParticipantStack.besuNode.getMinedBlocks(2)
+    assertThat(blocksAfterRound1).hasSize(2)
+  }
+}

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -8,6 +8,7 @@
  */
 package maru.app
 
+import java.time.Duration
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -18,7 +19,6 @@ import org.apache.logging.log4j.core.Appender
 import org.apache.logging.log4j.core.Core
 import org.apache.logging.log4j.core.Filter
 import org.apache.logging.log4j.core.LogEvent
-import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.Property
 import org.apache.logging.log4j.core.config.plugins.Plugin
@@ -76,25 +76,22 @@ class MaruLongRunningTransactionTest {
   @BeforeEach
   fun setUp() {
     // Setup Log4j2 Appender
-    listAppender = ListAppender.createAppender("ListAppender")
+    listAppender = ListAppender.createAppender("ListAppender-${java.util.UUID.randomUUID()}")
     listAppender.start()
-    val loggerContext = LogManager.getContext(false) as LoggerContext
-    val configuration = loggerContext.configuration
-    val fcuLoggerConfig =
-      configuration.getLoggerConfig(
+
+    val fcuLogger =
+      LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
-      )
-    fcuLoggerConfig.addAppender(listAppender, Level.INFO, null)
-    fcuLoggerConfig.level = Level.INFO
+      ) as org.apache.logging.log4j.core.Logger
+    fcuLogger.addAppender(listAppender)
+    fcuLogger.level = Level.INFO
 
-    val getPayloadLoggerConfig =
-      configuration.getLoggerConfig(
+    val getPayloadLogger =
+      LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
-      )
-    getPayloadLoggerConfig.addAppender(listAppender, Level.INFO, null)
-    getPayloadLoggerConfig.level = Level.INFO
-
-    loggerContext.updateLoggers()
+      ) as org.apache.logging.log4j.core.Logger
+    getPayloadLogger.addAppender(listAppender)
+    getPayloadLogger.level = Level.INFO
 
     transactionsHelper = BesuTransactionsHelper()
     cluster =
@@ -128,25 +125,36 @@ class MaruLongRunningTransactionTest {
     networkParticipantStack.maruApp.close()
     cluster.close()
 
-    val loggerContext = LogManager.getContext(false) as LoggerContext
-    val configuration = loggerContext.configuration
-    val fcuLoggerConfig =
-      configuration.getLoggerConfig(
+    val fcuLogger =
+      LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
-      )
-    fcuLoggerConfig.removeAppender(listAppender.name)
-    val getPayloadLoggerConfig =
-      configuration.getLoggerConfig(
+      ) as org.apache.logging.log4j.core.Logger
+    fcuLogger.removeAppender(listAppender)
+
+    val getPayloadLogger =
+      LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
-      )
-    getPayloadLoggerConfig.removeAppender(listAppender.name)
-    loggerContext.updateLoggers()
+      ) as org.apache.logging.log4j.core.Logger
+    getPayloadLogger.removeAppender(listAppender)
+
     listAppender.stop()
   }
 
   @Test
   fun `Maru waits for minBlockBuildTime in Round 1 when empty blocks are rejected`() {
-    // 1. Mine Block 1 successfully to transition out of the initial state
+    mineBlockWithTransaction(expectedBlockNumber = 1)
+
+    // Clear logs to only capture Block 2 building
+    listAppender.clear()
+
+    // In Round 0, it will create an empty block (since we send no transactions) and it will be rejected.
+    // Then it will transition to Round 1 and use EagerQbftBlockCreator, which sleeps for minBlockBuildTime.
+    waitForBlockBuildingGapToExceed(expectedMinBuildTime - 50L)
+
+    mineBlockWithTransaction(expectedBlockNumber = 2)
+  }
+
+  private fun mineBlockWithTransaction(expectedBlockNumber: Int) {
     transactionsHelper.run {
       networkParticipantStack.besuNode.sendTransactionAndAssertExecution(
         logger = log,
@@ -154,39 +162,50 @@ class MaruLongRunningTransactionTest {
         amount = Amount.ether(100),
       )
     }
+    assertThat(networkParticipantStack.besuNode.getMinedBlocks(expectedBlockNumber)).hasSize(expectedBlockNumber)
+  }
 
-    assertThat(networkParticipantStack.besuNode.getMinedBlocks(1)).hasSize(1)
-
-    // 2. Clear logs to only capture Block 2 building
-    listAppender.clear()
-
-    // 3. Wait for Maru to attempt to build Block 2.
-    // In Round 0, it will create an empty block (since we send no transactions) and it will be rejected.
-    // Then it will transition to Round 1 and use EagerQbftBlockCreator, which sleeps for minBlockBuildTime.
-    await.untilAsserted {
+  private fun waitForBlockBuildingGapToExceed(minimumGapMs: Long) {
+    var maxGap = 0L
+    await.atMost(Duration.ofSeconds(30)).untilAsserted {
       val fcuLogs = listAppender.events.filter { it.message.formattedMessage.contains("FCU(VALID)") }
       val getPayloadLogs = listAppender.events.filter { it.message.formattedMessage.contains("Produced #") }
 
       val hasLongRunningBlock =
         getPayloadLogs.any { getPayloadLog ->
           val precedingFcu = fcuLogs.lastOrNull { it.timeMillis <= getPayloadLog.timeMillis }
-          precedingFcu != null && (getPayloadLog.timeMillis - precedingFcu.timeMillis >= expectedMinBuildTime)
+          if (precedingFcu != null) {
+            val gap = getPayloadLog.timeMillis - precedingFcu.timeMillis
+            if (gap > maxGap) {
+              maxGap = gap
+            }
+            gap >= minimumGapMs
+          } else {
+            false
+          }
         }
 
       assertThat(hasLongRunningBlock)
-        .withFailMessage("No block building process took >= $expectedMinBuildTime ms")
-        .isTrue()
-    }
+        .withFailMessage {
+          val fcuDump = fcuLogs.joinToString("\n") { "FCU at ${it.timeMillis}: ${it.message.formattedMessage}" }
+          val payloadDump =
+            getPayloadLogs.joinToString("\n") { "Payload at ${it.timeMillis}: ${it.message.formattedMessage}" }
+          val allLogsDump =
+            listAppender.events.joinToString("\n") { "${it.timeMillis}: ${it.message.formattedMessage}" }
 
-    // 4. Send a transaction so Block 2 is not empty and gets successfully mined
-    transactionsHelper.run {
-      networkParticipantStack.besuNode.sendTransactionAndAssertExecution(
-        logger = log,
-        recipient = createAccount("another account"),
-        amount = Amount.ether(100),
-      )
-    }
+          """
+          No block building process took >= $minimumGapMs ms. Max gap found so far: $maxGap ms
 
-    assertThat(networkParticipantStack.besuNode.getMinedBlocks(2)).hasSize(2)
+          FCU Logs:
+          $fcuDump
+
+          Payload Logs:
+          $payloadDump
+
+          All Logs:
+          $allLogsDump
+          """.trimIndent()
+        }.isTrue()
+    }
   }
 }

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -9,6 +9,7 @@
 package maru.app
 
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -19,6 +20,7 @@ import org.apache.logging.log4j.core.Appender
 import org.apache.logging.log4j.core.Core
 import org.apache.logging.log4j.core.Filter
 import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.Logger
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.config.Property
 import org.apache.logging.log4j.core.config.plugins.Plugin
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test
 import testutils.Checks.getMinedBlocks
 import testutils.SingleNodeNetworkStack
 import testutils.besu.BesuTransactionsHelper
+import testutils.maru.MaruFactory
 
 @Plugin(name = "ListAppender", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
 class ListAppender(
@@ -68,7 +71,7 @@ class MaruLongRunningTransactionTest {
   private lateinit var networkParticipantStack: SingleNodeNetworkStack
   private lateinit var transactionsHelper: BesuTransactionsHelper
   private val log = LogManager.getLogger(this.javaClass)
-  private val maruFactory = testutils.maru.MaruFactory()
+  private val maruFactory = MaruFactory()
   private lateinit var listAppender: ListAppender
 
   private val expectedMinBuildTime = 1700L
@@ -76,20 +79,20 @@ class MaruLongRunningTransactionTest {
   @BeforeEach
   fun setUp() {
     // Setup Log4j2 Appender
-    listAppender = ListAppender.createAppender("ListAppender-${java.util.UUID.randomUUID()}")
+    listAppender = ListAppender.createAppender("ListAppender-${UUID.randomUUID()}")
     listAppender.start()
 
     val fcuLogger =
       LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
-      ) as org.apache.logging.log4j.core.Logger
+      ) as Logger
     fcuLogger.addAppender(listAppender)
     fcuLogger.level = Level.INFO
 
     val getPayloadLogger =
       LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
-      ) as org.apache.logging.log4j.core.Logger
+      ) as Logger
     getPayloadLogger.addAppender(listAppender)
     getPayloadLogger.level = Level.INFO
 
@@ -108,6 +111,10 @@ class MaruLongRunningTransactionTest {
           engineApiRpc = engineRpcUrl,
           dataDir = tmpDir,
           allowEmptyBlocks = false,
+          syncingConfig =
+            MaruFactory.defaultSyncingConfig.copy(
+              elSyncStatusRefreshInterval = 1000.seconds,
+            ),
           qbftOptions =
             QbftConfig(
               feeRecipient = maruFactory.qbftValidator.address.reversedArray(),
@@ -128,13 +135,13 @@ class MaruLongRunningTransactionTest {
     val fcuLogger =
       LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineForkchoiceUpdated",
-      ) as org.apache.logging.log4j.core.Logger
+      ) as Logger
     fcuLogger.removeAppender(listAppender)
 
     val getPayloadLogger =
       LogManager.getLogger(
         "org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.AbstractEngineGetPayload",
-      ) as org.apache.logging.log4j.core.Logger
+      ) as Logger
     getPayloadLogger.removeAppender(listAppender)
 
     listAppender.stop()
@@ -191,7 +198,9 @@ class MaruLongRunningTransactionTest {
           val payloadDump =
             getPayloadLogs.joinToString("\n") { "Payload at ${it.timeMillis}: ${it.message.formattedMessage}" }
           val allLogsDump =
-            listAppender.events.joinToString("\n") { "${it.timeMillis}: ${it.message.formattedMessage}" }
+            listAppender.events.joinToString("\n") {
+              "[${it.threadName}] ${it.timeMillis}: ${it.message.formattedMessage}"
+            }
 
           """
           No block building process took >= $minimumGapMs ms. Max gap found so far: $maxGap ms

--- a/app/src/integrationTest/kotlin/testutils/RecordingEngineProxy.kt
+++ b/app/src/integrationTest/kotlin/testutils/RecordingEngineProxy.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Consensys Software Inc.
+ *
+ * This file is dual-licensed under either the MIT license or Apache License 2.0.
+ * See the LICENSE-MIT and LICENSE-APACHE files in the repository root for details.
+ *
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+package testutils
+
+import io.javalin.Javalin
+import java.util.concurrent.CopyOnWriteArrayList
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+data class EngineApiCall(
+  val method: String,
+  val timestampMs: Long,
+)
+
+class RecordingEngineProxy(
+  private val targetUrl: String,
+) {
+  val calls: MutableList<EngineApiCall> = CopyOnWriteArrayList()
+  private val httpClient = OkHttpClient()
+  private val javalin =
+    Javalin
+      .create { config ->
+        config.showJavalinBanner = false
+      }.post("/*") { ctx ->
+        val body = ctx.bodyAsBytes()
+        val bodyStr = ctx.body()
+
+        val method = Regex("\"method\"\\s*:\\s*\"([^\"]+)\"").find(bodyStr)?.groupValues?.get(1) ?: "unknown"
+        if (method.startsWith("engine_")) {
+          calls.add(EngineApiCall(method, System.currentTimeMillis()))
+        }
+
+        val proxyRequest =
+          Request
+            .Builder()
+            .url(targetUrl)
+            .post(body.toRequestBody("application/json".toMediaType()))
+            .build()
+
+        httpClient.newCall(proxyRequest).execute().use { response ->
+          ctx.status(response.code)
+          response.body?.bytes()?.let { ctx.result(it) }
+        }
+      }
+
+  fun start() {
+    javalin.start(0)
+  }
+
+  fun stop() {
+    javalin.stop()
+  }
+
+  fun port(): Int = javalin.port()
+
+  fun url(): String = "http://127.0.0.1:${port()}"
+
+  fun clear() {
+    calls.clear()
+  }
+}

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -422,13 +422,14 @@ class MaruFactory(
     overridingP2PNetwork: P2PNetwork? = null,
     allowEmptyBlocks: Boolean = false,
     syncingConfig: SyncingConfig = defaultSyncingConfig,
+    qbftOptions: QbftConfig = validatorQbftOptions,
   ): MaruApp {
     val config =
       buildMaruConfig(
         ethereumJsonRpcUrl = ethereumJsonRpcUrl,
         engineApiRpc = engineApiRpc,
         dataDir = dataDir,
-        qbftOptions = validatorQbftOptions,
+        qbftOptions = qbftOptions,
         allowEmptyBlocks = allowEmptyBlocks,
         syncingConfig = syncingConfig,
       )


### PR DESCRIPTION
⚠️ Please make sure PR Title conforms to https://www.conventionalcommits.org/en/v1.0.0/#specification.
During the merge squash please be mindful to stick to conventional commits as well ⚠️

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to integration test coverage and test utilities, plus adding test-only HTTP dependencies; no production logic is modified.
> 
> **Overview**
> Adds a new integration test (`MaruLongRunningTransactionTest`) that verifies Maru waits roughly `minBlockBuildTime` in QBFT *Round 1* when empty blocks are rejected, by measuring the time gap between `engine_forkchoiceUpdated` and `engine_getPayload` calls.
> 
> Introduces a lightweight `RecordingEngineProxy` test utility (Javalin + OkHttp) to proxy Engine API JSON-RPC requests and record timestamped `engine_*` method invocations, and updates `MaruFactory.buildTestMaruValidatorWithoutP2pPeering` to accept an overridable `qbftOptions` so the test can set `minBlockBuildTime`/`roundExpiry`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62b27cb53cf105dc1a6d6d25b4d92dfc1fcf63f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->