### PR TITLE
chore(ci): update github runners

### DIFF
--- a/.github/workflows/chaos-testing.yml
+++ b/.github/workflows/chaos-testing.yml
@@ -47,7 +47,7 @@ jobs:
       COMMIT_TAG: ${{ inputs.commit_tag }}
       DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
       DOCKER_REPO_TOKEN: ${{ secrets.DOCKER_REPO_TOKEN }}
-    runs-on: [ gha-runner-scale-set-ubuntu-22.04-amd64-large ]
+    runs-on: [ gha-runner-scale-set-ubuntu-24-amd64-large ]
     name: chaos tests
     # useful for debugging flaky tests.
     #    strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -55,7 +55,7 @@ jobs:
       DOCKER_REPO_TOKEN: ${{ secrets.DOCKER_REPO_TOKEN }}
     outputs:
       tests_outcome: ${{ steps.run_e2e_tests.outcome }}
-    runs-on: [gha-runner-scale-set-ubuntu-22.04-amd64-med]
+    runs-on: [gha-runner-scale-set-ubuntu-24-amd64-med]
     name: e2e tests
     steps:
       - name: Setup upterm session

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
   filter-commit-changes:
     permissions:
       contents: read # for actions/checkout and dorny/paths-filter
-    runs-on: [gha-runner-scale-set-ubuntu-22.04-amd64-small]
+    runs-on: [gha-runner-scale-set-ubuntu-24-amd64-small]
     name: Filter commit changes
     outputs:
       has-changes-requiring-build: ${{ steps.filter.outputs.has-changes-requiring-build }}
@@ -61,7 +61,7 @@ jobs:
     permissions: {} # no permissions needed
     name: Debug Filters outputs
     needs: [ filter-commit-changes ]
-    runs-on: [ gha-runner-scale-set-ubuntu-22.04-amd64-small ]
+    runs-on: [ gha-runner-scale-set-ubuntu-24-amd64-small ]
     steps:
       - name: Debug filter outputs
         run: |

--- a/.github/workflows/maru-build-and-publish.yml
+++ b/.github/workflows/maru-build-and-publish.yml
@@ -64,7 +64,7 @@ jobs:
   build-and-publish:
     permissions:
       contents: read # for actions/checkout
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     name: Maru build and publish
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   compute-version:
     permissions:
       contents: read # for actions/checkout with fetch-depth: 0
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-small
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-small
     name: Compute version
     outputs:
       tag_name: ${{ steps.version.outputs.tag_name }}
@@ -74,7 +74,7 @@ jobs:
     permissions:
       contents: write # for actions/checkout and softprops/action-gh-release
     needs: [compute-version, build-and-publish-docker]
-    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
     name: Create GitHub Release
     steps:
       - name: Checkout

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       DOCKER_ORG_NAME: ${{ secrets.DOCKER_ORG_NAME }}
       DOCKER_REPO_TOKEN: ${{ secrets.DOCKER_REPO_TOKEN }}
-    runs-on: [gha-runner-scale-set-ubuntu-22.04-amd64-med]
+    runs-on: [gha-runner-scale-set-ubuntu-24-amd64-med]
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
     if: ${{ inputs.consensus-client-changed == 'true' }}
     env:
       COMMIT_TAG: ${{ inputs.commit_tag }}
-    runs-on: [ gha-runner-scale-set-ubuntu-22.04-amd64-med ]
+    runs-on: [ gha-runner-scale-set-ubuntu-24-amd64-med ]
     name: maru tests
     #   useful for debugging flaky tests. Comment out Jacoco and Codecov steps because they override the test results.
 #    strategy:


### PR DESCRIPTION
⚠️ Please make sure PR Title conforms to https://www.conventionalcommits.org/en/v1.0.0/#specification.
During the merge squash please be mindful to stick to conventional commits as well ⚠️

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading the runner OS can surface new CI failures due to changed system libraries, Docker/VM behavior, or toolchain defaults, even though no application code is modified.
> 
> **Overview**
> Updates GitHub Actions workflows to run on the `gha-runner-scale-set-ubuntu-24-*` runner sets instead of the `ubuntu-22.04` equivalents across build, test, smoke, e2e, chaos, main, and release pipelines.
> 
> No workflow logic changes beyond the runner/OS migration; the primary impact is CI environment compatibility and potential differences in tooling/runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013e574436540e2732d7400fa25f9c511f0cecdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->