### PR TITLE
debug: log allowEmptyBlocks wireup to triage MaruMultiValidatorTest CI failure

### DIFF
--- a/consensus/src/main/kotlin/maru/consensus/validation/BeaconBlockValidatorFactory.kt
+++ b/consensus/src/main/kotlin/maru/consensus/validation/BeaconBlockValidatorFactory.kt
@@ -13,6 +13,7 @@ import maru.consensus.state.StateTransition
 import maru.core.BeaconBlockHeader
 import maru.database.BeaconChain
 import maru.executionlayer.manager.ExecutionLayerManager
+import org.apache.logging.log4j.LogManager
 
 fun interface BeaconBlockValidatorFactory {
   fun createValidatorForBlock(beaconBlockHeader: BeaconBlockHeader): BlockValidator
@@ -25,6 +26,17 @@ class BeaconBlockValidatorFactoryImpl(
   executionLayerManager: ExecutionLayerManager?,
   val allowEmptyBlocks: Boolean,
 ) : BeaconBlockValidatorFactory {
+  init {
+    LogManager
+      .getLogger(BeaconBlockValidatorFactoryImpl::class.java)
+      .info(
+        "[debug/allowEmptyBlocks] BeaconBlockValidatorFactoryImpl constructed allowEmptyBlocks={} " +
+          "emptyBlockValidatorIncluded={}",
+        allowEmptyBlocks,
+        !allowEmptyBlocks,
+      )
+  }
+
   private val stateRootValidator = StateRootValidator(stateTransition)
   private val bodyRootValidator = BodyRootValidator()
   private val executionPayloadValidator =

--- a/consensus/src/main/kotlin/maru/consensus/validation/BlockValidator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/validation/BlockValidator.kt
@@ -12,6 +12,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapError
+import java.util.concurrent.atomic.AtomicBoolean
 import maru.consensus.qbft.ProposerSelector
 import maru.consensus.qbft.toConsensusRoundIdentifier
 import maru.consensus.state.StateTransition
@@ -26,6 +27,7 @@ import maru.executionlayer.manager.ExecutionLayerManager
 import maru.extensions.encodeHex
 import maru.serialization.rlp.bodyRoot
 import maru.serialization.rlp.stateRoot
+import org.apache.logging.log4j.LogManager
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 interface BlockValidator {
@@ -248,8 +250,20 @@ class ExecutionPayloadValidator(
 }
 
 object EmptyBlockValidator : BlockValidator {
-  override fun validateBlock(block: BeaconBlock): SafeFuture<Result<Unit, BlockValidationError>> =
-    SafeFuture.completedFuture(
+  private val log = LogManager.getLogger(EmptyBlockValidator::class.java)
+  private val firstInvocationLogged = AtomicBoolean(false)
+
+  override fun validateBlock(block: BeaconBlock): SafeFuture<Result<Unit, BlockValidationError>> {
+    if (firstInvocationLogged.compareAndSet(false, true)) {
+      log.info(
+        "[debug/allowEmptyBlocks] EmptyBlockValidator.validateBlock invoked for the first time. " +
+          "blockNumber={} txCount={} stack:",
+        block.beaconBlockHeader.number,
+        block.beaconBlockBody.executionPayload.transactions.size,
+        Throwable("EmptyBlockValidator first-invocation stack trace"),
+      )
+    }
+    return SafeFuture.completedFuture(
       BlockValidator.require(
         block.beaconBlockBody.executionPayload.transactions
           .isNotEmpty(),
@@ -259,4 +273,5 @@ object EmptyBlockValidator : BlockValidator {
           "hash=${block.beaconBlockHeader.hash.encodeHex()}"
       },
     )
+  }
 }

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/SyncSealedBlockImporterFactory.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/SyncSealedBlockImporterFactory.kt
@@ -29,14 +29,23 @@ import maru.consensus.validation.TimestampValidator
 import maru.core.BeaconBlockHeader
 import maru.database.BeaconChain
 import maru.p2p.ValidationResult
+import org.apache.logging.log4j.LogManager
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 class SyncSealedBlockImporterFactory {
+  private val log = LogManager.getLogger(SyncSealedBlockImporterFactory::class.java)
+
   fun create(
     beaconChain: BeaconChain,
     validatorProvider: ValidatorProvider,
     allowEmptyBlocks: Boolean = false,
   ): SealedBeaconBlockImporter<ValidationResult> {
+    log.info(
+      "[debug/allowEmptyBlocks] SyncSealedBlockImporterFactory.create called allowEmptyBlocks={} " +
+        "emptyBlockValidatorIncluded={}",
+      allowEmptyBlocks,
+      !allowEmptyBlocks,
+    )
     val stateTransition = StateTransitionImpl(validatorProvider)
     val sealsVerifier = QuorumOfSealsVerifier(validatorProvider, SCEP256SealVerifier())
 


### PR DESCRIPTION
## Summary

CI run [25536072042](https://github.com/Consensys/maru/actions/runs/25536072042/job/74952075914) failed on `MaruMultiValidatorTest > validators converge to stable block production without round skips` with the test timing out after 240s. The CI report shows the chain in a periodic state where every 3rd block is at `round=1` — the maximum consecutive `round=0` streak is 2, but the test demands 5.

The reason for the round-skip is a Besu QBFT log line:

```
ProposalPayloadValidator - Invalid Proposal Payload: block did not pass validation.
  Reason BlockValidationError(message=Block is empty number=2 executionPayloadBlockNumber=2 hash=…)
```

That error string is **unique to maru's `EmptyBlockValidator`** (`consensus/src/main/kotlin/maru/consensus/validation/BlockValidator.kt:257-259`), but the test sets `allowEmptyBlocks = true` and a source audit shows every chain-construction site correctly omits `EmptyBlockValidator` when the flag is true:

- `BeaconBlockValidatorFactory.kt:32` — QBFT validator path
- `SyncSealedBlockImporterFactory.kt:90` — CL sync importer path
- `QbftFollowerFactory.kt:90` — follower path (not exercised in this test)

So either the runtime `allowEmptyBlocks` value diverges from `config.allowEmptyBlocks=true`, or `EmptyBlockValidator` is being invoked from a code path not in the audit.

## What this PR adds

Three INFO-level diagnostic logs gated by `[debug/allowEmptyBlocks]` so they're easy to grep:

1. **`BeaconBlockValidatorFactoryImpl.<init>`** — logs the runtime `allowEmptyBlocks` value when the QBFT validator factory is constructed.
2. **`SyncSealedBlockImporterFactory.create`** — same, for the CL sync importer factory.
3. **`EmptyBlockValidator.validateBlock`** — once-per-VM (via `AtomicBoolean.compareAndSet`) log on first invocation, with a stack trace, so we can see what's calling it when `allowEmptyBlocks=true` should have removed it from the chain.

## Expected outcomes

| Scenario | Log signature | Diagnosis |
|---|---|---|
| `allowEmptyBlocks=true` logged at both factories AND `EmptyBlockValidator` never logs | rejections come from elsewhere (re-investigate) | n/a |
| `allowEmptyBlocks=false` at one factory | wireup leak — fix the leak | bug in maru |
| `allowEmptyBlocks=true` everywhere AND `EmptyBlockValidator` first-invocation logs with stack | chain composition diverges from source audit | bug in factory ctor / DI |

## Test plan

- [ ] Wait for CI on this branch and inspect the artifact `test reports` from the `testing / maru tests` job.
- [ ] Grep `[debug/allowEmptyBlocks]` in the integration-test logs.
- [ ] Read the `EmptyBlockValidator` first-invocation stack trace if present.
- [ ] Once root cause is identified, **revert this PR** and fix the underlying issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds INFO-level diagnostic logging (including a one-time stack trace) around `allowEmptyBlocks` and `EmptyBlockValidator` usage without changing validation behavior or control flow beyond logging.
> 
> **Overview**
> Adds targeted INFO diagnostics tagged `[debug/allowEmptyBlocks]` to help triage unexpected empty-block rejections.
> 
> Logs the runtime `allowEmptyBlocks` value (and whether `EmptyBlockValidator` is included) when `BeaconBlockValidatorFactoryImpl` is constructed and when `SyncSealedBlockImporterFactory.create` is called. Also updates `EmptyBlockValidator.validateBlock` to emit a **once-per-process** first-invocation log with block metadata and a stack trace to identify the caller path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97e25163d16d3864d298ac2683bb9cc03cd05b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->