### PR TITLE
feat: #444, expose maru_p2p_network_peer_limit metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Additions and Improvements
 
+- Added `maru_p2p_network_peer_limit` metric exposing the configured maximum number of P2P peers (`p2p.max-peers`), enabling alerts when `maru_p2p_network_peer_count` approaches the limit. (#444)
+
 ### Bug Fixes
 
 - Fixed #506: upgraded Hyperledger Besu from 25.11.0 to 26.2.0 to resolve `NoClassDefFoundError: org/web3j/abi/datatypes/CustomError`.

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
@@ -230,6 +230,12 @@ class P2PNetworkImpl(
           description = "Number of peers connected to the P2P network",
           measurementSupplier = { peerCount.toLong() },
         )
+        metricsFacade.createGauge(
+          category = MaruMetricsCategory.P2P_NETWORK,
+          name = "peer.limit",
+          description = "Configured maximum number of peers (p2p.max-peers)",
+          measurementSupplier = { p2pConfig.maxPeers.toLong() },
+        )
         nodeRecords().forEach(::logEnr)
       }
 


### PR DESCRIPTION
Closes #444

Adds a `peer.limit` gauge in the `P2P_NETWORK` category, which is published as `maru_p2p_network_peer_limit` (matching the existing `maru_p2p_network_peer_count` naming). The gauge reports the configured `p2p.max-peers` value, so operators can build alerts on `peer_count` approaching the limit.

The new gauge is registered alongside the existing `peer.count` gauge in `P2PNetworkImpl.start()`.

## Test plan
- [x] `./gradlew :p2p:compileKotlin`
- [x] `./gradlew :p2p:spotlessCheck`
- [x] `./gradlew :p2p:test --tests maru.p2p.P2PTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only Prometheus gauge sourced from existing `p2pConfig.maxPeers` and updates the changelog; no behavior changes to networking logic.
> 
> **Overview**
> Adds a new P2P metrics gauge, `maru_p2p_network_peer_limit`, which reports the configured `p2p.max-peers` value alongside the existing peer count metric to support alerting when connections approach the configured maximum.
> 
> Updates `CHANGELOG.md` to document the new metric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e33c063e3a54d868bd416e8986b31d43f8b919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->