### PR TITLE
chore: Chaos test improvements

### DIFF
--- a/chaos-testing/k3s.mk
+++ b/chaos-testing/k3s.mk
@@ -24,10 +24,12 @@ k3s-setup-kubeconfig:
 	# export KUBECONFIG=~/.kube/k3s-server
 
 k3s-wait:
-	@echo "Waiting for k3s server to be up..."
-	@until docker exec k3s-server sh -c "telnet localhost 6443 </dev/null 2>/dev/null | grep Connected" ; do \
-		sleep 1; \
+	@echo "Waiting for k3s API server to be ready..."
+	@until kubectl --kubeconfig ~/.kube/k3s-server get nodes >/dev/null 2>&1; do \
+		sleep 2; \
 	done
+	@echo "Waiting for k3s node to be Ready..."
+	@kubectl --kubeconfig ~/.kube/k3s-server wait --for=condition=Ready node --all --timeout=120s
 	@echo "k3s server is up and running."
 
 k3s-reload:


### PR DESCRIPTION
⚠️ Please make sure PR Title conforms to https://www.conventionalcommits.org/en/v1.0.0/#specification.
During the merge squash please be mindful to stick to conventional commits as well ⚠️

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to local test/chaos tooling: replaces a port-level readiness probe with `kubectl`-based checks, which could affect developer workflows if kubeconfig creation or kubectl availability differs.
> 
> **Overview**
> Updates `k3s-wait` in `chaos-testing/k3s.mk` to wait for the k3s API via `kubectl --kubeconfig ~/.kube/k3s-server get nodes` instead of a `telnet` port check.
> 
> Adds an explicit `kubectl wait --for=condition=Ready node --all --timeout=120s` step so the target only completes once nodes are actually Ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac1b38acad0e480e8f000fd82103527ad0280bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->