### PR TITLE
chore(misc): align spotless with linea-monorepo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,14 +12,16 @@ trim_trailing_whitespace = true
 
 [*.{kt,kts}]
 ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
-ij_kotlin_imports_layout = *, ^
 
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 ij_kotlin_packages_to_use_import_on_demand = unset
+ij_any_line_comment_at_first_column = false
+ij_any_add_a_space_at_line_comment_start = true
 
-# To allow java argument comments like /* argument = */
-ktlint_standard_comment-wrapping = disabled
+[*.{gradle}]
+ij_any_line_comment_at_first_column = false
+ij_any_add_a_space_at_line_comment_start = true
 
 [*.go]
 indent_style = tab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Additions and Improvements
 
+- Formatting rules are aligned with Linea monorepo conventions by upgrading Spotless and ktlint and matching the shared editor configuration.
 - Runtime and build dependencies are aligned with the same versions as the Linea `linea-monorepo` catalog (including Vert.x 5, Teku 25.12, Besu 26.5.0-36cda4f, Jackson, Netty, Tuweni `io.consensys.tuweni`, and related test libraries). SLF4J stays on the 2.0.x BOM so Vert.x 5 and Log4j’s SLF4J 2.x bridge resolve cleanly at runtime. Set `LINEA_LIBS_VERSION` when you need `build.linea.internal` artifacts to match a specific linea-monorepo build.
 
 ### Bug Fixes
@@ -13,4 +14,3 @@
 - Restore execution-layer peering in the in-JVM Besu test harness (`BesuClusterTest` and downstream cluster-based integration tests). Recent Besu acceptance-DSL versions force DiscV5 on while supplying only enode bootnodes, leaving DiscV5 with no bootstrap records and `net_peerCount` stuck at `0`. The harness now opts the test runner back to DiscV4, which the existing enode-bootnode wiring already covers. Requires a Besu version that exposes `BesuNodeConfigurationBuilder.discoveryV5Enabled(boolean)`.
 - Fixed an intermittent failure during the QBFT-to-PoS handover where the first post-merge `engine_forkchoiceUpdated` could be rejected by the execution client with `INVALID_PAYLOAD_ATTRIBUTES` (or `INVALID_WITHDRAWALS_PARAMS` on the V1 endpoint). The proposed `payloadAttributes.timestamp`, derived from `Math.round(wallClockMillis / 1000)`, could tie with the execution head's timestamp depending on sub-second wall-clock alignment. The next block's timestamp is now clamped to be strictly greater than the execution layer head's timestamp.
 - Picked up a Besu fix (consumed via the `26.5.0-36cda4f` build) that makes `BftExecutors.awaitStop` tolerant of the IDLE state. Previously, shutting down a Besu node whose genesis declared QBFT/IBFT but ran PoS from block 0 (`terminalTotalDifficulty=0`) would NPE inside `BftMiningCoordinator.awaitStop` because the BFT timer/processor executors were never started. The NPE surfaced as `Error shutting down node …` and could leave the in-JVM Besu plugin context in an unrecoverable state for subsequent restarts.
-

--- a/api/src/main/kotlin/maru/api/ApiServerImpl.kt
+++ b/api/src/main/kotlin/maru/api/ApiServerImpl.kt
@@ -9,7 +9,6 @@
 package maru.api
 
 import io.javalin.Javalin
-import java.util.concurrent.CompletableFuture
 import maru.VersionProvider
 import maru.api.beacon.GetBlock
 import maru.api.beacon.GetBlockHeader
@@ -24,6 +23,7 @@ import maru.api.node.GetSyncingStatus
 import maru.api.node.GetVersion
 import maru.p2p.NetworkDataProvider
 import maru.syncing.SyncStatusProvider
+import java.util.concurrent.CompletableFuture
 
 class ApiServerImpl(
   val config: Config,
@@ -45,30 +45,29 @@ class ApiServerImpl(
     } else {
       // To support apiserver restarts after stop, we need to create a new Javalin instance
       // https://github.com/javalin/javalin/issues/941
-      app =
-        Javalin
-          .create()
-          .exception(HandlerException::class.java) { e, ctx ->
-            ctx.status(e.code).json(ApiExceptionResponse(e.code, e.message))
-          }.exception(Exception::class.java) { e, ctx ->
-            ctx.status(500).json(ApiExceptionResponse(500, "Internal Server Error"))
-          }.get(GetNetworkIdentity.ROUTE, GetNetworkIdentity(networkDataProvider))
-          .get(GetPeers.ROUTE, GetPeers(networkDataProvider))
-          .get(GetPeer.ROUTE, GetPeer(networkDataProvider))
-          .get(GetPeerCount.ROUTE, GetPeerCount(networkDataProvider))
-          .get(GetVersion.ROUTE, GetVersion(versionProvider))
-          .get(
-            GetSyncingStatus.ROUTE,
-            GetSyncingStatus(
-              syncStatusProvider = syncStatusProvider,
-              isElOnlineProvider = isElOnlineProvider,
-            ),
-          ).get(GetHealth.ROUTE, GetHealth())
-          .get(GetBlockHeader.ROUTE, GetBlockHeader(chainDataProvider))
-          .get(GetBlock.ROUTE, GetBlock(chainDataProvider))
-          .get(GetStateValidator.ROUTE, GetStateValidator(chainDataProvider))
-          .get(GetStateValidators.ROUTE, GetStateValidators(chainDataProvider))
-          .start(config.port.toInt())
+      app = Javalin
+        .create()
+        .exception(HandlerException::class.java) { e, ctx ->
+          ctx.status(e.code).json(ApiExceptionResponse(e.code, e.message))
+        }.exception(Exception::class.java) { e, ctx ->
+          ctx.status(500).json(ApiExceptionResponse(500, "Internal Server Error"))
+        }.get(GetNetworkIdentity.ROUTE, GetNetworkIdentity(networkDataProvider))
+        .get(GetPeers.ROUTE, GetPeers(networkDataProvider))
+        .get(GetPeer.ROUTE, GetPeer(networkDataProvider))
+        .get(GetPeerCount.ROUTE, GetPeerCount(networkDataProvider))
+        .get(GetVersion.ROUTE, GetVersion(versionProvider))
+        .get(
+          GetSyncingStatus.ROUTE,
+          GetSyncingStatus(
+            syncStatusProvider = syncStatusProvider,
+            isElOnlineProvider = isElOnlineProvider,
+          ),
+        ).get(GetHealth.ROUTE, GetHealth())
+        .get(GetBlockHeader.ROUTE, GetBlockHeader(chainDataProvider))
+        .get(GetBlock.ROUTE, GetBlock(chainDataProvider))
+        .get(GetStateValidator.ROUTE, GetStateValidator(chainDataProvider))
+        .get(GetStateValidators.ROUTE, GetStateValidators(chainDataProvider))
+        .start(config.port.toInt())
     }
     return CompletableFuture.completedFuture(Unit)
   }

--- a/api/src/main/kotlin/maru/api/beacon/Extensions.kt
+++ b/api/src/main/kotlin/maru/api/beacon/Extensions.kt
@@ -40,22 +40,20 @@ fun MaruSealedBeaconBlock.toBeaconBlock(): BeaconBlock {
   val blockBody =
     MaruApiBeaconBlockBody(
       randaoReveal = "0x",
-      eth1Data =
-        Eth1Data(
-          depositCount = "0",
-          depositRoot = "0x",
-          blockHash = "0x",
-        ),
+      eth1Data = Eth1Data(
+        depositCount = "0",
+        depositRoot = "0x",
+        blockHash = "0x",
+      ),
       graffiti = "0x",
       proposerSlashings = emptyList(),
       attesterSlashings = emptyList(),
       attestations = currentBlockAttestations + prevBlockAttestations,
       deposits = emptyList(),
-      syncAggregate =
-        SyncAggregate(
-          syncCommitteeBits = "0x",
-          syncCommitteeSignature = "0x",
-        ),
+      syncAggregate = SyncAggregate(
+        syncCommitteeBits = "0x",
+        syncCommitteeSignature = "0x",
+      ),
       executionPayload = maruBody.executionPayload.toExecutionPayload(),
     )
 

--- a/api/src/main/kotlin/maru/api/beacon/GetStateValidator.kt
+++ b/api/src/main/kotlin/maru/api/beacon/GetStateValidator.kt
@@ -50,17 +50,16 @@ class GetStateValidator(
         index = indexedValidator.index.toString(),
         balance = "",
         status = "active_ongoing",
-        validator =
-          Validator(
-            pubkey = indexedValidator.value.address.encodeHex(),
-            withdrawalCredentials = "0x",
-            effectiveBalance = "",
-            slashed = false,
-            activationEligibilityEpoch = "",
-            activationEpoch = "",
-            exitEpoch = "",
-            withdrawableEpoch = "",
-          ),
+        validator = Validator(
+          pubkey = indexedValidator.value.address.encodeHex(),
+          withdrawalCredentials = "0x",
+          effectiveBalance = "",
+          slashed = false,
+          activationEligibilityEpoch = "",
+          activationEpoch = "",
+          exitEpoch = "",
+          withdrawableEpoch = "",
+        ),
       )
 
     val response =

--- a/api/src/main/kotlin/maru/api/beacon/GetStateValidators.kt
+++ b/api/src/main/kotlin/maru/api/beacon/GetStateValidators.kt
@@ -31,17 +31,16 @@ class GetStateValidators(
           index = index.toString(),
           balance = "",
           status = "active_ongoing",
-          validator =
-            Validator(
-              pubkey = validator.address.encodeHex(),
-              withdrawalCredentials = "0x",
-              effectiveBalance = "",
-              slashed = false,
-              activationEligibilityEpoch = "",
-              activationEpoch = "",
-              exitEpoch = "",
-              withdrawableEpoch = "",
-            ),
+          validator = Validator(
+            pubkey = validator.address.encodeHex(),
+            withdrawalCredentials = "0x",
+            effectiveBalance = "",
+            slashed = false,
+            activationEligibilityEpoch = "",
+            activationEpoch = "",
+            exitEpoch = "",
+            withdrawableEpoch = "",
+          ),
         )
       }
     val response =

--- a/api/src/main/kotlin/maru/api/node/GetNetworkIdentity.kt
+++ b/api/src/main/kotlin/maru/api/node/GetNetworkIdentity.kt
@@ -48,12 +48,11 @@ class GetNetworkIdentity(
         enr = networkDataProvider.getEnr() ?: "",
         p2pAddresses = networkDataProvider.getNodeAddresses(),
         discoveryAddresses = networkDataProvider.getDiscoveryAddresses(),
-        metadata =
-          Metadata(
-            seqNumber = "0",
-            attnets = "0x",
-            syncnets = "0x",
-          ),
+        metadata = Metadata(
+          seqNumber = "0",
+          attnets = "0x",
+          syncnets = "0x",
+        ),
       )
     ctx.status(HttpStatus.OK).json(GetNetworkIdentityResponse(networkIdentity))
   }

--- a/api/src/main/kotlin/maru/api/node/GetPeerCount.kt
+++ b/api/src/main/kotlin/maru/api/node/GetPeerCount.kt
@@ -36,13 +36,12 @@ class GetPeerCount(
 
     ctx.json(
       GetPeerCountResponse(
-        data =
-          PeerCountData(
-            disconnected = peerCountMap.getOrDefault(PeerInfo.PeerStatus.DISCONNECTED, 0).toString(),
-            connected = peerCountMap.getOrDefault(PeerInfo.PeerStatus.CONNECTED, 0).toString(),
-            connecting = peerCountMap.getOrDefault(PeerInfo.PeerStatus.CONNECTING, 0).toString(),
-            disconnecting = peerCountMap.getOrDefault(PeerInfo.PeerStatus.DISCONNECTING, 0).toString(),
-          ),
+        data = PeerCountData(
+          disconnected = peerCountMap.getOrDefault(PeerInfo.PeerStatus.DISCONNECTED, 0).toString(),
+          connected = peerCountMap.getOrDefault(PeerInfo.PeerStatus.CONNECTED, 0).toString(),
+          connecting = peerCountMap.getOrDefault(PeerInfo.PeerStatus.CONNECTING, 0).toString(),
+          disconnecting = peerCountMap.getOrDefault(PeerInfo.PeerStatus.DISCONNECTING, 0).toString(),
+        ),
       ),
     )
   }

--- a/api/src/main/kotlin/maru/api/node/GetSyncingStatus.kt
+++ b/api/src/main/kotlin/maru/api/node/GetSyncingStatus.kt
@@ -32,14 +32,13 @@ class GetSyncingStatus(
   override fun handle(ctx: Context) {
     ctx.status(200).json(
       GetSyncingStatusResponse(
-        data =
-          SyncingStatusData(
-            headSlot = syncStatusProvider.getCLSyncTarget().toString(),
-            syncDistance = syncStatusProvider.getBeaconSyncDistance().toString(),
-            isSyncing = !syncStatusProvider.isBeaconChainSynced(),
-            isOptimistic = true, // we only support optimistic mode for now
-            elOffline = !isElOnlineProvider.invoke(),
-          ),
+        data = SyncingStatusData(
+          headSlot = syncStatusProvider.getCLSyncTarget().toString(),
+          syncDistance = syncStatusProvider.getBeaconSyncDistance().toString(),
+          isSyncing = !syncStatusProvider.isBeaconChainSynced(),
+          isOptimistic = true, // we only support optimistic mode for now
+          elOffline = !isElOnlineProvider.invoke(),
+        ),
       ),
     )
   }

--- a/api/src/test/kotlin/maru/api/ApiServerTest.kt
+++ b/api/src/test/kotlin/maru/api/ApiServerTest.kt
@@ -9,7 +9,6 @@
 package maru.api
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import java.util.concurrent.TimeUnit
 import maru.VersionProvider
 import maru.api.beacon.GetBlock
 import maru.api.beacon.GetBlockHeader
@@ -60,6 +59,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 
 class ApiServerTest {
   private val defaultObjectMapper = jacksonObjectMapper()
@@ -142,15 +142,14 @@ class ApiServerTest {
 
   @BeforeEach
   fun beforeEach() {
-    apiServer =
-      ApiServerImpl(
-        config = ApiServerImpl.Config(port = 0u),
-        networkDataProvider = fakeNetworkDataProvider,
-        versionProvider = fakeVersionProvider,
-        chainDataProvider = fakeChainDataProvider,
-        syncStatusProvider = AlwaysSyncedController(beaconChain = fakeBeaconChain),
-        isElOnlineProvider = fakeElOnlineProvider,
-      )
+    apiServer = ApiServerImpl(
+      config = ApiServerImpl.Config(port = 0u),
+      networkDataProvider = fakeNetworkDataProvider,
+      versionProvider = fakeVersionProvider,
+      chainDataProvider = fakeChainDataProvider,
+      syncStatusProvider = AlwaysSyncedController(beaconChain = fakeBeaconChain),
+      isElOnlineProvider = fakeElOnlineProvider,
+    )
     apiServer.start()
     apiServerUrl = "http://localhost:${apiServer.port()}"
     client = OkHttpClient.Builder().readTimeout(0, TimeUnit.SECONDS).build()
@@ -204,12 +203,11 @@ class ApiServerTest {
         enr = fakeNetworkDataProvider.getEnr(),
         p2pAddresses = fakeNetworkDataProvider.getNodeAddresses(),
         discoveryAddresses = fakeNetworkDataProvider.getDiscoveryAddresses(),
-        metadata =
-          Metadata(
-            seqNumber = "0",
-            attnets = "0x",
-            syncnets = "0x",
-          ),
+        metadata = Metadata(
+          seqNumber = "0",
+          attnets = "0x",
+          syncnets = "0x",
+        ),
       )
 
     assert200okResponse(GetNetworkIdentity.ROUTE, GetNetworkIdentityResponse(networkIdentity))
@@ -286,14 +284,13 @@ class ApiServerTest {
     assert200okResponse(
       GetSyncingStatus.ROUTE,
       GetSyncingStatusResponse(
-        data =
-          SyncingStatusData(
-            headSlot = "100",
-            syncDistance = "0",
-            isSyncing = false,
-            isOptimistic = true,
-            elOffline = false,
-          ),
+        data = SyncingStatusData(
+          headSlot = "100",
+          syncDistance = "0",
+          isSyncing = false,
+          isOptimistic = true,
+          elOffline = false,
+        ),
       ),
     )
 
@@ -306,14 +303,13 @@ class ApiServerTest {
     assert200okResponse(
       GetSyncingStatus.ROUTE,
       GetSyncingStatusResponse(
-        data =
-          SyncingStatusData(
-            headSlot = "200",
-            syncDistance = "0",
-            isSyncing = false,
-            isOptimistic = true,
-            elOffline = true,
-          ),
+        data = SyncingStatusData(
+          headSlot = "200",
+          syncDistance = "0",
+          isSyncing = false,
+          isOptimistic = true,
+          elOffline = true,
+        ),
       ),
     )
   }
@@ -336,13 +332,11 @@ class ApiServerTest {
       GetBlockHeaderResponse(
         executionOptimistic = false,
         finalized = false,
-        data =
-          SignedBeaconBlockHeader(
-            message =
-              fakeChainDataProvider.SEALED_BEACON_BLOCK.beaconBlock.beaconBlockHeader
-                .toBeaconBlockHeader(),
-            signature = "0x",
-          ),
+        data = SignedBeaconBlockHeader(
+          message = fakeChainDataProvider.SEALED_BEACON_BLOCK.beaconBlock.beaconBlockHeader
+            .toBeaconBlockHeader(),
+          signature = "0x",
+        ),
       )
 
     assert200okResponse(
@@ -361,11 +355,10 @@ class ApiServerTest {
       GetBlockResponse(
         executionOptimistic = false,
         finalized = false,
-        data =
-          SignedBeaconBlock(
-            message = fakeChainDataProvider.SEALED_BEACON_BLOCK.toBeaconBlock(),
-            signature = "0x",
-          ),
+        data = SignedBeaconBlock(
+          message = fakeChainDataProvider.SEALED_BEACON_BLOCK.toBeaconBlock(),
+          signature = "0x",
+        ),
         version = "maru",
       )
     assert200okResponse(
@@ -384,23 +377,21 @@ class ApiServerTest {
       GetStateValidatorResponse(
         executionOptimistic = false,
         finalized = false,
-        data =
-          ValidatorResponse(
-            index = "0",
-            balance = "",
-            status = "active_ongoing",
-            validator =
-              Validator(
-                pubkey = validator.address.encodeHex(),
-                withdrawalCredentials = "0x",
-                effectiveBalance = "",
-                slashed = false,
-                activationEligibilityEpoch = "",
-                activationEpoch = "",
-                exitEpoch = "",
-                withdrawableEpoch = "",
-              ),
+        data = ValidatorResponse(
+          index = "0",
+          balance = "",
+          status = "active_ongoing",
+          validator = Validator(
+            pubkey = validator.address.encodeHex(),
+            withdrawalCredentials = "0x",
+            effectiveBalance = "",
+            slashed = false,
+            activationEligibilityEpoch = "",
+            activationEpoch = "",
+            exitEpoch = "",
+            withdrawableEpoch = "",
           ),
+        ),
       )
 
     val path =
@@ -418,17 +409,16 @@ class ApiServerTest {
           index = index.toString(),
           balance = "",
           status = "active_ongoing",
-          validator =
-            Validator(
-              pubkey = validator.address.encodeHex(),
-              withdrawalCredentials = "0x",
-              effectiveBalance = "",
-              slashed = false,
-              activationEligibilityEpoch = "",
-              activationEpoch = "",
-              exitEpoch = "",
-              withdrawableEpoch = "",
-            ),
+          validator = Validator(
+            pubkey = validator.address.encodeHex(),
+            withdrawalCredentials = "0x",
+            effectiveBalance = "",
+            slashed = false,
+            activationEligibilityEpoch = "",
+            activationEpoch = "",
+            exitEpoch = "",
+            withdrawableEpoch = "",
+          ),
         )
       }
     val expectedResponse =

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,17 +87,17 @@ jar {
   archiveBaseName = 'maru'
   manifest {
     attributes(
-      'Class-Path': project.configurations.runtimeClasspath
-      .collect {
-        it.getName()
-      }
-      .findAll {
-        it.endsWith('jar')
-      }
-      .join(' '),
-      'Main-Class': 'maru.app.CliEntrypoint',
-      'Multi-Release': 'true'
-      )
+        'Class-Path': project.configurations.runtimeClasspath
+        .collect {
+          it.getName()
+        }
+        .findAll {
+          it.endsWith('jar')
+        }
+        .join(' '),
+        'Main-Class': 'maru.app.CliEntrypoint',
+        'Multi-Release': 'true'
+        )
   }
 }
 
@@ -112,15 +112,13 @@ task integrationTest(type: Test) {
   // To make room for Besu threads
   systemProperties["junit.jupiter.execution.parallel.config.strategy"] = "fixed"
   int maxThreads = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-  systemProperties["junit.jupiter.execution.parallel.config.fixed.max-pool-size"]
-  = maxThreads
-  systemProperties["junit.jupiter.execution.parallel.config.fixed.parallelism"]
-  = maxThreads
+  systemProperties["junit.jupiter.execution.parallel.config.fixed.max-pool-size"] = maxThreads
+  systemProperties["junit.jupiter.execution.parallel.config.fixed.parallelism"] = maxThreads
 
   testLogging {
     events TestLogEvent.FAILED,
-    TestLogEvent.SKIPPED,
-    TestLogEvent.STANDARD_ERROR
+        TestLogEvent.SKIPPED,
+        TestLogEvent.STANDARD_ERROR
     // TestLogEvent.STARTED,
     // TestLogEvent.PASSED
     exceptionFormat TestExceptionFormat.FULL

--- a/app/src/integrationTest/kotlin/maru/app/MaruConsensusSwitchTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruConsensusSwitchTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import java.io.File
-import kotlin.time.Duration.Companion.seconds
 import linea.kotlin.decodeHex
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
@@ -34,6 +32,8 @@ import testutils.besu.ethGetBlockByNumber
 import testutils.besu.startWithRetry
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
 
 class MaruConsensusSwitchTest {
   companion object {
@@ -59,12 +59,11 @@ class MaruConsensusSwitchTest {
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
     // We'll set the switchTimestamp in the test method
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        net,
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      net,
+      ThreadBesuNodeRunner(),
+    )
   }
 
   @AfterEach
@@ -119,22 +118,20 @@ class MaruConsensusSwitchTest {
         "$cancunTimestamp, current timestamp: $currentTimestamp",
     )
 
-    validatorBesuNode =
-      BesuFactory.buildSwitchableBesuQbft(
-        shanghaiTimestamp = shanghaiTimestamp,
-        cancunTimestamp = cancunTimestamp,
-        pragueTimestamp = pragueTimestamp,
-        ttd = ttd,
-        validator = true,
-      )
-    followerBesuNode =
-      BesuFactory.buildSwitchableBesuQbft(
-        shanghaiTimestamp = shanghaiTimestamp,
-        cancunTimestamp = cancunTimestamp,
-        pragueTimestamp = pragueTimestamp,
-        ttd = ttd,
-        validator = false,
-      )
+    validatorBesuNode = BesuFactory.buildSwitchableBesuQbft(
+      shanghaiTimestamp = shanghaiTimestamp,
+      cancunTimestamp = cancunTimestamp,
+      pragueTimestamp = pragueTimestamp,
+      ttd = ttd,
+      validator = true,
+    )
+    followerBesuNode = BesuFactory.buildSwitchableBesuQbft(
+      shanghaiTimestamp = shanghaiTimestamp,
+      cancunTimestamp = cancunTimestamp,
+      pragueTimestamp = pragueTimestamp,
+      ttd = ttd,
+      validator = false,
+    )
     cluster.startWithRetry(validatorBesuNode, followerBesuNode)
 
     // Create a new Maru node with consensus switch configuration
@@ -148,24 +145,22 @@ class MaruConsensusSwitchTest {
         shanghaiTimestamp = shanghaiTimestamp,
         ttd = ttd,
       )
-    validatorMaruNode =
-      maruFactory.buildSwitchableTestMaruValidatorWithP2pPeering(
-        ethereumJsonRpcUrl = validatorEthereumJsonRpcBaseUrl,
-        engineApiRpc = validatorEngineRpcUrl,
-        dataDir = validatorMaruTmpDir.toPath(),
-      )
+    validatorMaruNode = maruFactory.buildSwitchableTestMaruValidatorWithP2pPeering(
+      ethereumJsonRpcUrl = validatorEthereumJsonRpcBaseUrl,
+      engineApiRpc = validatorEngineRpcUrl,
+      dataDir = validatorMaruTmpDir.toPath(),
+    )
     validatorMaruNode.start().get()
 
     val followerEthereumJsonRpcBaseUrl = followerBesuNode.jsonRpcBaseUrl().get()
     val followerEngineRpcUrl = followerBesuNode.engineRpcUrl().get()
 
-    followerMaruNode =
-      maruFactory.buildTestMaruFollowerWithConsensusSwitch(
-        ethereumJsonRpcUrl = followerEthereumJsonRpcBaseUrl,
-        engineApiRpc = followerEngineRpcUrl,
-        dataDir = followerMaruTmpDir.toPath(),
-        validatorPortForStaticPeering = validatorMaruNode.p2pPort(),
-      )
+    followerMaruNode = maruFactory.buildTestMaruFollowerWithConsensusSwitch(
+      ethereumJsonRpcUrl = followerEthereumJsonRpcBaseUrl,
+      engineApiRpc = followerEngineRpcUrl,
+      dataDir = followerMaruTmpDir.toPath(),
+      validatorPortForStaticPeering = validatorMaruNode.p2pPort(),
+    )
     followerMaruNode.start().get()
 
     followerMaruNode.awaitTillMaruHasPeers(1u)

--- a/app/src/integrationTest/kotlin/maru/app/MaruDiscoveryTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruDiscoveryTest.kt
@@ -8,9 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -26,6 +23,9 @@ import testutils.PeeringNodeNetworkStack
 import testutils.besu.BesuFactory
 import testutils.besu.BesuTransactionsHelper
 import testutils.maru.MaruFactory
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 /**
  * Test suite for Maru peer discovery with multiple nodes.
@@ -84,12 +84,11 @@ class MaruDiscoveryTest {
 
     // Initialize test infrastructure
     transactionsHelper = BesuTransactionsHelper()
-    besuCluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    besuCluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     // Create and start all network stacks (Besu + Maru)
     repeat(numberOfNodes) { index ->

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerDelayedStartTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerDelayedStartTest.kt
@@ -35,12 +35,11 @@ class MaruFollowerDelayedStartTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
   }
 
   @AfterEach
@@ -79,10 +78,9 @@ class MaruFollowerDelayedStartTest {
 
     validatorStack.besuNode.assertMinedBlocks(blocksToProduce)
 
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
     cluster.addNode(followerStack.besuNode)
 
     val followerMaruApp =

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerNegativeTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerNegativeTest.kt
@@ -8,9 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import maru.core.Seal
 import maru.p2p.NoOpP2PNetwork
 import maru.p2p.ValidationResult
@@ -32,6 +29,9 @@ import testutils.SpyingP2PNetwork
 import testutils.besu.BesuFactory
 import testutils.besu.BesuTransactionsHelper
 import testutils.maru.MaruFactory
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruFollowerNegativeTest {
   private val cluster: Cluster =

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerNoElTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerNoElTest.kt
@@ -10,13 +10,6 @@ package maru.app
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import java.io.File
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -34,6 +27,13 @@ import testutils.SingleNodeNetworkStack
 import testutils.besu.BesuTransactionsHelper
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruFollowerNoElTest {
   private lateinit var cluster: Cluster
@@ -52,25 +52,23 @@ class MaruFollowerNoElTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
-    validatorStack =
-      SingleNodeNetworkStack(
-        cluster = cluster,
-      ) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
-        maruFactory.buildTestMaruValidatorWithP2pPeering(
-          ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
-          engineApiRpc = engineRpcUrl,
-          dataDir = tmpDir,
-          apiPort = 0u,
-          startApiServer = true,
-        )
-      }
+    validatorStack = SingleNodeNetworkStack(
+      cluster = cluster,
+    ) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
+      maruFactory.buildTestMaruValidatorWithP2pPeering(
+        ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
+        engineApiRpc = engineRpcUrl,
+        dataDir = tmpDir,
+        apiPort = 0u,
+        startApiServer = true,
+      )
+    }
 
     // Start all Besu nodes together for proper peering
     validatorStack.maruApp.start().get()
@@ -81,17 +79,16 @@ class MaruFollowerNoElTest {
     // Get the validator's p2p port after it's started
     val validatorP2pPort = validatorStack.p2pPort
 
-    maruFollower =
-      maruFactory.buildTestMaruFollowerWithP2pPeering(
-        ethereumJsonRpcUrl = null,
-        engineApiRpc = null,
-        dataDir = maruFollowerDataDir.toPath(),
-        validatorPortForStaticPeering = validatorP2pPort,
-        syncingConfig = MaruFactory.defaultSyncingConfig,
-        enablePayloadValidation = false,
-        apiPort = 0u,
-        startApiServer = true,
-      )
+    maruFollower = maruFactory.buildTestMaruFollowerWithP2pPeering(
+      ethereumJsonRpcUrl = null,
+      engineApiRpc = null,
+      dataDir = maruFollowerDataDir.toPath(),
+      validatorPortForStaticPeering = validatorP2pPort,
+      syncingConfig = MaruFactory.defaultSyncingConfig,
+      enablePayloadValidation = false,
+      apiPort = 0u,
+      startApiServer = true,
+    )
 
     maruFollower.start().get()
 

--- a/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruFollowerTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import kotlin.collections.map
-import kotlin.time.Duration.Companion.seconds
 import maru.config.SyncingConfig
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
@@ -33,6 +31,8 @@ import testutils.besu.ethGetBlockByNumber
 import testutils.besu.startWithRetry
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import kotlin.collections.map
+import kotlin.time.Duration.Companion.seconds
 
 class MaruFollowerTest {
   companion object {
@@ -90,19 +90,17 @@ class MaruFollowerTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     validatorStack = PeeringNodeNetworkStack()
 
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
 
     // Start all Besu nodes together for proper peering
     PeeringNodeNetworkStack.startBesuNodes(cluster, validatorStack, followerStack)

--- a/app/src/integrationTest/kotlin/maru/app/MaruLineaFinalizationTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLineaFinalizationTest.kt
@@ -8,9 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import linea.domain.BlockParameter
 import linea.ethapi.EthApiClient
 import linea.web3j.ethapi.createEthApiClient
@@ -33,6 +30,9 @@ import testutils.besu.BesuTransactionsHelper
 import testutils.besu.ethGetBlockByNumber
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruLineaFinalizationTest {
   private lateinit var cluster: Cluster
@@ -49,18 +49,16 @@ class MaruLineaFinalizationTest {
   fun setUp() {
     fakeL1 = FakeL1JsonRpcServer().start()
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     validatorStack = PeeringNodeNetworkStack()
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
 
     PeeringNodeNetworkStack.startBesuNodes(cluster, validatorStack, followerStack)
 
@@ -94,20 +92,18 @@ class MaruLineaFinalizationTest {
 
     assertThat(validatorGenesis).isEqualTo(followerGenesis)
 
-    validatorEthApiClient =
-      createEthApiClient(
-        rpcUrl = validatorStack.besuNode.jsonRpcBaseUrl().get(),
-        log = LogManager.getLogger("clients.l2.test.validator"),
-        requestRetryConfig = null,
-        vertx = null,
-      )
-    followerEthApiClient =
-      createEthApiClient(
-        rpcUrl = followerStack.besuNode.jsonRpcBaseUrl().get(),
-        log = LogManager.getLogger("clients.l2.test.follower"),
-        requestRetryConfig = null,
-        vertx = null,
-      )
+    validatorEthApiClient = createEthApiClient(
+      rpcUrl = validatorStack.besuNode.jsonRpcBaseUrl().get(),
+      log = LogManager.getLogger("clients.l2.test.validator"),
+      requestRetryConfig = null,
+      vertx = null,
+    )
+    followerEthApiClient = createEthApiClient(
+      rpcUrl = followerStack.besuNode.jsonRpcBaseUrl().get(),
+      log = LogManager.getLogger("clients.l2.test.follower"),
+      requestRetryConfig = null,
+      vertx = null,
+    )
     // wait for Besu to be fully started and synced,
     // to avoid CI flakiness due low resources sometimes
     await

--- a/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruLongRunningTransactionTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import maru.config.QbftConfig
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
@@ -27,6 +25,8 @@ import testutils.RecordingEngineProxy
 import testutils.SingleNodeNetworkStack
 import testutils.besu.BesuTransactionsHelper
 import testutils.maru.MaruFactory
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class MaruLongRunningTransactionTest {
   private lateinit var cluster: Cluster
@@ -41,35 +41,33 @@ class MaruLongRunningTransactionTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
+
+    networkParticipantStack = SingleNodeNetworkStack(
+      cluster = cluster,
+    ) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
+      proxy = RecordingEngineProxy(engineRpcUrl)
+      proxy.start()
+
+      maruFactory.buildTestMaruValidatorWithoutP2pPeering(
+        ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
+        engineApiRpc = proxy.url(),
+        dataDir = tmpDir,
+        allowEmptyBlocks = false,
+        syncingConfig = MaruFactory.defaultSyncingConfig.copy(
+          elSyncStatusRefreshInterval = 1000.seconds,
+        ),
+        qbftOptions = QbftConfig(
+          feeRecipient = maruFactory.qbftValidator.address.reversedArray(),
+          minBlockBuildTime = expectedMinBuildTime.milliseconds,
+          roundExpiry = 2.seconds,
+        ),
       )
-
-    networkParticipantStack =
-      SingleNodeNetworkStack(cluster = cluster) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
-        proxy = RecordingEngineProxy(engineRpcUrl)
-        proxy.start()
-
-        maruFactory.buildTestMaruValidatorWithoutP2pPeering(
-          ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
-          engineApiRpc = proxy.url(),
-          dataDir = tmpDir,
-          allowEmptyBlocks = false,
-          syncingConfig =
-            MaruFactory.defaultSyncingConfig.copy(
-              elSyncStatusRefreshInterval = 1000.seconds,
-            ),
-          qbftOptions =
-            QbftConfig(
-              feeRecipient = maruFactory.qbftValidator.address.reversedArray(),
-              minBlockBuildTime = expectedMinBuildTime.milliseconds,
-              roundExpiry = 2.seconds,
-            ),
-        )
-      }
+    }
     networkParticipantStack.maruApp.start().get()
   }
 

--- a/app/src/integrationTest/kotlin/maru/app/MaruManyFollowerElsTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruManyFollowerElsTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.app
 
-import java.net.URI
 import maru.config.ApiEndpointConfig
 import maru.config.FollowersConfig
 import org.apache.logging.log4j.LogManager
@@ -31,6 +30,7 @@ import testutils.besu.ethGetBlockByNumber
 import testutils.besu.startWithRetry
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import java.net.URI
 
 /**
  * Integration tests for Maru with multiple follower execution layer nodes configured via FollowersConfig.
@@ -68,19 +68,17 @@ class MaruManyFollowerElsTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     validatorStack = PeeringNodeNetworkStack()
 
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
 
     followerBesu = BesuFactory.buildTestBesu(validator = false)
 

--- a/app/src/integrationTest/kotlin/maru/app/MaruMultiValidatorTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruMultiValidatorTest.kt
@@ -9,10 +9,6 @@
 package maru.app
 
 import io.libp2p.etc.types.fromHex
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import maru.consensus.qbft.ProposerSelectorImpl
 import maru.core.SealedBeaconBlock
 import maru.core.Validator
@@ -35,6 +31,10 @@ import testutils.PeeringNodeNetworkStack
 import testutils.besu.BesuFactory
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruMultiValidatorTest {
   companion object {
@@ -73,12 +73,11 @@ class MaruMultiValidatorTest {
 
   @BeforeEach
   fun setUp() {
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
     val besuBuilder = { BesuFactory.buildTestBesu(validator = false) }
     stack0 = PeeringNodeNetworkStack(besuBuilder)
     stack1 = PeeringNodeNetworkStack(besuBuilder)
@@ -358,13 +357,12 @@ class MaruMultiValidatorTest {
 
     // Verify blocks consistent across all 4 validators
     checkAllValidatorBlocksAreTheSame(
-      validatorBlocks =
-        listOf(
-          { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
-          { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
-          { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
-          { stack3.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
-        ),
+      validatorBlocks = listOf(
+        { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
+        { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
+        { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
+        { stack3.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, verifyCount) },
+      ),
       blocksToMetadata = ::clBlocksToMetadata,
     )
 
@@ -407,12 +405,11 @@ class MaruMultiValidatorTest {
     val verifyStart = heightAfterStop + 1uL
     val count = STABLE_BLOCKS.toULong()
     checkAllValidatorBlocksAreTheSame(
-      validatorBlocks =
-        listOf(
-          { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-        ),
+      validatorBlocks = listOf(
+        { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+      ),
       blocksToMetadata = ::clBlocksToMetadata,
     )
     log.info("Block production continued successfully with 3 of 4 validators")
@@ -463,12 +460,11 @@ class MaruMultiValidatorTest {
     val verifyStart = heightAfterStop + 1uL
     val count = STABLE_BLOCKS.toULong()
     checkAllValidatorBlocksAreTheSame(
-      validatorBlocks =
-        listOf(
-          { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-        ),
+      validatorBlocks = listOf(
+        { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+      ),
       blocksToMetadata = ::clBlocksToMetadata,
     )
     log.info("Block production recovered after quorum was restored")
@@ -510,13 +506,12 @@ class MaruMultiValidatorTest {
     val verifyStart = heightBeforeRestart + 1uL
     val count = STABLE_BLOCKS.toULong()
     checkAllValidatorBlocksAreTheSame(
-      validatorBlocks =
-        listOf(
-          { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-          { stack3.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
-        ),
+      validatorBlocks = listOf(
+        { stack0.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack1.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack2.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+        { stack3.maruApp.beaconChain.getSealedBeaconBlocks(verifyStart, count) },
+      ),
       blocksToMetadata = ::clBlocksToMetadata,
     )
     log.info("Block production resumed successfully after full restart")

--- a/app/src/integrationTest/kotlin/maru/app/MaruPeerScoringTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruPeerScoringTest.kt
@@ -8,12 +8,6 @@
  */
 package maru.app
 
-import java.lang.Thread.sleep
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import linea.domain.BlockParameter
 import linea.ethapi.EthApiClient
 import linea.timer.JvmTimerFactory
@@ -48,6 +42,12 @@ import testutils.besu.BesuFactory
 import testutils.besu.BesuTransactionsHelper
 import testutils.besu.ethGetBlockByNumber
 import testutils.maru.MaruFactory
+import java.lang.Thread.sleep
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruPeerScoringTest {
   private lateinit var besuCluster: Cluster
@@ -153,18 +153,16 @@ class MaruPeerScoringTest {
     timerFactory: TimerFactory,
   ): MaruNodeSetup {
     transactionsHelper = BesuTransactionsHelper()
-    besuCluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    besuCluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     validatorStack = PeeringNodeNetworkStack()
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
 
     PeeringNodeNetworkStack.startBesuNodes(besuCluster, validatorStack, followerStack)
 
@@ -178,18 +176,18 @@ class MaruPeerScoringTest {
         discoveryPort = 0u,
         cooldownPeriod = validatorCooldownPeriod,
         p2pNetworkFactory = {
-          privateKeyBytes: ByteArray,
-          p2pConfig: P2PConfig,
-          chainId: UInt,
-          serDe: SerDe<SealedBeaconBlock>,
-          metricsFacade: MetricsFacade,
-          metricsSystem: MetricsSystem,
-          statusManager: StatusManager,
-          chain: BeaconChain,
-          forkIdHashManager: ForkPeeringManager,
-          isBlockImportEnabledProvider: () -> Boolean,
-          p2pState: P2PState,
-          timerFactory: TimerFactory,
+            privateKeyBytes: ByteArray,
+            p2pConfig: P2PConfig,
+            chainId: UInt,
+            serDe: SerDe<SealedBeaconBlock>,
+            metricsFacade: MetricsFacade,
+            metricsSystem: MetricsSystem,
+            statusManager: StatusManager,
+            chain: BeaconChain,
+            forkIdHashManager: ForkPeeringManager,
+            isBlockImportEnabledProvider: () -> Boolean,
+            p2pState: P2PState,
+            timerFactory: TimerFactory,
           ->
           MisbehavingP2PNetwork(
             privateKeyBytes = privateKeyBytes,
@@ -217,13 +215,12 @@ class MaruPeerScoringTest {
         ?.asEnr()
     log.info("Validator ENR: $bootnodeEnr")
 
-    validatorEthApiClient =
-      createEthApiClient(
-        rpcUrl = validatorStack.besuNode.jsonRpcBaseUrl().get(),
-        log = LogManager.getLogger("clients.l2.test.validator"),
-        requestRetryConfig = null,
-        vertx = null,
-      )
+    validatorEthApiClient = createEthApiClient(
+      rpcUrl = validatorStack.besuNode.jsonRpcBaseUrl().get(),
+      log = LogManager.getLogger("clients.l2.test.validator"),
+      requestRetryConfig = null,
+      vertx = null,
+    )
 
     await
       .atMost(20.seconds.toJavaDuration())
@@ -266,13 +263,12 @@ class MaruPeerScoringTest {
 
     followerStack.maruApp.start().get()
 
-    followerEthApiClient =
-      createEthApiClient(
-        rpcUrl = followerStack.besuNode.jsonRpcBaseUrl().get(),
-        log = LogManager.getLogger("clients.l2.test.follower"),
-        requestRetryConfig = null,
-        vertx = null,
-      )
+    followerEthApiClient = createEthApiClient(
+      rpcUrl = followerStack.besuNode.jsonRpcBaseUrl().get(),
+      log = LogManager.getLogger("clients.l2.test.follower"),
+      requestRetryConfig = null,
+      vertx = null,
+    )
     // wait for Besu to be fully started,
     // to avoid CI flakiness due to low resources sometimes
     await

--- a/app/src/integrationTest/kotlin/maru/app/MaruQbftValidatorTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruQbftValidatorTest.kt
@@ -53,23 +53,23 @@ class MaruQbftValidatorTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     spyingP2pNetwork = SpyingP2PNetwork(NoOpP2PNetwork)
-    networkParticipantStack =
-      SingleNodeNetworkStack(cluster = cluster) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
-        maruFactory.buildTestMaruValidatorWithoutP2pPeering(
-          ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
-          engineApiRpc = engineRpcUrl,
-          dataDir = tmpDir,
-          overridingP2PNetwork = spyingP2pNetwork,
-        )
-      }
+    networkParticipantStack = SingleNodeNetworkStack(
+      cluster = cluster,
+    ) { ethereumJsonRpcBaseUrl, engineRpcUrl, tmpDir ->
+      maruFactory.buildTestMaruValidatorWithoutP2pPeering(
+        ethereumJsonRpcUrl = ethereumJsonRpcBaseUrl,
+        engineApiRpc = engineRpcUrl,
+        dataDir = tmpDir,
+        overridingP2PNetwork = spyingP2pNetwork,
+      )
+    }
     networkParticipantStack.maruApp.start().get()
   }
 

--- a/app/src/integrationTest/kotlin/maru/app/MaruStartFromPragueTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruStartFromPragueTest.kt
@@ -8,10 +8,6 @@
  */
 package maru.app
 
-import java.io.File
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
-import kotlin.time.toJavaDuration
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -30,6 +26,10 @@ import testutils.besu.BesuTransactionsHelper
 import testutils.besu.latestBlock
 import testutils.besu.startWithRetry
 import testutils.maru.MaruFactory
+import java.io.File
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaDuration
 
 class MaruStartFromPragueTest {
   private lateinit var cluster: Cluster
@@ -46,12 +46,11 @@ class MaruStartFromPragueTest {
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
     // We'll set the switchTimestamp in the test method
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        net,
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      net,
+      ThreadBesuNodeRunner(),
+    )
   }
 
   @AfterEach
@@ -66,13 +65,12 @@ class MaruStartFromPragueTest {
   fun `should start QBFT consensus from prague fork allowing empty blocks`() {
     val besuNode = BesuFactory.buildTestBesu()
     cluster.startWithRetry(besuNode)
-    maruNode =
-      maruFactory.buildTestMaruValidatorWithoutP2pPeering(
-        ethereumJsonRpcUrl = besuNode.jsonRpcBaseUrl().get(),
-        engineApiRpc = besuNode.engineRpcUrl().get(),
-        dataDir = tmpDir.toPath(),
-        allowEmptyBlocks = true,
-      )
+    maruNode = maruFactory.buildTestMaruValidatorWithoutP2pPeering(
+      ethereumJsonRpcUrl = besuNode.jsonRpcBaseUrl().get(),
+      engineApiRpc = besuNode.engineRpcUrl().get(),
+      dataDir = tmpDir.toPath(),
+      allowEmptyBlocks = true,
+    )
     maruNode.start().get()
 
     await
@@ -88,13 +86,12 @@ class MaruStartFromPragueTest {
   fun `should start QBFT consensus from prague fork not allowing empty blocks`() {
     val besuNode = BesuFactory.buildTestBesu()
     cluster.startWithRetry(besuNode)
-    maruNode =
-      maruFactory.buildTestMaruValidatorWithP2pPeering(
-        ethereumJsonRpcUrl = besuNode.jsonRpcBaseUrl().get(),
-        engineApiRpc = besuNode.engineRpcUrl().get(),
-        dataDir = tmpDir.toPath(),
-        allowEmptyBlocks = false,
-      )
+    maruNode = maruFactory.buildTestMaruValidatorWithP2pPeering(
+      ethereumJsonRpcUrl = besuNode.jsonRpcBaseUrl().get(),
+      engineApiRpc = besuNode.engineRpcUrl().get(),
+      dataDir = tmpDir.toPath(),
+      allowEmptyBlocks = false,
+    )
     maruNode.start().get()
     val totalBlocksToProduce = 5
     repeat(totalBlocksToProduce) {

--- a/app/src/integrationTest/kotlin/maru/app/MaruSupportsOsakaTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruSupportsOsakaTest.kt
@@ -8,10 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
-import kotlin.time.toJavaDuration
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.ElFork
@@ -26,6 +22,10 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.time.toJavaDuration
 
 class MaruSupportsOsakaTest {
   private lateinit var cluster: MaruCluster
@@ -34,11 +34,10 @@ class MaruSupportsOsakaTest {
   fun beforeEach() {
     configureLoggers(
       rootLevel = Level.WARN,
-      logLevels =
-        listOf(
-          "maru" to Level.INFO,
-          "maru.clients" to Level.DEBUG,
-        ),
+      logLevels = listOf(
+        "maru" to Level.INFO,
+        "maru.clients" to Level.DEBUG,
+      ),
     )
   }
 
@@ -51,17 +50,15 @@ class MaruSupportsOsakaTest {
 
   @Test
   fun `should run network starting from Osaka`() {
-    cluster =
-      MaruCluster(
-        blockTimeSeconds = 1u,
-        chainForks =
-          mapOf(
-            Instant.fromEpochSeconds(0) to ChainFork(clFork = ClFork.QBFT_PHASE0, elFork = ElFork.Osaka),
-          ),
-      ).addNode(NodeRole.Sequencer, withBesuEl = true)
-        .addNode(NodeRole.Follower, withBesuEl = true) {
-          it.staticPeers(listOf("sequencer"))
-        }.start()
+    cluster = MaruCluster(
+      blockTimeSeconds = 1u,
+      chainForks = mapOf(
+        Instant.fromEpochSeconds(0) to ChainFork(clFork = ClFork.QBFT_PHASE0, elFork = ElFork.Osaka),
+      ),
+    ).addNode(NodeRole.Sequencer, withBesuEl = true)
+      .addNode(NodeRole.Follower, withBesuEl = true) {
+        it.staticPeers(listOf("sequencer"))
+      }.start()
 
     // Assert Maru is creating Blocks and Synced
     await().atMost(60.seconds.toJavaDuration()).untilAsserted {
@@ -75,25 +72,23 @@ class MaruSupportsOsakaTest {
   @Test
   fun `should switch from Prague to Osaka`() {
     val osakaTimestamp = Clock.System.now().plus(30.seconds)
-    cluster =
-      MaruCluster(
-        chainForks =
-          mapOf(
-            Instant.fromEpochSeconds(0) to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Prague,
-              ),
-            osakaTimestamp to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Osaka,
-              ),
+    cluster = MaruCluster(
+      chainForks = mapOf(
+        Instant.fromEpochSeconds(0) to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Prague,
           ),
-      ).addNode("sequencer", addBesu = true)
-        .addNode(NodeRole.Follower, withBesuEl = true) {
-          it.staticPeers(listOf("sequencer"))
-        }.start()
+        osakaTimestamp to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Osaka,
+          ),
+      ),
+    ).addNode("sequencer", addBesu = true)
+      .addNode(NodeRole.Follower, withBesuEl = true) {
+        it.staticPeers(listOf("sequencer"))
+      }.start()
     // Assert Maru is creating Blocks and Synced
     await().atMost(60.seconds.toJavaDuration()).untilAsserted {
       assertThat(

--- a/app/src/integrationTest/kotlin/maru/app/MaruValidatorRestartTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruValidatorRestartTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import maru.test.util.NetworkUtil.findFreePorts
 import org.apache.logging.log4j.LogManager
 import org.awaitility.kotlin.await
@@ -28,6 +26,8 @@ import testutils.besu.BesuFactory
 import testutils.besu.BesuTransactionsHelper
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruValidatorRestartTest {
   private lateinit var cluster: Cluster
@@ -39,18 +39,16 @@ class MaruValidatorRestartTest {
 
   @BeforeEach
   fun setup() {
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
     transactionsHelper = BesuTransactionsHelper()
     validatorStack = PeeringNodeNetworkStack()
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
   }
 
   @AfterEach

--- a/app/src/integrationTest/kotlin/maru/app/MaruValidatorTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/MaruValidatorTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import maru.config.SyncingConfig
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
@@ -31,6 +29,8 @@ import testutils.besu.BesuTransactionsHelper
 import testutils.besu.ethGetBlockByNumber
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruValidatorTest {
   private lateinit var cluster: Cluster
@@ -79,19 +79,17 @@ class MaruValidatorTest {
   @BeforeEach
   fun setUp() {
     transactionsHelper = BesuTransactionsHelper()
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().awaitPeerDiscovery(false).build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().awaitPeerDiscovery(false).build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
 
     validatorStack = PeeringNodeNetworkStack()
 
-    followerStack =
-      PeeringNodeNetworkStack(
-        besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
-      )
+    followerStack = PeeringNodeNetworkStack(
+      besuBuilder = { BesuFactory.buildTestBesu(validator = false) },
+    )
 
     // FollowerStack's besu node should be the first to start to ensure that it becomes the cluster's Bootnode
     // This way in the test where ValidatorStack's besu node is restarted, it can still peer within the cluster.

--- a/app/src/integrationTest/kotlin/maru/app/QbftConsensus4ValidatorBenchmarkTest.kt
+++ b/app/src/integrationTest/kotlin/maru/app/QbftConsensus4ValidatorBenchmarkTest.kt
@@ -13,9 +13,6 @@ import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.distribution.HistogramSnapshot
 import io.vertx.micrometer.backends.BackendRegistries
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.milliseconds
 import maru.crypto.SecpCrypto
 import org.apache.logging.log4j.LogManager
 import org.assertj.core.api.Assertions.assertThat
@@ -32,6 +29,9 @@ import testutils.PeeringNodeNetworkStack
 import testutils.besu.BesuFactory
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Benchmark measuring QBFT consensus latency with 4 validators on the local JVM — no containers.
@@ -68,12 +68,11 @@ class QbftConsensus4ValidatorBenchmarkTest {
 
   @BeforeEach
   fun setUp() {
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
     val besuBuilder = { BesuFactory.buildTestBesu(validator = false) }
     stack0 = PeeringNodeNetworkStack(besuBuilder)
     stack1 = PeeringNodeNetworkStack(besuBuilder)
@@ -301,7 +300,11 @@ class QbftConsensus4ValidatorBenchmarkTest {
     log.info("  ── Phase breakdown ──")
     printHistogram("phase.proposal", "phase.proposal", "timer → PROPOSAL received (non-proposer only)")
     printHistogram("phase.prepare.first", "phase.prepare.first", "start → first PREPARE received")
-    printHistogram("phase.prepare.spread", "phase.prepare.spread", "first → last PREPARE (parallel validation spread)")
+    printHistogram(
+      "phase.prepare.spread",
+      "phase.prepare.spread",
+      "first → last PREPARE (parallel validation spread)",
+    )
     printHistogram("phase.commit.first", "phase.commit.first", "last PREPARE → first COMMIT")
     printHistogram("phase.commit.spread", "phase.commit.spread", "first → last COMMIT (gossip jitter)")
     printHistogram(

--- a/app/src/integrationTest/kotlin/testutils/Checks.kt
+++ b/app/src/integrationTest/kotlin/testutils/Checks.kt
@@ -8,9 +8,6 @@
  */
 package testutils
 
-import java.math.BigInteger
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
@@ -18,6 +15,9 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode
 import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.protocol.core.methods.response.EthBlock
 import testutils.besu.BesuFactory
+import java.math.BigInteger
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 /**
  * Metadata for block comparison containing essential block identity.
@@ -124,7 +124,8 @@ object Checks {
       Assertions
         .assertThat(actualBlockTime)
         .withFailMessage(
-          "invalid block time: expected=${BesuFactory.MIN_BLOCK_TIME} actual=$actualBlockTime blocks timestamps=$timestampsSeconds",
+          "invalid block time: expected=${BesuFactory.MIN_BLOCK_TIME} actual=$actualBlockTime " +
+            "blocks timestamps=$timestampsSeconds",
         ).isEqualTo(BesuFactory.MIN_BLOCK_TIME)
       timestamp
     }

--- a/app/src/integrationTest/kotlin/testutils/MisbehavingP2PNetwork.kt
+++ b/app/src/integrationTest/kotlin/testutils/MisbehavingP2PNetwork.kt
@@ -8,7 +8,6 @@
  */
 package testutils
 
-import kotlin.time.Duration
 import linea.timer.TimerFactory
 import maru.config.P2PConfig
 import maru.core.SealedBeaconBlock
@@ -22,6 +21,7 @@ import maru.p2p.messages.BlockRetrievalStrategy
 import maru.p2p.messages.StatusManager
 import maru.serialization.SerDe
 import net.consensys.linea.metrics.MetricsFacade
+import kotlin.time.Duration
 import org.hyperledger.besu.plugin.services.MetricsSystem as BesuMetricsSystem
 
 class MisbehavingP2PNetwork(

--- a/app/src/integrationTest/kotlin/testutils/PeeringNodeNetworkStack.kt
+++ b/app/src/integrationTest/kotlin/testutils/PeeringNodeNetworkStack.kt
@@ -8,13 +8,13 @@
  */
 package testutils
 
-import java.nio.file.Files
-import java.nio.file.Path
 import maru.app.MaruApp
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster
 import testutils.besu.BesuFactory
 import testutils.besu.startWithRetry
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * NetworkParticipantStack for multi-node scenarios with proper peering support.

--- a/app/src/integrationTest/kotlin/testutils/RecordingEngineProxy.kt
+++ b/app/src/integrationTest/kotlin/testutils/RecordingEngineProxy.kt
@@ -9,11 +9,11 @@
 package testutils
 
 import io.javalin.Javalin
-import java.util.concurrent.CopyOnWriteArrayList
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.CopyOnWriteArrayList
 
 data class EngineApiCall(
   val method: String,

--- a/app/src/integrationTest/kotlin/testutils/SingleNodeNetworkStack.kt
+++ b/app/src/integrationTest/kotlin/testutils/SingleNodeNetworkStack.kt
@@ -8,13 +8,13 @@
  */
 package testutils
 
-import java.nio.file.Files
-import java.nio.file.Path
 import maru.app.MaruApp
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster
 import testutils.besu.BesuFactory
 import testutils.besu.startWithRetry
+import java.nio.file.Files
+import java.nio.file.Path
 
 /**
  * Original NetworkParticipantStack implementation for single node scenarios.

--- a/app/src/integrationTest/kotlin/testutils/SpyingP2PNetwork.kt
+++ b/app/src/integrationTest/kotlin/testutils/SpyingP2PNetwork.kt
@@ -8,7 +8,6 @@
  */
 package testutils
 
-import java.util.concurrent.CopyOnWriteArrayList
 import maru.consensus.qbft.adapters.QbftBlockCodecAdapter
 import maru.core.SealedBeaconBlock
 import maru.p2p.GossipMessageType
@@ -24,6 +23,7 @@ import org.hyperledger.besu.consensus.qbft.core.messagedata.ProposalMessageData
 import org.hyperledger.besu.consensus.qbft.core.messagedata.RoundChangeMessageData
 import org.hyperledger.besu.consensus.qbft.core.types.QbftMessage
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CopyOnWriteArrayList
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData as BesuMessageData
 
 class SpyingP2PNetwork(

--- a/app/src/main/kotlin/maru/app/CliEntrypoint.kt
+++ b/app/src/main/kotlin/maru/app/CliEntrypoint.kt
@@ -8,9 +8,9 @@
  */
 package maru.app
 
-import kotlin.system.exitProcess
 import org.apache.logging.log4j.LogManager
 import picocli.CommandLine
+import kotlin.system.exitProcess
 
 object CliEntrypoint {
   private val log = LogManager.getLogger(this.javaClass)

--- a/app/src/main/kotlin/maru/app/ConsensusMetrics.kt
+++ b/app/src/main/kotlin/maru/app/ConsensusMetrics.kt
@@ -8,12 +8,12 @@
  */
 package maru.app
 
-import java.util.concurrent.ConcurrentHashMap
 import maru.core.SealedBeaconBlock
 import maru.metrics.MaruMetricsCategory
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import org.hyperledger.besu.consensus.qbft.core.messagedata.QbftV1
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Micrometer-based consensus metrics that record QBFT phase latencies as histograms,
@@ -54,7 +54,7 @@ class ConsensusMetrics(
   private val firstCommitTimes = ConcurrentHashMap<Long, Long>()
   private val lastCommitTimes = ConcurrentHashMap<Long, Long>()
 
-  // ── Micrometer histograms (one per role) ────────────────────────────────────
+  // Micrometer histograms (one per role).
 
   private fun histogram(
     metricsFacade: MetricsFacade,
@@ -110,7 +110,7 @@ class ConsensusMetrics(
   private val phaseImportNonProposer =
     histogram(metricsFacade, "phase.import", "Last COMMIT to block committed (ms)", ROLE_NON_PROPOSER)
 
-  // ── recording methods ──────────────────────────────────────────────────────
+  // Recording methods.
 
   /** Called when BLOCK_TIMER_EXPIRY fires on this validator. */
   fun recordTimerFire(blockNumber: Long) {

--- a/app/src/main/kotlin/maru/app/MaruApp.kt
+++ b/app/src/main/kotlin/maru/app/MaruApp.kt
@@ -9,8 +9,6 @@
 package maru.app
 
 import io.vertx.core.Vertx
-import java.time.Clock
-import java.util.concurrent.CompletableFuture
 import linea.timer.TimerFactory
 import maru.api.ApiServer
 import maru.config.MaruConfig
@@ -43,6 +41,8 @@ import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.plugin.services.MetricsSystem
 import org.web3j.protocol.Web3j
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
+import java.time.Clock
+import java.util.concurrent.CompletableFuture
 
 interface LongRunningCloseable :
   LongRunningService,
@@ -288,11 +288,10 @@ class MaruApp(
     val protocolStarter =
       ProtocolStarter(
         forksSchedule = beaconGenesisConfig,
-        protocolFactory =
-          OmniProtocolFactory(
-            qbftConsensusFactory = qbftFactory,
-            difficultyAwareQbftFactory = difficultyAwareQbftFactory,
-          ),
+        protocolFactory = OmniProtocolFactory(
+          qbftConsensusFactory = qbftFactory,
+          difficultyAwareQbftFactory = difficultyAwareQbftFactory,
+        ),
         nextBlockTimestampProvider = nextTargetBlockTimestampProvider,
         forkTransitionCheckInterval = config.forkTransition.protocolTransitionPollingInterval,
         forkTransitionNotifier = forkTransitionSubscriptionManager,

--- a/app/src/main/kotlin/maru/app/MaruAppCli.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppCli.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import java.io.File
-import java.util.concurrent.Callable
 import maru.config.MaruConfigLoader
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.core.LoggerContext
@@ -18,6 +16,8 @@ import picocli.CommandLine.ArgGroup
 import picocli.CommandLine.Command
 import picocli.CommandLine.ITypeConverter
 import picocli.CommandLine.Option
+import java.io.File
+import java.util.concurrent.Callable
 
 internal class KebabToEnumConverter<T : Enum<T>>(
   private val enumClass: Class<T>,
@@ -84,7 +84,8 @@ class MaruAppCli(
       names = ["--maru-genesis-file", "--genesis-file"],
       paramLabel = "BEACON_GENESIS.json",
       description = [
-        "Beacon chain genesis file (\"--maru-genesis-file\" will be deprecated soon and replaced by \"--genesis-file\")",
+        "Beacon chain genesis file (\"--maru-genesis-file\" will be deprecated soon " +
+          "and replaced by \"--genesis-file\")",
       ],
       required = false,
     )

--- a/app/src/main/kotlin/maru/app/MaruAppFactory.kt
+++ b/app/src/main/kotlin/maru/app/MaruAppFactory.kt
@@ -14,11 +14,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.vertx.core.Vertx
 import io.vertx.micrometer.MicrometerMetricsOptions
 import io.vertx.micrometer.backends.BackendRegistries
-import java.nio.file.Files
-import java.nio.file.Path
-import java.time.Clock
-import kotlin.io.path.createDirectories
-import kotlin.io.path.exists
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.contract.l1.Web3JLineaRollupSmartContractClientReadOnly
 import linea.kotlin.encodeHex
@@ -83,6 +78,11 @@ import org.web3j.protocol.Web3j
 import org.web3j.protocol.http.HttpService
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.networking.p2p.network.config.GeneratingFilePrivateKeySource
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
 import org.hyperledger.besu.plugin.services.MetricsSystem as BesuMetricsSystem
 
 interface MaruAppFactoryCreator {
@@ -236,74 +236,72 @@ class MaruAppFactory : MaruAppFactoryCreator {
     val finalizationProvider =
       overridingFinalizationProvider
         ?: setupFinalizationProvider(config, overridingLineaContractClient, vertx, timerFactory)
-    syncControllerImpl =
-      if (config.p2p != null) {
-        val followerELNodeEngineApiWeb3JClients: Map<String, Web3JClient> =
-          config.followers.followers.mapValues { (followerLabel, apiEndpointConfig) ->
-            Helpers.createWeb3jClient(
-              apiEndpointConfig = apiEndpointConfig,
-              log = LogManager.getLogger("maru.clients.follower.$followerLabel"),
-            )
-          }
-        val elSyncBlockImportHandlers =
-          Helpers.createForkAwareBlockImportHandlers(
-            forksSchedule = beaconGenesisConfig,
-            metricsFacade = metricsFacade,
-            followerELNodeEngineApiWeb3JClients = followerELNodeEngineApiWeb3JClients,
-            finalizationProvider = finalizationProvider,
+    syncControllerImpl = if (config.p2p != null) {
+      val followerELNodeEngineApiWeb3JClients: Map<String, Web3JClient> =
+        config.followers.followers.mapValues { (followerLabel, apiEndpointConfig) ->
+          Helpers.createWeb3jClient(
+            apiEndpointConfig = apiEndpointConfig,
+            log = LogManager.getLogger("maru.clients.follower.$followerLabel"),
           )
-        // Validators manage EL sync through QBFT consensus itself.
-        // Followers only use ELSyncService when an explicit polling interval is configured.
-        val elSyncEnabled = config.qbft == null && config.syncing.elSyncStatusRefreshInterval != null
-        val elSyncServiceFactory: ((ELSyncStatus) -> Unit) -> LongRunningService = { onStatusChange ->
-          val refreshInterval = config.syncing.elSyncStatusRefreshInterval
-          if (elSyncEnabled && engineApiWeb3jClient != null) {
-            val validatorImportHandler =
-              ElForkAwareBlockImporter(
-                forksSchedule = beaconGenesisConfig,
-                elManagerMap = elManagerMap,
-                importerName = "El sync payload validator",
-                finalizationProvider = finalizationProvider,
-              )
-            ELSyncService(
-              config = ELSyncService.Config(refreshInterval!!),
-              beaconChain = kvDatabase,
-              eLValidatorBlockImportHandler = validatorImportHandler,
-              followerELBLockImportHandler = elSyncBlockImportHandlers,
-              onStatusChange = onStatusChange,
-              timerFactory = timerFactory,
-            )
-          } else {
-            NoOpLongRunningService
-          }
         }
-        BeaconSyncControllerImpl.create(
-          beaconChain = kvDatabase,
-          peersHeadsProvider = peersHeadBlockProvider,
-          targetChainHeadCalculator = createSyncTargetSelector(config.syncing.syncTargetSelection),
-          validatorProvider = StaticValidatorProvider(qbftConfig.validatorSet),
-          peerLookup = p2pNetwork.getPeerLookup(),
-          besuMetrics = besuMetricsSystemAdapter,
+      val elSyncBlockImportHandlers =
+        Helpers.createForkAwareBlockImportHandlers(
+          forksSchedule = beaconGenesisConfig,
           metricsFacade = metricsFacade,
-          peerChainTrackerConfig = PeerChainTracker.Config(config.syncing.peerChainHeightPollingInterval),
-          elSyncServiceFactory = elSyncServiceFactory,
-          elSyncEnabled = elSyncEnabled,
-          desyncTolerance = config.syncing.desyncTolerance,
-          pipelineConfig =
-            BeaconChainDownloadPipelineFactory.Config(
-              blockRangeRequestTimeout = config.syncing.download.blockRangeRequestTimeout,
-              backoffDelay = config.syncing.download.backoffDelay,
-              blocksBatchSize = config.syncing.download.blocksBatchSize,
-              blocksParallelism = config.syncing.download.blocksParallelism,
-              maxRetries = config.syncing.download.maxRetries,
-              useUnconditionalRandomDownloadPeer = config.syncing.download.useUnconditionalRandomDownloadPeer,
-            ),
-          allowEmptyBlocks = config.allowEmptyBlocks,
-          timerFactory = timerFactory,
+          followerELNodeEngineApiWeb3JClients = followerELNodeEngineApiWeb3JClients,
+          finalizationProvider = finalizationProvider,
         )
-      } else {
-        AlwaysSyncedController(kvDatabase)
+      // Validators manage EL sync through QBFT consensus itself.
+      // Followers only use ELSyncService when an explicit polling interval is configured.
+      val elSyncEnabled = config.qbft == null && config.syncing.elSyncStatusRefreshInterval != null
+      val elSyncServiceFactory: ((ELSyncStatus) -> Unit) -> LongRunningService = { onStatusChange ->
+        val refreshInterval = config.syncing.elSyncStatusRefreshInterval
+        if (elSyncEnabled && engineApiWeb3jClient != null) {
+          val validatorImportHandler =
+            ElForkAwareBlockImporter(
+              forksSchedule = beaconGenesisConfig,
+              elManagerMap = elManagerMap,
+              importerName = "El sync payload validator",
+              finalizationProvider = finalizationProvider,
+            )
+          ELSyncService(
+            config = ELSyncService.Config(refreshInterval!!),
+            beaconChain = kvDatabase,
+            eLValidatorBlockImportHandler = validatorImportHandler,
+            followerELBLockImportHandler = elSyncBlockImportHandlers,
+            onStatusChange = onStatusChange,
+            timerFactory = timerFactory,
+          )
+        } else {
+          NoOpLongRunningService
+        }
       }
+      BeaconSyncControllerImpl.create(
+        beaconChain = kvDatabase,
+        peersHeadsProvider = peersHeadBlockProvider,
+        targetChainHeadCalculator = createSyncTargetSelector(config.syncing.syncTargetSelection),
+        validatorProvider = StaticValidatorProvider(qbftConfig.validatorSet),
+        peerLookup = p2pNetwork.getPeerLookup(),
+        besuMetrics = besuMetricsSystemAdapter,
+        metricsFacade = metricsFacade,
+        peerChainTrackerConfig = PeerChainTracker.Config(config.syncing.peerChainHeightPollingInterval),
+        elSyncServiceFactory = elSyncServiceFactory,
+        elSyncEnabled = elSyncEnabled,
+        desyncTolerance = config.syncing.desyncTolerance,
+        pipelineConfig = BeaconChainDownloadPipelineFactory.Config(
+          blockRangeRequestTimeout = config.syncing.download.blockRangeRequestTimeout,
+          backoffDelay = config.syncing.download.backoffDelay,
+          blocksBatchSize = config.syncing.download.blocksBatchSize,
+          blocksParallelism = config.syncing.download.blocksParallelism,
+          maxRetries = config.syncing.download.maxRetries,
+          useUnconditionalRandomDownloadPeer = config.syncing.download.useUnconditionalRandomDownloadPeer,
+        ),
+        allowEmptyBlocks = config.allowEmptyBlocks,
+        timerFactory = timerFactory,
+      )
+    } else {
+      AlwaysSyncedController(kvDatabase)
+    }
 
     val apiServer =
       overridingApiServer
@@ -373,26 +371,23 @@ class MaruAppFactory : MaruAppFactoryCreator {
               ?: Web3JLineaRollupSmartContractClientReadOnly(
                 web3j = web3jClient,
                 contractAddress = lineaConfig.contractAddress.encodeHex(),
-                ethLogsClient =
-                  createEthApiClient(
-                    web3jClient = web3jClient,
-                    vertx = vertx,
-                  ),
+                ethLogsClient = createEthApiClient(
+                  web3jClient = web3jClient,
+                  vertx = vertx,
+                ),
                 log = LogManager.getLogger("maru.clients.l1.linea"),
               )
           val l2Endpoint = lineaConfig.l2EthApiEndpoint
           LineaFinalizationProvider(
             lineaContract = contractClient,
-            l2EthApi =
-              createEthApiClient(
-                rpcUrl =
-                  l2Endpoint.endpoint
-                    .toString(),
-                log = LogManager.getLogger("maru.clients.l2.eth.el"),
-                requestRetryConfig = l2Endpoint.requestRetries,
-                vertx = vertx,
-                stopRetriesOnErrorPredicate = { true },
-              ),
+            l2EthApi = createEthApiClient(
+              rpcUrl = l2Endpoint.endpoint
+                .toString(),
+              log = LogManager.getLogger("maru.clients.l2.eth.el"),
+              requestRetryConfig = l2Endpoint.requestRetries,
+              vertx = vertx,
+              stopRetriesOnErrorPredicate = { true },
+            ),
             pollingUpdateInterval = lineaConfig.l1PollingInterval,
             l1HighestBlock = lineaConfig.l1HighestBlockTag,
             timerFactory = timerFactory,

--- a/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
+++ b/app/src/main/kotlin/maru/app/QbftProtocolValidatorFactory.kt
@@ -8,7 +8,6 @@
  */
 package maru.app
 
-import java.time.Clock
 import maru.config.QbftConfig
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
@@ -30,6 +29,7 @@ import maru.syncing.SyncStatusProvider
 import net.consensys.linea.metrics.MetricsFacade
 import org.hyperledger.besu.plugin.services.MetricsSystem
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
+import java.time.Clock
 
 class QbftProtocolValidatorFactory(
   private val qbftOptions: QbftConfig,
@@ -48,7 +48,10 @@ class QbftProtocolValidatorFactory(
   private val payloadValidationEnabled: Boolean,
   /** Optional: called when BLOCK_TIMER_EXPIRY fires. See [QbftEventMultiplexer.onBlockTimerFired]. */
   private val onBlockTimerFired: ((blockNumber: Long) -> Unit)? = null,
-  /** Optional: called when a QBFT message arrives from P2P, before queue insertion. See [QbftMessageProcessor.onMessageReceived]. */
+  /**
+   * Optional: called when a QBFT message arrives from P2P, before queue insertion.
+   * See [QbftMessageProcessor.onMessageReceived].
+   */
   private val onMessageReceived: ((msgCode: Int, sequenceNumber: Long) -> Unit)? = null,
   /** Optional: called when a block is committed by QBFT consensus. */
   private val onBlockMined: ((SealedBeaconBlock) -> Unit)? = null,

--- a/app/src/test/kotlin/maru/app/MaruAppCliTest.kt
+++ b/app/src/test/kotlin/maru/app/MaruAppCliTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.app
 
-import java.io.File
-import java.time.Clock
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.timer.TimerFactory
 import maru.api.ApiServer
@@ -36,6 +34,8 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import picocli.CommandLine
+import java.io.File
+import java.time.Clock
 import org.hyperledger.besu.plugin.services.MetricsSystem as BesuMetricsSystem
 
 class MaruAppCliTest {
@@ -121,18 +121,15 @@ class MaruAppCliTest {
     @BeforeAll
     @JvmStatic
     fun beforeAll() {
-      tempMaruConfigFile =
-        File.createTempFile("MaruAppCliTest", ".toml").also {
-          it.writeText(maruConfigDtoToml)
-        }
-      tempMaruConfigOverridesFile =
-        File.createTempFile("MaruAppCliTest", ".toml").also {
-          it.writeText(maruConfigOverridesDtoToml)
-        }
-      tempMaruGenesisFile =
-        File.createTempFile("MaruAppCliTest", ".json").also {
-          it.writeText(maruGenesisJson)
-        }
+      tempMaruConfigFile = File.createTempFile("MaruAppCliTest", ".toml").also {
+        it.writeText(maruConfigDtoToml)
+      }
+      tempMaruConfigOverridesFile = File.createTempFile("MaruAppCliTest", ".toml").also {
+        it.writeText(maruConfigOverridesDtoToml)
+      }
+      tempMaruGenesisFile = File.createTempFile("MaruAppCliTest", ".json").also {
+        it.writeText(maruGenesisJson)
+      }
     }
 
     @AfterAll

--- a/app/src/test/kotlin/maru/app/MaruAppFactoryCheckEthApiTest.kt
+++ b/app/src/test/kotlin/maru/app/MaruAppFactoryCheckEthApiTest.kt
@@ -8,9 +8,6 @@
  */
 package maru.app
 
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.ConsensusConfig
@@ -22,6 +19,9 @@ import maru.consensus.QbftConsensusConfig
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 
 class MaruAppFactoryCheckEthApiTest {
   private fun baseQbftConfig() =

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,15 @@ allprojects {
   spotless {
     kotlin {
       // by default the target is every '.kt' and '.kts` file in the java sourcesets
-      ktlint()
-        .setEditorConfigPath("$rootDir/.editorconfig")
+      ktlint(libs.versions.ktlint.get().toString())
+          .editorConfigOverride([
+            'ktlint_standard_discouraged-comment-location': 'disabled',
+            'ktlint_standard_property-naming': 'disabled',
+            'ktlint_standard_function-naming': 'disabled',
+            'ktlint_standard_function-signature': 'disabled',
+          ])
       licenseHeaderFile("${rootDir}/gradle/spotless/java-kotlin.license").onlyIfContentMatches("^(?!/\\*\\r?\\n \\*." +
-        "*ConsenSys AG\\.)")
+          "*ConsenSys AG\\.)")
     }
     java {
       // This path needs to be relative to each project
@@ -45,12 +50,13 @@ allprojects {
       endWithNewline()
       // apply appropriate license header files.
       licenseHeaderFile("${rootDir}/gradle/spotless/java-kotlin.license").onlyIfContentMatches("^(?!/\\*\\r?\\n \\*." +
-        "*ConsenSys AG\\.)")
+          "*ConsenSys AG\\.)")
     }
     // spotless check applied to build.gradle (groovy) files
     groovyGradle {
       target '*.gradle'
-      greclipse().configFile(rootProject.file('gradle/spotless/greclipse.properties'))
+      greclipse("4.35")
+      leadingTabsToSpaces(2)
       endWithNewline()
     }
   }

--- a/chaos-testing/health-checker/build.gradle
+++ b/chaos-testing/health-checker/build.gradle
@@ -51,8 +51,8 @@ tasks.register('acceptanceTest', Test) { test ->
 
   testLogging {
     events TestLogEvent.FAILED,
-      TestLogEvent.SKIPPED,
-      TestLogEvent.STANDARD_ERROR
+        TestLogEvent.SKIPPED,
+        TestLogEvent.STANDARD_ERROR
     exceptionFormat TestExceptionFormat.FULL
     showCauses true
     showExceptions true

--- a/chaos-testing/health-checker/src/acceptanceTest/kotlin/chaos/ConsensusMetricsBenchmarkTest.kt
+++ b/chaos-testing/health-checker/src/acceptanceTest/kotlin/chaos/ConsensusMetricsBenchmarkTest.kt
@@ -38,7 +38,7 @@ class ConsensusMetricsBenchmarkTest {
   private val log = LogManager.getLogger(this.javaClass)
   private val httpClient = OkHttp()
 
-  // ── metric definitions ─────────────────────────────────────────────────────
+  // Metric definitions.
 
   private data class MetricDef(
     val promName: String,
@@ -59,7 +59,7 @@ class ConsensusMetricsBenchmarkTest {
       ),
     )
 
-  // ── histogram data model ───────────────────────────────────────────────────
+  // Histogram data model.
 
   private data class HistogramData(
     val count: Long,
@@ -95,10 +95,9 @@ class ConsensusMetricsBenchmarkTest {
 
       if (braceStart >= 0 && braceEnd > braceStart) {
         metricName = line.substring(0, braceStart).trim()
-        labels =
-          labelRegex
-            .findAll(line.substring(braceStart + 1, braceEnd))
-            .associate { it.groupValues[1] to it.groupValues[2] }
+        labels = labelRegex
+          .findAll(line.substring(braceStart + 1, braceEnd))
+          .associate { it.groupValues[1] to it.groupValues[2] }
         valueStr = line.substring(braceEnd + 1).trim()
       } else {
         val spaceIdx = line.lastIndexOf(' ')
@@ -153,7 +152,7 @@ class ConsensusMetricsBenchmarkTest {
     return HistogramData(count = count, sum = sum, max = max, quantiles = quantiles)
   }
 
-  // ── cross-pod aggregation ──────────────────────────────────────────────────
+  // Cross-pod aggregation.
 
   /**
    * Merges per-pod [HistogramData] into a single aggregate.
@@ -181,7 +180,7 @@ class ConsensusMetricsBenchmarkTest {
     return HistogramData(count = totalCount, sum = totalSum, max = totalMax, quantiles = mergedQuantiles)
   }
 
-  // ── test entry point ───────────────────────────────────────────────────────
+  // Test entry point.
 
   @Test
   fun `collect and print QBFT consensus metrics from all chaos pods`() {
@@ -230,7 +229,7 @@ class ConsensusMetricsBenchmarkTest {
     printReport(podSamples, experimentLatency)
   }
 
-  // ── report printer ─────────────────────────────────────────────────────────
+  // Report printer.
 
   private fun printReport(
     podSamples: Map<String, Map<Pair<String, Map<String, String>>, Double>>,

--- a/chaos-testing/health-checker/src/acceptanceTest/kotlin/chaos/NodesSyncTest.kt
+++ b/chaos-testing/health-checker/src/acceptanceTest/kotlin/chaos/NodesSyncTest.kt
@@ -9,8 +9,6 @@
 package chaos
 
 import chaos.SetupHelper.getNodesUrlsFromFile
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import linea.kotlin.toULong
 import linea.log4j.configureLoggers
 import linea.web3j.createWeb3jHttpClient
@@ -26,6 +24,8 @@ import org.awaitility.kotlin.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class NodesSyncTest {
   private val log = LogManager.getLogger("maru.chaos.NodesSyncTest")
@@ -175,7 +175,8 @@ class NodesSyncTest {
       .untilAsserted {
         assertThat(getClBeaconChainHeadBlockNumber(maruSequencer.value).get())
           .withFailMessage {
-            "Maru sequencer stopped producing beacon blocks at height ${highestMaruBlock.message.body.executionPayload.blockNumber}"
+            "Maru sequencer stopped producing beacon blocks at height " +
+              highestMaruBlock.message.body.executionPayload.blockNumber
           }.isGreaterThan(highestMaruBlock.message.slot.toULong())
       }
 

--- a/config/src/main/kotlin/maru/config/Config.kt
+++ b/config/src/main/kotlin/maru/config/Config.kt
@@ -8,6 +8,10 @@
  */
 package maru.config
 
+import linea.domain.BlockParameter
+import linea.domain.RetryConfig
+import linea.kotlin.assertIs20Bytes
+import maru.extensions.encodeHex
 import java.net.InetAddress
 import java.net.URL
 import java.nio.file.Path
@@ -17,10 +21,6 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import linea.domain.BlockParameter
-import linea.domain.RetryConfig
-import linea.kotlin.assertIs20Bytes
-import maru.extensions.encodeHex
 
 data class Persistence(
   val dataPath: Path,

--- a/config/src/main/kotlin/maru/config/ConfigLoaderHelper.kt
+++ b/config/src/main/kotlin/maru/config/ConfigLoaderHelper.kt
@@ -18,12 +18,12 @@ import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.ConfigResult
 import com.sksamuel.hoplite.ExperimentalHoplite
 import com.sksamuel.hoplite.fp.Validated
-import java.nio.file.Path
 import maru.config.consensus.ForkConfigDecoder
 import maru.config.decoders.TomlByteArrayHexDecoder
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.nio.file.Path
 
 fun ConfigLoaderBuilder.addTomlDecoders(strict: Boolean): ConfigLoaderBuilder =
   this

--- a/config/src/main/kotlin/maru/config/HopliteTomlFriendly.kt
+++ b/config/src/main/kotlin/maru/config/HopliteTomlFriendly.kt
@@ -8,14 +8,14 @@
  */
 package maru.config
 
+import linea.domain.BlockParameter
+import linea.domain.RetryConfig
+import linea.kotlin.assertIs20Bytes
 import java.net.URL
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import linea.domain.BlockParameter
-import linea.domain.RetryConfig
-import linea.kotlin.assertIs20Bytes
 
 data class PayloadValidatorDto(
   val engineApiEndpoint: ApiEndpointDto,
@@ -200,10 +200,9 @@ data class MaruConfigDtoToml(
       qbft = qbft?.toDomain(),
       p2p = p2p,
       validatorElNode = payloadValidator?.domainFriendly(),
-      followers =
-        FollowersConfig(
-          followers = followerEngineApis?.mapValues { it.value.domainFriendly() } ?: emptyMap(),
-        ),
+      followers = FollowersConfig(
+        followers = followerEngineApis?.mapValues { it.value.domainFriendly() } ?: emptyMap(),
+      ),
       observability = observability,
       api = api,
       syncing = syncing,

--- a/config/src/main/kotlin/maru/config/MaruConfigLoader.kt
+++ b/config/src/main/kotlin/maru/config/MaruConfigLoader.kt
@@ -12,12 +12,12 @@ import com.sksamuel.hoplite.ConfigLoaderBuilder
 import com.sksamuel.hoplite.ExperimentalHoplite
 import com.sksamuel.hoplite.json.JsonPropertySource
 import com.sksamuel.hoplite.toml.TomlPropertySource
-import java.io.File
-import kotlin.io.path.Path
 import maru.config.MaruConfigLoader.appTomlConfigLoaderBuilder
 import maru.config.consensus.ForkConfigDecoder
 import maru.config.consensus.JsonFriendlyForksSchedule
 import maru.config.decoders.TomlByteArrayHexDecoder
+import java.io.File
+import kotlin.io.path.Path
 
 object MaruConfigLoader {
   @OptIn(ExperimentalHoplite::class)

--- a/config/src/main/kotlin/maru/config/consensus/JsonFriendlyForksSchedule.kt
+++ b/config/src/main/kotlin/maru/config/consensus/JsonFriendlyForksSchedule.kt
@@ -19,11 +19,6 @@ import com.sksamuel.hoplite.fp.NonEmptyList
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
 import com.sksamuel.hoplite.valueOrNull
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.map
-import kotlin.collections.toSet
-import kotlin.reflect.KType
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.ConsensusConfig
@@ -34,6 +29,11 @@ import maru.consensus.ForksSchedule
 import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
 import maru.extensions.fromHexToByteArray
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.map
+import kotlin.collections.toSet
+import kotlin.reflect.KType
 
 object ForkConfigDecoder : Decoder<JsonFriendlyForksSchedule> {
   override fun decode(
@@ -85,19 +85,17 @@ object ForkConfigDecoder : Decoder<JsonFriendlyForksSchedule> {
 
       "qbft" ->
         QbftConsensusConfig(
-          validatorSet =
-            (obj["validatorset"] as ArrayNode)
-              .elements
-              .map {
-                Validator(
-                  it.valueOrNull()!!.fromHexToByteArray(),
-                )
-              }.toSet(),
-          fork =
-            ChainFork(
-              clFork = ClFork.QBFT_PHASE0,
-              elFork = ElFork.valueOf(obj.getString("elfork")),
-            ),
+          validatorSet = (obj["validatorset"] as ArrayNode)
+            .elements
+            .map {
+              Validator(
+                it.valueOrNull()!!.fromHexToByteArray(),
+              )
+            }.toSet(),
+          fork = ChainFork(
+            clFork = ClFork.QBFT_PHASE0,
+            elFork = ElFork.valueOf(obj.getString("elfork")),
+          ),
         ).valid()
 
       else -> (ConfigFailure.UnsupportedCollectionType(obj, "Unsupported fork type $type!") as ConfigFailure).invalid()

--- a/config/src/main/kotlin/maru/config/decoders/TomlByteArrayHexDecoder.kt
+++ b/config/src/main/kotlin/maru/config/decoders/TomlByteArrayHexDecoder.kt
@@ -16,8 +16,8 @@ import com.sksamuel.hoplite.StringNode
 import com.sksamuel.hoplite.decoder.Decoder
 import com.sksamuel.hoplite.fp.invalid
 import com.sksamuel.hoplite.fp.valid
-import kotlin.reflect.KType
 import linea.kotlin.decodeHex
+import kotlin.reflect.KType
 
 class TomlByteArrayHexDecoder : Decoder<ByteArray> {
   override fun decode(

--- a/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
+++ b/config/src/test/kotlin/maru/config/HopliteFriendlinessTest.kt
@@ -10,10 +10,6 @@ package maru.config
 
 import com.sksamuel.hoplite.ConfigException
 import com.sksamuel.hoplite.ExperimentalHoplite
-import java.net.URI
-import kotlin.io.path.Path
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import linea.domain.BlockParameter
 import linea.domain.RetryConfig
 import linea.kotlin.decodeHex
@@ -22,10 +18,21 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.net.URI
+import kotlin.io.path.Path
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalHoplite::class)
 class HopliteFriendlinessTest {
   private val protocolTransitionPollingInterval = 2.seconds
+  private val staticPeer =
+    "/dns4/bootnode.linea.build/tcp/3322/p2p/" +
+      "16Uiu2HAmFjVuJoKD6sobrxwyJyysM1rgCsfWKzFLwvdB2HKuHwTg"
+  private val discoveryBootnode =
+    "enr:-Iu4QHk0YN5IRRnufqsWkbO6Tn0iGTx4H_hnyiIEdXDuhIe0KKrxmaECisyvO40mEmmqKLhz_tdIhx2y" +
+      "FBK8XFKhvxABgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQOgBvD-dv0cX5szOeEsiAMtwxnP1q5CA5toY" +
+      "DrgUyOhV4N0Y3CCJBKDdWRwgiQT"
 
   private val baseConfigWithoutQbftAndPayloadToml =
     """
@@ -36,13 +43,13 @@ class HopliteFriendlinessTest {
     [p2p]
     port = 3322
     ip-address = "10.11.12.13"
-    static-peers = ["/dns4/bootnode.linea.build/tcp/3322/p2p/16Uiu2HAmFjVuJoKD6sobrxwyJyysM1rgCsfWKzFLwvdB2HKuHwTg"]
+    static-peers = ["$staticPeer"]
     reconnect-delay = "500 ms"
     peering-fork-mismatch-leeway-time = "10 seconds"
 
     [p2p.discovery]
     port = 3324
-    bootnodes = ["enr:-Iu4QHk0YN5IRRnufqsWkbO6Tn0iGTx4H_hnyiIEdXDuhIe0KKrxmaECisyvO40mEmmqKLhz_tdIhx2yFBK8XFKhvxABgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQOgBvD-dv0cX5szOeEsiAMtwxnP1q5CA5toYDrgUyOhV4N0Y3CCJBKDdWRwgiQT"]
+    bootnodes = ["$discoveryBootnode"]
     refresh-interval = "30 seconds"
     search-timeout = "10 seconds"
     search-interval = "2 seconds"
@@ -135,63 +142,55 @@ class HopliteFriendlinessTest {
     P2PConfig(
       ipAddress = "10.11.12.13",
       port = 3322u,
-      staticPeers =
-        listOf(
-          "/dns4/bootnode.linea.build/tcp/3322/p2p/16Uiu2HAmFjVuJoKD6sobrxwyJyysM1rgCsfWKzFLwvdB2HKuHwTg",
-        ),
+      staticPeers = listOf(
+        staticPeer,
+      ),
       reconnectDelay = 500.milliseconds,
       peeringForkMismatchLeewayTime = 10.seconds,
-      discovery =
-        P2PConfig.Discovery(
-          port = 3324u,
-          bootnodes =
-            listOf(
-              "enr:-Iu4QHk0YN5IRRnufqsWkbO6Tn0iGTx4H_hnyiIEdXDuhIe0KKrxmaECisyvO40mEmmqKLhz_tdIhx2yFBK8XFKhvxABgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQOgBvD-dv0cX5szOeEsiAMtwxnP1q5CA5toYDrgUyOhV4N0Y3CCJBKDdWRwgiQT",
-            ),
-          refreshInterval = 30.seconds,
-          searchTimeout = 10.seconds,
-          searchInterval = 2.seconds,
-          advertisedIp = "13.12.11.10",
+      discovery = P2PConfig.Discovery(
+        port = 3324u,
+        bootnodes = listOf(
+          discoveryBootnode,
         ),
-      reputation =
-        P2PConfig.Reputation(
-          smallChange = 1,
-          largeChange = 5,
-          disconnectScoreThreshold = -20,
-          capacity = 100,
-          cooldownPeriod = 2.seconds,
-          banPeriod = 30.seconds,
-        ),
-      statusUpdate =
-        P2PConfig.StatusUpdate(
-          refreshInterval = 30.seconds,
-          refreshIntervalLeeway = 10.seconds,
-          timeout = 3.seconds,
-        ),
+        refreshInterval = 30.seconds,
+        searchTimeout = 10.seconds,
+        searchInterval = 2.seconds,
+        advertisedIp = "13.12.11.10",
+      ),
+      reputation = P2PConfig.Reputation(
+        smallChange = 1,
+        largeChange = 5,
+        disconnectScoreThreshold = -20,
+        capacity = 100,
+        cooldownPeriod = 2.seconds,
+        banPeriod = 30.seconds,
+      ),
+      statusUpdate = P2PConfig.StatusUpdate(
+        refreshInterval = 30.seconds,
+        refreshIntervalLeeway = 10.seconds,
+        timeout = 3.seconds,
+      ),
     )
   private val defaultEthApiEndpoint =
     ApiEndpointConfig(
       endpoint = URI.create("http://localhost:8545").toURL(),
-      requestRetries =
-        RetryConfig.noRetries,
+      requestRetries = RetryConfig.noRetries,
     )
   private val engineApiEndpoint =
     ApiEndpointConfig(
       endpoint = URI.create("http://localhost:8555").toURL(),
       jwtSecretPath = "/secret/path",
-      requestRetries =
-        RetryConfig.endlessRetry(
-          backoffDelay = 1.seconds,
-          failuresWarningThreshold = 3u,
-        ),
+      requestRetries = RetryConfig.endlessRetry(
+        backoffDelay = 1.seconds,
+        failuresWarningThreshold = 3u,
+      ),
     )
   private val payloadValidator =
     PayloadValidatorDto(
-      engineApiEndpoint =
-        ApiEndpointDto(
-          endpoint = URI.create("http://localhost:8555").toURL(),
-          jwtSecretPath = "/secret/path",
-        ),
+      engineApiEndpoint = ApiEndpointDto(
+        endpoint = URI.create("http://localhost:8555").toURL(),
+        jwtSecretPath = "/secret/path",
+      ),
       payloadValidationEnabled = true,
     )
   private val follower1 =
@@ -233,21 +232,19 @@ class HopliteFriendlinessTest {
   private val syncingConfig =
     SyncingConfig(
       peerChainHeightPollingInterval = 5.seconds,
-      syncTargetSelection =
-        SyncingConfig.SyncTargetSelection.MostFrequent(
-          peerChainHeightGranularity = 10U,
-        ),
+      syncTargetSelection = SyncingConfig.SyncTargetSelection.MostFrequent(
+        peerChainHeightGranularity = 10U,
+      ),
       elSyncStatusRefreshInterval = 6.seconds,
       desyncTolerance = 10UL,
-      download =
-        SyncingConfig.Download(
-          blockRangeRequestTimeout = 10.seconds,
-          blocksBatchSize = 64u,
-          blocksParallelism = 10u,
-          maxRetries = 5u,
-          backoffDelay = 10.seconds,
-          useUnconditionalRandomDownloadPeer = true,
-        ),
+      download = SyncingConfig.Download(
+        blockRangeRequestTimeout = 10.seconds,
+        blocksBatchSize = 64u,
+        blocksParallelism = 10u,
+        maxRetries = 5u,
+        backoffDelay = 10.seconds,
+        useUnconditionalRandomDownloadPeer = true,
+      ),
     )
   private val defaultsDto = DefaultsDtoToml(l2EthEndpoint = ApiEndpointDto(URI.create("http://localhost:8545").toURL()))
   private val forkTransitionOverrideEndpoint =
@@ -273,11 +270,10 @@ class HopliteFriendlinessTest {
       observability = ObservabilityConfig(port = 9090u),
       api = ApiConfig(port = 8080u),
       syncing = syncingConfig,
-      forkTransition =
-        ForkTransitionDtoToml(
-          l2EthApiEndpoint = ApiEndpointDto(URI.create("http://localhost:8595").toURL()),
-          protocolTransitionPollingInterval = protocolTransitionPollingInterval,
-        ),
+      forkTransition = ForkTransitionDtoToml(
+        l2EthApiEndpoint = ApiEndpointDto(URI.create("http://localhost:8595").toURL()),
+        protocolTransitionPollingInterval = protocolTransitionPollingInterval,
+      ),
     )
 
   @Test
@@ -324,11 +320,10 @@ class HopliteFriendlinessTest {
         persistence = persistence,
         qbft = qbftOptions.toDomain(),
         p2p = p2pConfig,
-        validatorElNode =
-          ValidatorElNode(
-            engineApiEndpoint = engineApiEndpoint,
-            payloadValidationEnabled = true,
-          ),
+        validatorElNode = ValidatorElNode(
+          engineApiEndpoint = engineApiEndpoint,
+          payloadValidationEnabled = true,
+        ),
         followers = followersConfig,
         observability = ObservabilityConfig(port = 9090u),
         api = ApiConfig(port = 8080u),
@@ -346,11 +341,10 @@ class HopliteFriendlinessTest {
         persistence = persistence,
         qbft = qbftOptions.toDomain(),
         p2p = p2pConfig,
-        validatorElNode =
-          ValidatorElNode(
-            engineApiEndpoint = engineApiEndpoint,
-            payloadValidationEnabled = true,
-          ),
+        validatorElNode = ValidatorElNode(
+          engineApiEndpoint = engineApiEndpoint,
+          payloadValidationEnabled = true,
+        ),
         followers = emptyFollowersConfig,
         observability = ObservabilityConfig(port = 9090u),
         api = ApiConfig(port = 8080u),
@@ -531,11 +525,10 @@ class HopliteFriendlinessTest {
       MaruConfig(
         allowEmptyBlocks = true,
         persistence = persistence,
-        validatorElNode =
-          ValidatorElNode(
-            engineApiEndpoint = engineApiEndpoint,
-            payloadValidationEnabled = true,
-          ),
+        validatorElNode = ValidatorElNode(
+          engineApiEndpoint = engineApiEndpoint,
+          payloadValidationEnabled = true,
+        ),
         qbft = qbftOptions.toDomain(),
         p2p = p2pConfig,
         followers = emptyFollowersConfig,
@@ -594,11 +587,10 @@ class HopliteFriendlinessTest {
         linea = expectedLineaConfig,
         persistence = persistence,
         p2p = p2pConfig,
-        validatorElNode =
-          ValidatorElNode(
-            engineApiEndpoint = engineApiEndpoint,
-            payloadValidationEnabled = true,
-          ),
+        validatorElNode = ValidatorElNode(
+          engineApiEndpoint = engineApiEndpoint,
+          payloadValidationEnabled = true,
+        ),
         qbft = qbftOptions.toDomain(),
         followers = emptyFollowersConfig,
         observability = ObservabilityConfig(port = 9090u),
@@ -868,11 +860,10 @@ class HopliteFriendlinessTest {
         observability = ObservabilityConfig(port = 9090u),
         api = ApiConfig(port = 8080u),
         syncing = syncingConfig,
-        forkTransition =
-          ForkTransition(
-            l2EthApiEndpoint = defaultEthApiEndpoint,
-            protocolTransitionPollingInterval = 1.seconds,
-          ),
+        forkTransition = ForkTransition(
+          l2EthApiEndpoint = defaultEthApiEndpoint,
+          protocolTransitionPollingInterval = 1.seconds,
+        ),
       ),
     )
   }

--- a/config/src/test/kotlin/maru/config/consensus/JsonFriendlyForksScheduleTest.kt
+++ b/config/src/test/kotlin/maru/config/consensus/JsonFriendlyForksScheduleTest.kt
@@ -71,11 +71,10 @@ class JsonFriendlyForksScheduleTest {
           ForkSpec(
             timestampSeconds = 4UL,
             blockTimeSeconds = 6U,
-            configuration =
-              QbftConsensusConfig(
-                validatorSet = setOf(Validator("0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0".fromHexToByteArray())),
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-              ),
+            configuration = QbftConsensusConfig(
+              validatorSet = setOf(Validator("0x1b9abeec3215d8ade8a33607f2cf0f4f60e5f0d0".fromHexToByteArray())),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+            ),
           ),
         ),
       ),

--- a/consensus/src/main/kotlin/maru/consensus/NewBlockHandler.kt
+++ b/consensus/src/main/kotlin/maru/consensus/NewBlockHandler.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus
 
-import java.util.concurrent.ConcurrentHashMap
 import maru.core.BeaconBlock
 import maru.core.SealedBeaconBlock
 import maru.extensions.encodeHex
@@ -16,6 +15,7 @@ import maru.p2p.SealedBeaconBlockHandler
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.ConcurrentHashMap
 
 class SealedBeaconBlockHandlerAdapter<T>(
   val adaptee: NewBlockHandler<T>,
@@ -77,9 +77,9 @@ class NewBlockHandlerMultiplexer(
   handlersMap: Map<String, NewBlockHandler<*>>,
   log: Logger = LogManager.getLogger(NewBlockHandlerMultiplexer::class.java),
 ) : CallAndForgetFutureMultiplexer<BeaconBlock>(
-    handlersMap = blockHandlersToGenericHandlers(handlersMap),
-    log = log,
-  ),
+  handlersMap = blockHandlersToGenericHandlers(handlersMap),
+  log = log,
+),
   NewBlockHandler<Unit> {
   companion object {
     fun blockHandlersToGenericHandlers(

--- a/consensus/src/main/kotlin/maru/consensus/ProtocolStarter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/ProtocolStarter.kt
@@ -8,15 +8,15 @@
  */
 package maru.consensus
 
-import java.time.Clock
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration
 import linea.timer.Timer
 import linea.timer.TimerFactory
 import maru.core.Protocol
 import maru.subscription.SubscriptionNotifier
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.time.Clock
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
 
 class ProtocolStarter(
   private val forksSchedule: ForksSchedule,

--- a/consensus/src/main/kotlin/maru/consensus/ValidatorProvider.kt
+++ b/consensus/src/main/kotlin/maru/consensus/ValidatorProvider.kt
@@ -8,9 +8,9 @@
  */
 package maru.consensus
 
-import java.util.SequencedSet
 import maru.core.Validator
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.SequencedSet
 
 /**
  * Provides access to the set of validators for a given block.
@@ -25,7 +25,8 @@ interface ValidatorProvider {
 }
 
 /**
- * A [ValidatorProvider] that always returns the same [Validator] instance. This is useful for the single validator case.
+ * A [ValidatorProvider] that always returns the same [Validator] instance.
+ * This is useful for the single validator case.
  */
 class StaticValidatorProvider(
   validators: Set<Validator>,

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/BeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/BeaconBlockImporter.kt
@@ -50,12 +50,11 @@ class FollowerBeaconBlockImporter(
     ): NewBlockHandler<ValidationResult> =
       FollowerBeaconBlockImporter(
         executionLayerManager = executionLayerManager,
-        delegate =
-          SetHeadOnlyBlockImporter(
-            executionLayerManager = executionLayerManager,
-            finalizationStateProvider = finalizationStateProvider,
-            importerName = importerName,
-          ),
+        delegate = SetHeadOnlyBlockImporter(
+          executionLayerManager = executionLayerManager,
+          finalizationStateProvider = finalizationStateProvider,
+          importerName = importerName,
+        ),
         importerName = importerName,
       )
   }
@@ -142,13 +141,11 @@ class BlockBuildingBeaconBlockImporter(
         finalizedHash = finalizationState.finalizedBlockHash,
         nextBlockTimestamp = nextBlockTimestamp,
         feeRecipient = feeRecipient,
-        prevRandao =
-          prevRandaoProvider.calculateNextPrevRandao(
-            signee =
-              beaconBlock.beaconBlockBody.executionPayload.blockNumber
-                .inc(),
-            prevRandao = beaconBlock.beaconBlockBody.executionPayload.prevRandao,
-          ),
+        prevRandao = prevRandaoProvider.calculateNextPrevRandao(
+          signee = beaconBlock.beaconBlockBody.executionPayload.blockNumber
+            .inc(),
+          prevRandao = beaconBlock.beaconBlockBody.executionPayload.prevRandao,
+        ),
       )
     } else {
       log.info(

--- a/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/blockimport/SealedBeaconBlockImporter.kt
@@ -13,7 +13,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.flatMap
 import com.github.michaelbull.result.mapError
-import java.util.concurrent.atomic.AtomicBoolean
 import maru.consensus.AsyncFunction
 import maru.consensus.CallAndForgetFutureMultiplexer
 import maru.consensus.state.StateTransition
@@ -28,6 +27,7 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.util.log.LogUtil
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.atomic.AtomicBoolean
 
 // This is basically Chain of Responsibility design pattern, except it doesn't allow multiple children
 // Multiplexer class was created to address that
@@ -39,9 +39,9 @@ class NewSealedBeaconBlockHandlerMultiplexer<T>(
   handlersMap: Map<String, SealedBeaconBlockHandler<*>>,
   log: Logger = LogManager.getLogger(CallAndForgetFutureMultiplexer<*>::javaClass)!!,
 ) : CallAndForgetFutureMultiplexer<SealedBeaconBlock>(
-    handlersMap = sealedBlockHandlersToGenericHandlers(handlersMap),
-    log = log,
-  ),
+  handlersMap = sealedBlockHandlersToGenericHandlers(handlersMap),
+  log = log,
+),
   SealedBeaconBlockHandler<Unit> {
   companion object {
     fun sealedBlockHandlersToGenericHandlers(
@@ -172,7 +172,9 @@ class ValidatingSealedBeaconBlockImporter(
       val beaconBlockHeader = beaconBlock.beaconBlockHeader
       LogUtil.throttledLog(
         log::info,
-        "block received: clBlockNumber=${beaconBlockHeader.number} elBlockNumber=${beaconBlock.beaconBlockBody.executionPayload.blockNumber} clBlockHash=${beaconBlockHeader.hash.encodeHex()}",
+        "block received: clBlockNumber=${beaconBlockHeader.number} " +
+          "elBlockNumber=${beaconBlock.beaconBlockBody.executionPayload.blockNumber} " +
+          "clBlockHash=${beaconBlockHeader.hash.encodeHex()}",
         shouldLog,
         30,
       )

--- a/consensus/src/main/kotlin/maru/consensus/qbft/ConstantRoundTimeExpiryCalculator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/ConstantRoundTimeExpiryCalculator.kt
@@ -8,10 +8,10 @@
  */
 package maru.consensus.qbft
 
-import java.time.Duration
-import kotlin.time.toJavaDuration
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.hyperledger.besu.consensus.common.bft.RoundExpiryTimeCalculator
+import java.time.Duration
+import kotlin.time.toJavaDuration
 
 /**
  * A [RoundExpiryTimeCalculator] that always returns a constant round expiry time.

--- a/consensus/src/main/kotlin/maru/consensus/qbft/DelayedQbftBlockCreator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/DelayedQbftBlockCreator.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.util.Optional
 import maru.consensus.ValidatorProvider
 import maru.consensus.qbft.adapters.QbftBlockAdapter
 import maru.consensus.qbft.adapters.QbftSealedBlockAdapter
@@ -35,6 +34,7 @@ import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCreator
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader
 import org.hyperledger.besu.crypto.SECPSignature
+import java.util.Optional
 
 /**
  * Responsible for QBFT block creation. As opposed to EagerBlockCreator, Delayed one relies on the fact that FCU was

--- a/consensus/src/main/kotlin/maru/consensus/qbft/DifficultyAwareQbft.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/DifficultyAwareQbft.kt
@@ -8,10 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.lang.Exception
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import linea.timer.Timer
 import linea.timer.TimerFactory
 import linea.timer.VertxTimerFactory
@@ -23,6 +19,10 @@ import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.DefaultBlockParameter
+import java.lang.Exception
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DifficultyAwareQbftFactory(
   private val ethereumJsonRpcClient: Web3j?,
@@ -120,15 +120,14 @@ class DifficultyAwareQbft(
         return
       }
       log.debug("Starting DifficultyAwareQbft with pollingInterval={} seconds", forkSpec.blockTimeSeconds)
-      poller =
-        timerFactory.createTimer(
-          name = "DifficultyAwareQbft",
-          period = forkSpec.blockTimeSeconds.toInt().seconds,
-          initialDelay = if (timerFactory is VertxTimerFactory) 1.milliseconds else Duration.ZERO,
-          timerSchedule = linea.timer.TimerSchedule.FIXED_RATE,
-          errorHandler = { e -> log.warn("DifficultyAwareQbft poll task exception", e) },
-          task = Runnable { pollTask() },
-        )
+      poller = timerFactory.createTimer(
+        name = "DifficultyAwareQbft",
+        period = forkSpec.blockTimeSeconds.toInt().seconds,
+        initialDelay = if (timerFactory is VertxTimerFactory) 1.milliseconds else Duration.ZERO,
+        timerSchedule = linea.timer.TimerSchedule.FIXED_RATE,
+        errorHandler = { e -> log.warn("DifficultyAwareQbft poll task exception", e) },
+        task = Runnable { pollTask() },
+      )
       poller?.start()
       postTtdProtocol?.start()
     }

--- a/consensus/src/main/kotlin/maru/consensus/qbft/EagerQbftBlockCreator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/EagerQbftBlockCreator.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import kotlin.time.Duration
 import maru.consensus.PrevRandaoProvider
 import maru.consensus.qbft.adapters.toBeaconBlockHeader
 import maru.consensus.state.FinalizationProvider
@@ -20,6 +19,7 @@ import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCreator
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockHeader
 import org.hyperledger.besu.crypto.SECPSignature
+import kotlin.time.Duration
 
 /**
  * Responsible for QBFT block creation. As opposed to DelayedQbftBlockCreator, Eager one will send the FCU request to
@@ -89,13 +89,11 @@ class EagerQbftBlockCreator(
           finalizedHash = finalizedState.finalizedBlockHash,
           nextBlockTimestamp = safeTimestampSeconds.toULong(),
           feeRecipient = feeRecipient,
-          prevRandao =
-            prevRandaoProvider.calculateNextPrevRandao(
-              signee =
-                parentBeaconBlock.beaconBlockBody.executionPayload.blockNumber
-                  .inc(),
-              prevRandao = parentBeaconBlock.beaconBlockBody.executionPayload.prevRandao,
-            ),
+          prevRandao = prevRandaoProvider.calculateNextPrevRandao(
+            signee = parentBeaconBlock.beaconBlockBody.executionPayload.blockNumber
+              .inc(),
+            prevRandao = parentBeaconBlock.beaconBlockBody.executionPayload.prevRandao,
+          ),
         ).get()
     log.debug(
       "Building new block, FCU result={}",

--- a/consensus/src/main/kotlin/maru/consensus/qbft/LinearRoundTimeExpiryCalculator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/LinearRoundTimeExpiryCalculator.kt
@@ -8,13 +8,14 @@
  */
 package maru.consensus.qbft
 
-import java.time.Duration
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.hyperledger.besu.consensus.common.bft.RoundExpiryTimeCalculator
+import java.time.Duration
 
 /**
  * A [RoundExpiryTimeCalculator] that uses a linear algorithm for increasing the round expiry time.
- * This implementation calculates the round expiry time for a round as: `baseExpiryPeriod  + (round * baseExpiryPeriod * coefficient)`.
+ * This implementation calculates the round expiry time for a round as:
+ * `baseExpiryPeriod + (round * baseExpiryPeriod * coefficient)`.
  *
  * @param baseExpiryPeriod the duration used as the base to be returned for all rounds.
  */

--- a/consensus/src/main/kotlin/maru/consensus/qbft/ProposerSelectorImpl.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/ProposerSelectorImpl.kt
@@ -8,13 +8,13 @@
  */
 package maru.consensus.qbft
 
-import kotlin.collections.map
 import maru.core.BeaconState
 import maru.core.Validator
 import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftProposerSelector
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.collections.map
 
 fun interface ProposerSelector {
   fun getProposerForBlock(
@@ -36,10 +36,14 @@ object ProposerSelectorImpl : ProposerSelector {
       parentBeaconState.validators.map { it.toAddress() }
     val proposer =
       BftProposerSelector.selectProposerForRound(
-        /* roundIdentifier = */ roundIdentifier,
-        /* prevBlockProposer = */ prevBlockProposerAddress,
-        /* validatorsForRound = */ validatorsForRound,
-        /* changeEachBlock = */ true,
+        /* roundIdentifier = */
+        roundIdentifier,
+        /* prevBlockProposer = */
+        prevBlockProposerAddress,
+        /* validatorsForRound = */
+        validatorsForRound,
+        /* changeEachBlock = */
+        true,
       )
     return SafeFuture.completedFuture(Validator(proposer.bytes.toArray()))
   }

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftConsensusValidator.kt
@@ -8,10 +8,10 @@
  */
 package maru.consensus.qbft
 
-import java.util.concurrent.Executor
 import maru.core.Protocol
 import org.hyperledger.besu.consensus.common.bft.BftExecutors
 import org.hyperledger.besu.consensus.qbft.core.statemachine.QbftController
+import java.util.concurrent.Executor
 
 class QbftConsensusValidator(
   private val qbftController: QbftController,

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftEventProcessor.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftEventProcessor.kt
@@ -8,12 +8,12 @@
  */
 package maru.consensus.qbft
 
-import java.util.Optional
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.consensus.common.bft.BftEventQueue
 import org.hyperledger.besu.consensus.common.bft.events.BftEvent
+import java.util.Optional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class QbftEventProcessor(
   private val incomingQueue: BftEventQueue,

--- a/consensus/src/main/kotlin/maru/consensus/qbft/QbftValidatorFactory.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/QbftValidatorFactory.kt
@@ -8,9 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.time.Clock
-import java.util.concurrent.Executors
-import kotlin.time.Duration.Companion.seconds
 import maru.config.QbftConfig
 import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
@@ -73,6 +70,9 @@ import org.hyperledger.besu.cryptoservices.NodeKey
 import org.hyperledger.besu.ethereum.core.Util
 import org.hyperledger.besu.plugin.services.MetricsSystem
 import org.hyperledger.besu.util.Subscribers
+import java.time.Clock
+import java.util.concurrent.Executors
+import kotlin.time.Duration.Companion.seconds
 
 class QbftValidatorFactory(
   private val beaconChain: BeaconChain,
@@ -90,7 +90,10 @@ class QbftValidatorFactory(
   private val payloadValidationEnabled: Boolean,
   /** Optional: called when BLOCK_TIMER_EXPIRY fires. See [QbftEventMultiplexer.onBlockTimerFired]. */
   private val onBlockTimerFired: ((blockNumber: Long) -> Unit)? = null,
-  /** Optional: called when a QBFT message arrives from P2P, before queue insertion. See [QbftMessageProcessor.onMessageReceived]. */
+  /**
+   * Optional: called when a QBFT message arrives from P2P, before queue insertion.
+   * See [QbftMessageProcessor.onMessageReceived].
+   */
   private val onMessageReceived: ((msgCode: Int, sequenceNumber: Long) -> Unit)? = null,
   /** Optional: called when a block is committed by the QBFT consensus (mined). */
   private val onBlockMined: ((SealedBeaconBlock) -> Unit)? = null,
@@ -156,9 +159,12 @@ class QbftValidatorFactory(
       }
     val roundTimer =
       RoundTimer(
-        /* queue = */ bftEventQueue,
-        /* roundExpiryTimeCalculator = */ roundTimeExpiryCalculator,
-        /* bftExecutors = */ bftExecutors,
+        /* queue = */
+        bftEventQueue,
+        /* roundExpiryTimeCalculator = */
+        roundTimeExpiryCalculator,
+        /* bftExecutors = */
+        bftExecutors,
       )
     val blockTimer = BlockTimer(bftEventQueue, besuForksSchedule, bftExecutors, clock)
     val validatorMulticaster = P2PValidatorMulticaster(p2PNetwork)
@@ -203,31 +209,47 @@ class QbftValidatorFactory(
       )
     val messageValidatorFactory =
       MessageValidatorFactory(
-        /* proposerSelector = */ qbftProposerSelector,
-        /* protocolSchedule = */ protocolSchedule,
-        /* validatorProvider = */ besuValidatorProvider,
-        /* blockInterface = */ blockInterface,
+        /* proposerSelector = */
+        qbftProposerSelector,
+        /* protocolSchedule = */
+        protocolSchedule,
+        /* validatorProvider = */
+        besuValidatorProvider,
+        /* blockInterface = */
+        blockInterface,
       )
     val messageFactory = MessageFactory(nodeKey, blockCodec)
     val qbftRoundFactory =
       QbftRoundFactory(
-        /* finalState = */ finalState,
-        /* blockInterface = */ blockInterface,
-        /* protocolSchedule = */ protocolSchedule,
-        /* minedBlockObservers = */ minedBlockObservers,
-        /* messageValidatorFactory = */ messageValidatorFactory,
-        /* messageFactory = */ messageFactory,
+        /* finalState = */
+        finalState,
+        /* blockInterface = */
+        blockInterface,
+        /* protocolSchedule = */
+        protocolSchedule,
+        /* minedBlockObservers = */
+        minedBlockObservers,
+        /* messageValidatorFactory = */
+        messageValidatorFactory,
+        /* messageFactory = */
+        messageFactory,
       )
 
     val transitionLogger = QbftValidatorModeTransitionLoggerAdapter()
     val qbftBlockHeightManagerFactory =
       QbftBlockHeightManagerFactory(
-        /* finalState = */ finalState,
-        /* roundFactory = */ qbftRoundFactory,
-        /* messageValidatorFactory = */ messageValidatorFactory,
-        /* messageFactory = */ messageFactory,
-        /* validatorProvider = */ besuValidatorProvider,
-        /* validatorModeTransitionLogger = */ transitionLogger,
+        /* finalState = */
+        finalState,
+        /* roundFactory = */
+        qbftRoundFactory,
+        /* messageValidatorFactory = */
+        messageValidatorFactory,
+        /* messageFactory = */
+        messageFactory,
+        /* validatorProvider = */
+        besuValidatorProvider,
+        /* validatorModeTransitionLogger = */
+        transitionLogger,
       )
     val duplicateMessageTracker = MessageTracker(qbftOptions.duplicateMessageLimit)
     val chainHeaderNumber =
@@ -238,20 +260,30 @@ class QbftValidatorFactory(
         .toLong()
     val futureMessageBuffer =
       FutureMessageBuffer<QbftMessage>(
-        /* futureMessagesMaxDistance = */ qbftOptions.futureMessageMaxDistance,
-        /* futureMessagesLimit = */ qbftOptions.futureMessagesLimit,
-        /* chainHeight = */ chainHeaderNumber,
+        /* futureMessagesMaxDistance = */
+        qbftOptions.futureMessageMaxDistance,
+        /* futureMessagesLimit = */
+        qbftOptions.futureMessagesLimit,
+        /* chainHeight = */
+        chainHeaderNumber,
       )
     val gossiper = QbftGossiper(validatorMulticaster)
     val qbftController =
       QbftController(
-        /* blockchain = */ blockChain,
-        /* finalState = */ finalState,
-        /* qbftBlockHeightManagerFactory = */ qbftBlockHeightManagerFactory,
-        /* gossiper = */ gossiper,
-        /* duplicateMessageTracker = */ duplicateMessageTracker,
-        /* futureMessageBuffer = */ futureMessageBuffer,
-        /* blockEncoder = */ blockCodec,
+        /* blockchain = */
+        blockChain,
+        /* finalState = */
+        finalState,
+        /* qbftBlockHeightManagerFactory = */
+        qbftBlockHeightManagerFactory,
+        /* gossiper = */
+        gossiper,
+        /* duplicateMessageTracker = */
+        duplicateMessageTracker,
+        /* futureMessageBuffer = */
+        futureMessageBuffer,
+        /* blockEncoder = */
+        blockCodec,
       )
 
     val eventMultiplexer =

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adapters/ForksScheduleAdapter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adapters/ForksScheduleAdapter.kt
@@ -8,13 +8,13 @@
  */
 package maru.consensus.qbft.adapters
 
-import java.math.BigInteger
-import java.util.Optional
 import maru.config.QbftConfig
 import maru.consensus.ForkSpec
 import org.apache.tuweni.bytes.Bytes
 import org.hyperledger.besu.config.BftConfigOptions
 import org.hyperledger.besu.datatypes.Address
+import java.math.BigInteger
+import java.util.Optional
 import org.hyperledger.besu.consensus.common.ForkSpec as BesuForkSpec
 import org.hyperledger.besu.consensus.common.ForksSchedule as BesuForksSchedule
 

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adapters/QbftBlockImporterAdapter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adapters/QbftBlockImporterAdapter.kt
@@ -8,13 +8,13 @@
  */
 package maru.consensus.qbft.adapters
 
-import java.util.Optional
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockImporter
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList
+import java.util.Optional
 
 /**
  * Responsible for: transactional  and El node

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adapters/QbftBlockValidatorAdapter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adapters/QbftBlockValidatorAdapter.kt
@@ -10,13 +10,13 @@ package maru.consensus.qbft.adapters
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
-import java.util.Optional
 import maru.consensus.validation.BlockValidator
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlock
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockValidator
 import org.hyperledger.besu.ethereum.mainnet.block.access.list.BlockAccessList
+import java.util.Optional
 
 class QbftBlockValidatorAdapter(
   private val blockValidator: BlockValidator,

--- a/consensus/src/main/kotlin/maru/consensus/qbft/adapters/QbftFinalStateAdapter.kt
+++ b/consensus/src/main/kotlin/maru/consensus/qbft/adapters/QbftFinalStateAdapter.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft.adapters
 
-import java.time.Clock
 import maru.consensus.qbft.toAddress
 import maru.database.BeaconChain
 import org.hyperledger.besu.consensus.common.bft.BftHelpers
@@ -21,6 +20,7 @@ import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockCreatorFactory
 import org.hyperledger.besu.consensus.qbft.core.types.QbftFinalState
 import org.hyperledger.besu.cryptoservices.NodeKey
 import org.hyperledger.besu.datatypes.Address
+import java.time.Clock
 
 class QbftFinalStateAdapter(
   private val localAddress: Address,

--- a/consensus/src/main/kotlin/maru/consensus/validation/BeaconBlockValidatorFactory.kt
+++ b/consensus/src/main/kotlin/maru/consensus/validation/BeaconBlockValidatorFactory.kt
@@ -41,18 +41,17 @@ class BeaconBlockValidatorFactoryImpl(
     } else {
       val parentHeader = parentBlock.beaconBlock.beaconBlockHeader
       return CompositeBlockValidator(
-        blockValidators =
-          listOfNotNull(
-            stateRootValidator,
-            BlockNumberValidator(parentHeader),
-            ExecutionPayloadBlockNumberValidator(parentBlock.beaconBlock.beaconBlockBody.executionPayload),
-            TimestampValidator(parentHeader),
-            proposerValidator,
-            ParentRootValidator(parentHeader),
-            bodyRootValidator,
-            executionPayloadValidator,
-            emptyBlockValidator,
-          ),
+        blockValidators = listOfNotNull(
+          stateRootValidator,
+          BlockNumberValidator(parentHeader),
+          ExecutionPayloadBlockNumberValidator(parentBlock.beaconBlock.beaconBlockBody.executionPayload),
+          TimestampValidator(parentHeader),
+          proposerValidator,
+          ParentRootValidator(parentHeader),
+          bodyRootValidator,
+          executionPayloadValidator,
+          emptyBlockValidator,
+        ),
       )
     }
   }

--- a/consensus/src/test/kotlin/maru/consensus/NewBlockHandlerMultiplexerTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/NewBlockHandlerMultiplexerTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus
 
-import kotlin.text.contains
 import maru.core.ext.DataGenerators
 import maru.extensions.encodeHex
 import org.apache.logging.log4j.Logger
@@ -22,6 +21,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.text.contains
 
 class NewBlockHandlerMultiplexerTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/NextBlockTimestampProviderTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/NextBlockTimestampProviderTest.kt
@@ -8,11 +8,11 @@
  */
 package maru.consensus
 
+import org.assertj.core.api.Assertions.assertThat
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import kotlin.test.Test
-import org.assertj.core.api.Assertions.assertThat
 
 class NextBlockTimestampProviderTest {
   private val chainId = 1337u

--- a/consensus/src/test/kotlin/maru/consensus/PrevRandaoProviderTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/PrevRandaoProviderTest.kt
@@ -8,12 +8,12 @@
  */
 package maru.consensus
 
-import kotlin.random.Random
-import kotlin.test.Test
 import maru.crypto.Hashing
 import maru.extensions.encodeHex
 import maru.extensions.xor
 import org.assertj.core.api.Assertions.assertThat
+import kotlin.random.Random
+import kotlin.test.Test
 
 class PrevRandaoProviderTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/ProtocolStarterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/ProtocolStarterTest.kt
@@ -8,11 +8,6 @@
  */
 package maru.consensus
 
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZoneOffset
-import kotlin.time.Duration.Companion.seconds
 import linea.timer.TimerFactory
 import maru.core.Protocol
 import maru.subscription.InOrderFanoutSubscriptionManager
@@ -21,6 +16,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testutils.maru.TestablePeriodicTimerFactory
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.time.Duration.Companion.seconds
 
 class ProtocolStarterTest {
   private class StubProtocol : Protocol {
@@ -316,11 +316,10 @@ class ProtocolStarterTest {
     return ProtocolStarter(
       forksSchedule = forksSchedule,
       protocolFactory = protocolFactory,
-      nextBlockTimestampProvider =
-        NextBlockTimestampProviderImpl(
-          clock = clock,
-          forksSchedule = forksSchedule,
-        ),
+      nextBlockTimestampProvider = NextBlockTimestampProviderImpl(
+        clock = clock,
+        forksSchedule = forksSchedule,
+      ),
       forkTransitionCheckInterval = 1.seconds,
       clock = clock,
       timerFactory = timerFactory,

--- a/consensus/src/test/kotlin/maru/consensus/StaticValidatorProviderTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/StaticValidatorProviderTest.kt
@@ -8,11 +8,11 @@
  */
 package maru.consensus
 
-import kotlin.test.Test
 import maru.core.Validator
 import maru.core.ext.DataGenerators
 import maru.extensions.fromHexToByteArray
 import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
 
 class StaticValidatorProviderTest {
   private val validators = DataGenerators.randomValidators()

--- a/consensus/src/test/kotlin/maru/consensus/blockimport/NewSealedBeaconBlockHandlerMultiplexerTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/blockimport/NewSealedBeaconBlockHandlerMultiplexerTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.blockimport
 
-import kotlin.text.contains
 import maru.core.ext.DataGenerators
 import maru.p2p.SealedBeaconBlockHandler
 import org.apache.logging.log4j.Logger
@@ -22,6 +21,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.text.contains
 
 class NewSealedBeaconBlockHandlerMultiplexerTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/blockimport/TransactionalSealedBeaconBlockImporterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/blockimport/TransactionalSealedBeaconBlockImporterTest.kt
@@ -42,17 +42,16 @@ class TransactionalSealedBeaconBlockImporterTest {
   fun setUp() {
     initialBeaconState = DataGenerators.randomBeaconState(2UL)
     beaconChain = InMemoryBeaconChain(initialBeaconState)
-    qbftBlockImporter =
-      TransactionalSealedBeaconBlockImporter(
-        beaconChain = beaconChain,
-        stateTransition = stateTransition,
-        beaconBlockImporter = {
+    qbftBlockImporter = TransactionalSealedBeaconBlockImporter(
+      beaconChain = beaconChain,
+      stateTransition = stateTransition,
+      beaconBlockImporter = {
           _: BeaconState,
           _: BeaconBlock,
-          ->
-          beaconBlockImporterResponse
-        },
-      )
+        ->
+        beaconBlockImporterResponse
+      },
+    )
   }
 
   @AfterEach

--- a/consensus/src/test/kotlin/maru/consensus/qbft/ConstantRoundTimeExpiryCalculatorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/ConstantRoundTimeExpiryCalculatorTest.kt
@@ -8,12 +8,12 @@
  */
 package maru.consensus.qbft
 
-import java.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class ConstantRoundTimeExpiryCalculatorTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/qbft/DelayedQbftBlockCreatorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/DelayedQbftBlockCreatorTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.math.BigInteger
 import maru.consensus.ValidatorProvider
 import maru.consensus.qbft.adapters.QbftBlockAdapter
 import maru.consensus.qbft.adapters.QbftBlockHeaderAdapter
@@ -37,6 +36,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture
+import java.math.BigInteger
 
 class DelayedQbftBlockCreatorTest {
   private val executionLayerManager = Mockito.mock(ExecutionLayerManager::class.java)

--- a/consensus/src/test/kotlin/maru/consensus/qbft/EagerQbftBlockCreatorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/EagerQbftBlockCreatorTest.kt
@@ -8,12 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import kotlin.random.Random
-import kotlin.time.Duration.Companion.milliseconds
 import maru.consensus.ValidatorProvider
 import maru.consensus.qbft.adapters.QbftBlockHeaderAdapter
 import maru.consensus.qbft.adapters.toBeaconBlock
@@ -66,6 +60,12 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider
 import testutils.besu.BesuFactory
 import testutils.besu.BesuTransactionsHelper
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
 
 class EagerQbftBlockCreatorTest {
   private lateinit var cluster: Cluster
@@ -83,23 +83,20 @@ class EagerQbftBlockCreatorTest {
 
   @BeforeEach
   fun beforeEach() {
-    cluster =
-      Cluster(
-        ClusterConfigurationBuilder().build(),
-        NetConditions(NetTransactions()),
-        ThreadBesuNodeRunner(),
-      )
-    besuInstance =
-      BesuFactory.buildTestBesu().also {
-        cluster.start(it)
-      }
-    ethApiClient =
-      Web3jClientBuilder()
-        .endpoint(besuInstance.engineRpcUrl().get())
-        .timeout(Duration.ofMinutes(1))
-        .timeProvider(SystemTimeProvider.SYSTEM_TIME_PROVIDER)
-        .executionClientEventsPublisher { }
-        .build()
+    cluster = Cluster(
+      ClusterConfigurationBuilder().build(),
+      NetConditions(NetTransactions()),
+      ThreadBesuNodeRunner(),
+    )
+    besuInstance = BesuFactory.buildTestBesu().also {
+      cluster.start(it)
+    }
+    ethApiClient = Web3jClientBuilder()
+      .endpoint(besuInstance.engineRpcUrl().get())
+      .timeout(Duration.ofMinutes(1))
+      .timeProvider(SystemTimeProvider.SYSTEM_TIME_PROVIDER)
+      .executionClientEventsPublisher { }
+      .build()
     reset(
       proposerSelector,
       validatorProvider,
@@ -148,10 +145,9 @@ class EagerQbftBlockCreatorTest {
         },
         prevRandaoProvider = prevRandaoProvider,
         feeRecipient = feeRecipient,
-        config =
-          EagerQbftBlockCreator.Config(
-            minBlockBuildTime = 500.milliseconds,
-          ),
+        config = EagerQbftBlockCreator.Config(
+          minBlockBuildTime = 500.milliseconds,
+        ),
         beaconChain = beaconChain,
       )
     return eagerQbftBlockCreator
@@ -170,10 +166,9 @@ class EagerQbftBlockCreatorTest {
     val parentBlock =
       BeaconBlock(
         beaconBlockHeader = DataGenerators.randomBeaconBlockHeader(0U),
-        beaconBlockBody =
-          DataGenerators
-            .randomBeaconBlockBody()
-            .copy(executionPayload = genesisExecutionPayload),
+        beaconBlockBody = DataGenerators
+          .randomBeaconBlockBody()
+          .copy(executionPayload = genesisExecutionPayload),
       )
     val sealedGenesisBeaconBlock = SealedBeaconBlock(parentBlock, emptySet())
     val parentHeader = QbftBlockHeaderAdapter(sealedGenesisBeaconBlock.beaconBlock.beaconBlockHeader)
@@ -244,10 +239,9 @@ class EagerQbftBlockCreatorTest {
     val genesisBeaconBlock =
       BeaconBlock(
         beaconBlockHeader = DataGenerators.randomBeaconBlockHeader(0U),
-        beaconBlockBody =
-          DataGenerators
-            .randomBeaconBlockBody()
-            .copy(executionPayload = GENESIS_EXECUTION_PAYLOAD),
+        beaconBlockBody = DataGenerators
+          .randomBeaconBlockBody()
+          .copy(executionPayload = GENESIS_EXECUTION_PAYLOAD),
       )
     val sealedGenesisBeaconBlock = SealedBeaconBlock(genesisBeaconBlock, emptySet())
     val parentHeader = QbftBlockHeaderAdapter(sealedGenesisBeaconBlock.beaconBlock.beaconBlockHeader)
@@ -298,10 +292,9 @@ class EagerQbftBlockCreatorTest {
     val genesisBeaconBlock =
       BeaconBlock(
         beaconBlockHeader = DataGenerators.randomBeaconBlockHeader(0U), // Genesis block has number 0
-        beaconBlockBody =
-          DataGenerators
-            .randomBeaconBlockBody()
-            .copy(executionPayload = GENESIS_EXECUTION_PAYLOAD),
+        beaconBlockBody = DataGenerators
+          .randomBeaconBlockBody()
+          .copy(executionPayload = GENESIS_EXECUTION_PAYLOAD),
       )
     val sealedGenesisBeaconBlock = SealedBeaconBlock(genesisBeaconBlock, emptySet())
     val parentHeader = QbftBlockHeaderAdapter(sealedGenesisBeaconBlock.beaconBlock.beaconBlockHeader)

--- a/consensus/src/test/kotlin/maru/consensus/qbft/FollowerBeaconBlockImporterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/FollowerBeaconBlockImporterTest.kt
@@ -8,9 +8,6 @@
  */
 package maru.consensus.qbft
 
-import kotlin.random.Random
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import maru.consensus.NextBlockTimestampProvider
 import maru.consensus.blockimport.BlockBuildingBeaconBlockImporter
 import maru.consensus.state.FinalizationState
@@ -26,6 +23,9 @@ import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class FollowerBeaconBlockImporterTest {
   private lateinit var executionLayerManagerDouble: FakeExecutionLayerManager
@@ -41,17 +41,16 @@ class FollowerBeaconBlockImporterTest {
     executionLayerManagerDouble = FakeExecutionLayerManager()
     finalizationState = FinalizationState(Random.nextBytes(32), Random.nextBytes(32))
 
-    beaconBlockImporter =
-      BlockBuildingBeaconBlockImporter(
-        executionLayerManager = executionLayerManagerDouble,
-        finalizationStateProvider = { finalizationState },
-        nextBlockTimestampProvider = { nextBlockTimestamp },
-        prevRandaoProvider = prevRandaoProvider,
-        shouldBuildNextBlock = { _: BeaconState, _: ConsensusRoundIdentifier, _: ULong ->
-          shouldBuildNextBlock
-        },
-        feeRecipient = feeRecipient,
-      )
+    beaconBlockImporter = BlockBuildingBeaconBlockImporter(
+      executionLayerManager = executionLayerManagerDouble,
+      finalizationStateProvider = { finalizationState },
+      nextBlockTimestampProvider = { nextBlockTimestamp },
+      prevRandaoProvider = prevRandaoProvider,
+      shouldBuildNextBlock = { _: BeaconState, _: ConsensusRoundIdentifier, _: ULong ->
+        shouldBuildNextBlock
+      },
+      feeRecipient = feeRecipient,
+    )
   }
 
   @Test
@@ -102,15 +101,14 @@ class FollowerBeaconBlockImporterTest {
     val nextBlockTimestampProviderDouble = FakeNextBlockTimestampProvider(nextBlockTimestamp)
     val expectedParentTimestamp = randomBeaconState.beaconBlockHeader.timestamp
 
-    beaconBlockImporter =
-      BlockBuildingBeaconBlockImporter(
-        executionLayerManager = executionLayerManagerDouble,
-        finalizationStateProvider = { finalizationState },
-        nextBlockTimestampProvider = nextBlockTimestampProviderDouble,
-        prevRandaoProvider = prevRandaoProvider,
-        shouldBuildNextBlock = shouldBuildNextBlockDouble,
-        feeRecipient = feeRecipient,
-      )
+    beaconBlockImporter = BlockBuildingBeaconBlockImporter(
+      executionLayerManager = executionLayerManagerDouble,
+      finalizationStateProvider = { finalizationState },
+      nextBlockTimestampProvider = nextBlockTimestampProviderDouble,
+      prevRandaoProvider = prevRandaoProvider,
+      shouldBuildNextBlock = shouldBuildNextBlockDouble,
+      feeRecipient = feeRecipient,
+    )
 
     beaconBlockImporter.importBlock(randomBeaconState, randomBeaconBlock)
 

--- a/consensus/src/test/kotlin/maru/consensus/qbft/LinearRoundTimeExpiryCalculatorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/LinearRoundTimeExpiryCalculatorTest.kt
@@ -8,11 +8,11 @@
  */
 package maru.consensus.qbft
 
-import java.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class LinearRoundTimeExpiryCalculatorTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/qbft/MinimalQbftMessageDecoderTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/MinimalQbftMessageDecoderTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.util.Optional
-import kotlin.random.Random
 import maru.consensus.qbft.adapters.QbftBlockAdapter
 import maru.consensus.qbft.adapters.QbftBlockCodecAdapter
 import maru.core.ext.DataGenerators
@@ -39,6 +37,8 @@ import org.hyperledger.besu.datatypes.Hash
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.Optional
+import kotlin.random.Random
 
 class MinimalQbftMessageDecoderTest {
   private val keyData = PrivateKeyGenerator.generatePrivateKey()

--- a/consensus/src/test/kotlin/maru/consensus/qbft/ProposerSelectorImplTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/ProposerSelectorImplTest.kt
@@ -8,13 +8,13 @@
  */
 package maru.consensus.qbft
 
-import java.util.SequencedSet
 import maru.core.BeaconState
 import maru.core.Validator
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.junit.jupiter.api.Test
+import java.util.SequencedSet
 
 class ProposerSelectorImplTest {
   private val totalValidators = 5

--- a/consensus/src/test/kotlin/maru/consensus/qbft/QbftBlockCreatorFactoryTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/QbftBlockCreatorFactoryTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import kotlin.time.Duration.Companion.milliseconds
 import maru.consensus.PrevRandaoProvider
 import maru.consensus.ValidatorProvider
 import maru.consensus.state.FinalizationProvider
@@ -20,6 +19,7 @@ import org.hyperledger.besu.consensus.common.bft.blockcreation.ProposerSelector
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
+import kotlin.time.Duration.Companion.milliseconds
 
 class QbftBlockCreatorFactoryTest {
   private val executionLayerManager = Mockito.mock(ExecutionLayerManager::class.java)

--- a/consensus/src/test/kotlin/maru/consensus/qbft/QbftGossiperTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/QbftGossiperTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import kotlin.test.Test
 import maru.consensus.qbft.adapters.P2PValidatorMulticaster
 import org.hyperledger.besu.consensus.qbft.core.types.QbftMessage
 import org.mockito.Mockito.mock
@@ -16,6 +15,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
+import kotlin.test.Test
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData as BesuMessageData
 
 class QbftGossiperTest {

--- a/consensus/src/test/kotlin/maru/consensus/qbft/QbftMessageProcessorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/QbftMessageProcessorTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.util.concurrent.TimeUnit
 import maru.consensus.qbft.adapters.QbftBlockAdapter
 import maru.consensus.qbft.adapters.QbftBlockCodecAdapter
 import maru.consensus.qbft.adapters.QbftBlockchainAdapter
@@ -38,6 +37,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
 
 class QbftMessageProcessorTest {
   private val keyData = PrivateKeyGenerator.generatePrivateKey()

--- a/consensus/src/test/kotlin/maru/consensus/qbft/QbftSyncChainHeadNotificationTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/QbftSyncChainHeadNotificationTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft
 
-import java.util.concurrent.TimeUnit
 import maru.consensus.qbft.adapters.QbftBlockchainAdapter
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators
@@ -17,6 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.hyperledger.besu.consensus.common.bft.BftEventQueue
 import org.hyperledger.besu.consensus.qbft.core.types.QbftNewChainHead
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 
 /**
  * Verifies that the sync-completion → QbftNewChainHead wiring works with real objects.

--- a/consensus/src/test/kotlin/maru/consensus/qbft/adapters/ProposerSelectorAdapterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/adapters/ProposerSelectorAdapterTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft.adapters
 
-import kotlin.test.Test
 import maru.consensus.qbft.ProposerSelectorImpl
 import maru.consensus.qbft.toAddress
 import maru.core.ext.DataGenerators
@@ -18,6 +17,7 @@ import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
+import kotlin.test.Test
 
 class ProposerSelectorAdapterTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftBlockInterfaceAdapterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftBlockInterfaceAdapterTest.kt
@@ -9,7 +9,6 @@
 package maru.consensus.qbft.adapters
 
 import com.github.michaelbull.result.Ok
-import java.util.SequencedSet
 import maru.consensus.qbft.toAddress
 import maru.consensus.state.StateTransition
 import maru.consensus.validation.StateRootValidator
@@ -20,6 +19,7 @@ import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.SequencedSet
 
 class QbftBlockInterfaceAdapterTest {
   private fun createStateTransition(
@@ -58,11 +58,10 @@ class QbftBlockInterfaceAdapterTest {
     val newProposer = DataGenerators.randomValidator()
     val beaconBlock =
       BeaconBlock(
-        beaconBlockHeader =
-          DataGenerators.randomBeaconBlockHeader(1UL).copy(
-            round = 10u,
-            proposer = originalProposer,
-          ),
+        beaconBlockHeader = DataGenerators.randomBeaconBlockHeader(1UL).copy(
+          round = 10u,
+          proposer = originalProposer,
+        ),
         beaconBlockBody = DataGenerators.randomBeaconBlockBody(),
       )
     val qbftBlock = QbftBlockAdapter(beaconBlock)
@@ -101,11 +100,10 @@ class QbftBlockInterfaceAdapterTest {
     val validators = DataGenerators.randomValidators().toSortedSet()
     val beaconBlock =
       BeaconBlock(
-        beaconBlockHeader =
-          DataGenerators.randomBeaconBlockHeader(1UL).copy(
-            round = 10u,
-            proposer = originalProposer,
-          ),
+        beaconBlockHeader = DataGenerators.randomBeaconBlockHeader(1UL).copy(
+          round = 10u,
+          proposer = originalProposer,
+        ),
         beaconBlockBody = DataGenerators.randomBeaconBlockBody(),
       )
     val qbftBlock = QbftBlockAdapter(beaconBlock)

--- a/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftBlockValidatorAdapterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftBlockValidatorAdapterTest.kt
@@ -10,7 +10,6 @@ package maru.consensus.qbft.adapters
 
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
-import java.util.Optional
 import maru.consensus.validation.BlockValidator
 import maru.core.BeaconBlock
 import maru.core.ext.DataGenerators
@@ -18,6 +17,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.hyperledger.besu.consensus.qbft.core.types.QbftBlockValidator
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.Optional
 
 class QbftBlockValidatorAdapterTest {
   private val newBlock = DataGenerators.randomBeaconBlock(10u)
@@ -26,11 +26,10 @@ class QbftBlockValidatorAdapterTest {
   @Test
   fun `validateBlock should return false when block validation error`() {
     val blockValidatorError = BlockValidator.error("Error")
-    blockValidator =
-      object : BlockValidator {
-        override fun validateBlock(block: BeaconBlock): SafeFuture<Result<Unit, BlockValidator.BlockValidationError>> =
-          SafeFuture.completedFuture(blockValidatorError)
-      }
+    blockValidator = object : BlockValidator {
+      override fun validateBlock(block: BeaconBlock): SafeFuture<Result<Unit, BlockValidator.BlockValidationError>> =
+        SafeFuture.completedFuture(blockValidatorError)
+    }
     val qbftBlockValidatorAdapter =
       QbftBlockValidatorAdapter(
         blockValidator = blockValidator,
@@ -47,11 +46,10 @@ class QbftBlockValidatorAdapterTest {
 
   @Test
   fun `validateBlock should return true when valid block`() {
-    blockValidator =
-      object : BlockValidator {
-        override fun validateBlock(block: BeaconBlock): SafeFuture<Result<Unit, BlockValidator.BlockValidationError>> =
-          SafeFuture.completedFuture(BlockValidator.ok())
-      }
+    blockValidator = object : BlockValidator {
+      override fun validateBlock(block: BeaconBlock): SafeFuture<Result<Unit, BlockValidator.BlockValidationError>> =
+        SafeFuture.completedFuture(BlockValidator.ok())
+    }
 
     val qbftBlockValidatorAdapter =
       QbftBlockValidatorAdapter(

--- a/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftValidatorProviderAdapterTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftValidatorProviderAdapterTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft.adapters
 
-import kotlin.test.Test
 import maru.consensus.ValidatorProvider
 import maru.consensus.qbft.toAddress
 import maru.core.ext.DataGenerators
@@ -16,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture
+import kotlin.test.Test
 
 class QbftValidatorProviderAdapterTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftValidatorProviderAdaptorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/qbft/adapters/QbftValidatorProviderAdaptorTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.consensus.qbft.adapters
 
-import kotlin.test.Test
 import maru.consensus.ValidatorProvider
 import maru.consensus.qbft.toAddress
 import maru.core.ext.DataGenerators
@@ -16,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture
+import kotlin.test.Test
 
 class QbftValidatorProviderAdaptorTest {
   @Test

--- a/consensus/src/test/kotlin/maru/consensus/validation/BlockValidatorTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/validation/BlockValidatorTest.kt
@@ -11,7 +11,6 @@ package maru.consensus.validation
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getError
-import java.util.SequencedSet
 import maru.consensus.ValidatorProvider
 import maru.consensus.qbft.ProposerSelector
 import maru.consensus.qbft.toConsensusRoundIdentifier
@@ -39,6 +38,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.SequencedSet
 
 class BlockValidatorTest {
   private val validators = (1..3).map { DataGenerators.randomValidator() }
@@ -64,10 +64,9 @@ class BlockValidatorTest {
   private val validNewBlockBody =
     DataGenerators.randomBeaconBlockBody(numSeals = validators.size).let { body ->
       body.copy(
-        executionPayload =
-          body.executionPayload.copy(
-            blockNumber = validCurrBlockBody.executionPayload.blockNumber + 1u,
-          ),
+        executionPayload = body.executionPayload.copy(
+          blockNumber = validCurrBlockBody.executionPayload.blockNumber + 1u,
+        ),
       )
     }
   private val validNewBlockStateRootHeader =
@@ -302,11 +301,10 @@ class BlockValidatorTest {
 
     val blockBodyWithEnoughSeals =
       validNewBlockBody.copy(
-        prevCommitSeals =
-          setOf(
-            validNewBlockBody.prevCommitSeals.elementAt(0),
-            validNewBlockBody.prevCommitSeals.elementAt(1),
-          ),
+        prevCommitSeals = setOf(
+          validNewBlockBody.prevCommitSeals.elementAt(0),
+          validNewBlockBody.prevCommitSeals.elementAt(1),
+        ),
       )
     val expectedError = "Seal verification error!"
     val sealsVerifier =
@@ -383,10 +381,9 @@ class BlockValidatorTest {
   fun `test invalid execution payload`() {
     val blockBody =
       validNewBlockBody.copy(
-        executionPayload =
-          validNewBlockBody.executionPayload.copy(
-            timestamp = validNewBlockBody.executionPayload.timestamp + 1u,
-          ),
+        executionPayload = validNewBlockBody.executionPayload.copy(
+          timestamp = validNewBlockBody.executionPayload.timestamp + 1u,
+        ),
       )
     val invalidExecutionClient =
       mock<ExecutionLayerManager> {
@@ -420,10 +417,9 @@ class BlockValidatorTest {
   fun `test empty block`() {
     val blockBody =
       validNewBlockBody.copy(
-        executionPayload =
-          validNewBlockBody.executionPayload.copy(
-            transactions = emptyList(),
-          ),
+        executionPayload = validNewBlockBody.executionPayload.copy(
+          transactions = emptyList(),
+        ),
       )
     val result =
       EmptyBlockValidator
@@ -444,10 +440,9 @@ class BlockValidatorTest {
     val parentExecutionPayload = validCurrBlockBody.executionPayload
     val validBlockBody =
       validNewBlockBody.copy(
-        executionPayload =
-          validNewBlockBody.executionPayload.copy(
-            blockNumber = parentExecutionPayload.blockNumber + 1u,
-          ),
+        executionPayload = validNewBlockBody.executionPayload.copy(
+          blockNumber = parentExecutionPayload.blockNumber + 1u,
+        ),
       )
     val validBlock = validNewBlock.copy(beaconBlockBody = validBlockBody)
 
@@ -462,10 +457,9 @@ class BlockValidatorTest {
     val parentExecutionPayload = validCurrBlockBody.executionPayload
     val invalidBlockBody =
       validNewBlockBody.copy(
-        executionPayload =
-          validNewBlockBody.executionPayload.copy(
-            blockNumber = parentExecutionPayload.blockNumber,
-          ),
+        executionPayload = validNewBlockBody.executionPayload.copy(
+          blockNumber = parentExecutionPayload.blockNumber,
+        ),
       )
     val invalidBlock = validNewBlock.copy(beaconBlockBody = invalidBlockBody)
 
@@ -486,10 +480,9 @@ class BlockValidatorTest {
     val parentExecutionPayload = validCurrBlockBody.executionPayload
     val invalidBlockBody =
       validNewBlockBody.copy(
-        executionPayload =
-          validNewBlockBody.executionPayload.copy(
-            blockNumber = parentExecutionPayload.blockNumber + 2UL,
-          ),
+        executionPayload = validNewBlockBody.executionPayload.copy(
+          blockNumber = parentExecutionPayload.blockNumber + 2UL,
+        ),
       )
     val invalidBlock = validNewBlock.copy(beaconBlockBody = invalidBlockBody)
 

--- a/consensus/src/test/kotlin/maru/consensus/validation/SealsVerifierTest.kt
+++ b/consensus/src/test/kotlin/maru/consensus/validation/SealsVerifierTest.kt
@@ -11,7 +11,6 @@ package maru.consensus.validation
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import java.util.SequencedSet
 import maru.consensus.ValidatorProvider
 import maru.core.BeaconBlockHeader
 import maru.core.Seal
@@ -20,6 +19,7 @@ import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.SequencedSet
 
 class SealsVerifierTest {
   private val validators =

--- a/core/src/main/kotlin/maru/consensus/ForkSchedule.kt
+++ b/core/src/main/kotlin/maru/consensus/ForkSchedule.kt
@@ -8,10 +8,10 @@
  */
 package maru.consensus
 
+import org.apache.logging.log4j.LogManager
 import java.util.NavigableSet
 import java.util.TreeSet
 import kotlin.reflect.KClass
-import org.apache.logging.log4j.LogManager
 
 enum class ClFork(
   val version: Byte,

--- a/core/src/main/kotlin/maru/database/BeaconChain.kt
+++ b/core/src/main/kotlin/maru/database/BeaconChain.kt
@@ -8,10 +8,10 @@
  */
 package maru.database
 
-import kotlin.math.min
 import maru.core.BeaconBlock
 import maru.core.BeaconState
 import maru.core.SealedBeaconBlock
+import kotlin.math.min
 
 interface BeaconChain : AutoCloseable {
   fun isInitialized(): Boolean

--- a/core/src/main/kotlin/maru/services/LongRunningService.kt
+++ b/core/src/main/kotlin/maru/services/LongRunningService.kt
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: MIT OR Apache-2.0
  */
 package maru.services
-import java.util.concurrent.CompletableFuture
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CompletableFuture
 import linea.LongRunningService as LineaLongRunningService
 
 typealias LongRunningService = LineaLongRunningService

--- a/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
+++ b/core/src/main/kotlin/maru/subscription/SubscriptionManager.kt
@@ -8,13 +8,13 @@
  */
 package maru.subscription
 
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import tech.pegasys.teku.infrastructure.async.SafeFuture
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.jvm.internal.CallableReference
 import kotlin.reflect.jvm.ExperimentalReflectionOnLambdas
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
-import tech.pegasys.teku.infrastructure.async.SafeFuture
 
 /**
  * Return the receiver object for a CallableReference.

--- a/core/src/test/kotlin/maru/consensus/ForksScheduleTest.kt
+++ b/core/src/test/kotlin/maru/consensus/ForksScheduleTest.kt
@@ -8,12 +8,12 @@
  */
 package maru.consensus
 
-import kotlin.random.Random
 import maru.core.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import kotlin.random.Random
 
 class ForksScheduleTest {
   private val consensusConfig =
@@ -239,25 +239,22 @@ class ForksScheduleTest {
       ForkSpec(
         timestampSeconds = 1000UL,
         blockTimeSeconds = 10u,
-        configuration =
-          DifficultyAwareQbftConfig(
-            postTtdConfig =
-              QbftConsensusConfig(
-                validatorSet = validators,
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-              ),
-            terminalTotalDifficulty = 1000UL,
+        configuration = DifficultyAwareQbftConfig(
+          postTtdConfig = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
           ),
+          terminalTotalDifficulty = 1000UL,
+        ),
       )
     val qbftFork =
       ForkSpec(
         timestampSeconds = 2000UL,
         blockTimeSeconds = 10u,
-        configuration =
-          QbftConsensusConfig(
-            validatorSet = validators,
-            fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-          ),
+        configuration = QbftConsensusConfig(
+          validatorSet = validators,
+          fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+        ),
       )
 
     @Test
@@ -288,11 +285,10 @@ class ForksScheduleTest {
           difficultyAwareQbftFork,
           qbftFork.copy(
             timestampSeconds = difficultyAwareQbftFork.timestampSeconds + 1000UL,
-            configuration =
-              QbftConsensusConfig(
-                validatorSet = validators,
-                fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
-              ),
+            configuration = QbftConsensusConfig(
+              validatorSet = validators,
+              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
+            ),
           ),
         )
 

--- a/core/src/test/kotlin/maru/core/BeaconBlockHeaderTest.kt
+++ b/core/src/test/kotlin/maru/core/BeaconBlockHeaderTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.core
 
-import kotlin.random.Random
 import maru.core.ext.DataGenerators
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -16,6 +15,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.random.Random
 
 class BeaconBlockHeaderTest {
   @Test

--- a/core/src/test/kotlin/maru/core/InMemoryBeaconChainTest.kt
+++ b/core/src/test/kotlin/maru/core/InMemoryBeaconChainTest.kt
@@ -8,13 +8,13 @@
  */
 package maru.core
 
-import kotlin.random.Random
 import maru.core.ext.DataGenerators
 import maru.database.InMemoryBeaconChain
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class InMemoryBeaconChainTest {
   private lateinit var initialBeaconState: BeaconState

--- a/core/src/test/kotlin/maru/subscription/InOrderFanoutSubscriptionManagerTest.kt
+++ b/core/src/test/kotlin/maru/subscription/InOrderFanoutSubscriptionManagerTest.kt
@@ -8,12 +8,12 @@
  */
 package maru.subscription
 
-import java.util.concurrent.CopyOnWriteArrayList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CopyOnWriteArrayList
 
 class InOrderFanoutSubscriptionManagerTest {
   private lateinit var subscriptionManager: InOrderFanoutSubscriptionManager<String>
@@ -58,10 +58,10 @@ class InOrderFanoutSubscriptionManagerTest {
     notifications: MutableList<String> = CopyOnWriteArrayList(),
     subscriberLabel: String = "SubscriberInnerClass",
   ) : SubscriberRootClass(
-      subscriptionManager = subscriptionManager,
-      notifications = notifications,
-      subscriberLabel = subscriberLabel,
-    )
+    subscriptionManager = subscriptionManager,
+    notifications = notifications,
+    subscriberLabel = subscriberLabel,
+  )
 
   @Test
   fun `should assign id when not provided and remove them`() {
@@ -98,7 +98,8 @@ class InOrderFanoutSubscriptionManagerTest {
       }
 
     val lambdaSubscriberIdPrefix =
-      "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them(InOrderFanoutSubscriptionManagerTest.kt"
+      "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided " +
+        "and remove them(InOrderFanoutSubscriptionManagerTest.kt"
     SubscriberRootClass(subscriptionManager, notifications, "subscriberRootClass3")
       .also { subscriber ->
         val id1 =
@@ -132,7 +133,8 @@ class InOrderFanoutSubscriptionManagerTest {
       .also { subscribersIds.add(it) }
 
     val lambdaSubscriberIdPrefix2 =
-      "maru.subscription.InOrderFanoutSubscriptionManagerTest.should_assign_id_when_not_provided_and_remove_them\$addSubscriber(InOrderFanoutSubscriptionManagerTest.kt"
+      "maru.subscription.InOrderFanoutSubscriptionManagerTest." +
+        "should_assign_id_when_not_provided_and_remove_them\$addSubscriber(InOrderFanoutSubscriptionManagerTest.kt"
 
     fun addSubscriber(handlerName: String) {
       val subsId =
@@ -155,10 +157,14 @@ class InOrderFanoutSubscriptionManagerTest {
      "maru.subscription.SubscriberRootClass.syncHandler133845838",
      "maru.subscription.SubscriberRootClass.asyncHandler133845838",
      lambdas:
-     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:88)",
-     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:89)",
-     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:92)"
-     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:108)"
+     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them
+     by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:88)",
+     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them
+     by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:89)",
+     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them
+     by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:92)"
+     "maru.subscription.InOrderFanoutSubscriptionManagerTest.should assign id when not provided and remove them
+     by reference - root class(InOrderFanoutSubscriptionManagerTest.kt:108)"
      */
 
     subscriptionManager.notifySubscribers("d1")

--- a/core/src/test/kotlin/maru/subscription/SubscriberRootClass.kt
+++ b/core/src/test/kotlin/maru/subscription/SubscriberRootClass.kt
@@ -8,8 +8,8 @@
  */
 package maru.subscription
 
-import java.util.concurrent.CopyOnWriteArrayList
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CopyOnWriteArrayList
 
 open class SubscriberRootClass(
   val subscriptionManager: SubscriptionManager<String>,

--- a/core/src/testFixtures/kotlin/maru/core/ext/DataGenerators.kt
+++ b/core/src/testFixtures/kotlin/maru/core/ext/DataGenerators.kt
@@ -8,11 +8,6 @@
  */
 package maru.core.ext
 
-import java.math.BigInteger
-import java.util.SequencedSet
-import kotlin.random.Random
-import kotlin.random.nextUInt
-import kotlin.random.nextULong
 import maru.core.BeaconBlock
 import maru.core.BeaconBlockBody
 import maru.core.BeaconBlockHeader
@@ -37,6 +32,11 @@ import org.hyperledger.besu.datatypes.Address
 import org.hyperledger.besu.datatypes.TransactionType
 import org.hyperledger.besu.datatypes.Wei
 import org.hyperledger.besu.ethereum.core.Transaction
+import java.math.BigInteger
+import java.util.SequencedSet
+import kotlin.random.Random
+import kotlin.random.nextUInt
+import kotlin.random.nextULong
 
 object DataGenerators {
   val defaultValidatorSet: Set<Validator> =
@@ -127,11 +127,10 @@ object DataGenerators {
   fun randomSealedBeaconBlock(number: ULong): SealedBeaconBlock =
     SealedBeaconBlock(
       beaconBlock = randomBeaconBlock(number),
-      commitSeals =
-        (1..3)
-          .map {
-            Seal(Random.nextBytes(96))
-          }.toSet(),
+      commitSeals = (1..3)
+        .map {
+          Seal(Random.nextBytes(96))
+        }.toSet(),
     )
 
   fun randomBeaconBlockBody(numSeals: Int = 3): BeaconBlockBody =
@@ -208,6 +207,6 @@ object DataGenerators {
   fun randomValidPayloadStatus(): PayloadStatus =
     PayloadStatus(ExecutionPayloadStatus.VALID, latestValidHash = Random.nextBytes(32), validationError = null)
 
-  // Generates a random timestamp restricted to range of 0 to Long.MAX_VALUE as value is converted to a Java long for the ForkSpec
+  // Generates a random timestamp restricted to 0..Long.MAX_VALUE because ForkSpec converts it to a Java long.
   fun randomTimestamp(): ULong = Random.nextLong(0, Long.MAX_VALUE).toULong()
 }

--- a/crypto/src/main/kotlin/maru/crypto/Hashing.kt
+++ b/crypto/src/main/kotlin/maru/crypto/Hashing.kt
@@ -8,10 +8,10 @@
  */
 package maru.crypto
 
-import java.security.MessageDigest
 import maru.core.Hasher
 import org.apache.tuweni.bytes.Bytes
 import org.hyperledger.besu.datatypes.Hash
+import java.security.MessageDigest
 
 object Hashing {
   fun shortShaHash(inputData: ByteArray): ByteArray = sha256(inputData).slice(0 until 20).toByteArray()

--- a/crypto/src/testFixtures/kotlin/maru/crypto/PrivateKeyGenerator.kt
+++ b/crypto/src/testFixtures/kotlin/maru/crypto/PrivateKeyGenerator.kt
@@ -59,7 +59,12 @@ object PrivateKeyGenerator {
     }
 
     override fun toString(): String =
-      "KeyData(privateKey=${privateKey.contentToString()}, prefixedPrivateKey=${prefixedPrivateKey.contentToString()}, address=${address.contentToString()}, peerId=$peerId, nodeKey=$nodeKey)"
+      "KeyData(" +
+        "privateKey=${privateKey.contentToString()}, " +
+        "prefixedPrivateKey=${prefixedPrivateKey.contentToString()}, " +
+        "address=${address.contentToString()}, " +
+        "peerId=$peerId, " +
+        "nodeKey=$nodeKey)"
   }
 
   fun logKeyData(keyData: KeyData) {

--- a/e2e/build.gradle
+++ b/e2e/build.gradle
@@ -64,8 +64,8 @@ tasks.register('acceptanceTest', Test) { test ->
 
   testLogging {
     events TestLogEvent.FAILED,
-      TestLogEvent.SKIPPED,
-      TestLogEvent.STANDARD_ERROR
+        TestLogEvent.SKIPPED,
+        TestLogEvent.STANDARD_ERROR
     // TestLogEvent.STARTED,
     // TestLogEvent.PASSED
     exceptionFormat TestExceptionFormat.FULL

--- a/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
+++ b/e2e/src/acceptanceTest/kotlin/maru/e2e/CliqueToPosTest.kt
@@ -13,17 +13,6 @@ import com.palantir.docker.compose.DockerComposeRule
 import com.palantir.docker.compose.configuration.DockerComposeFiles
 import com.palantir.docker.compose.configuration.ProjectName
 import com.palantir.docker.compose.connection.waiting.HealthChecks
-import java.io.File
-import java.math.BigInteger
-import java.net.URI
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import java.util.UUID
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import linea.kotlin.toULong
 import maru.app.MaruApp
 import maru.config.ApiEndpointConfig
@@ -53,6 +42,17 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import testutils.Web3jTransactionsHelper
 import testutils.maru.MaruFactory
 import testutils.maru.awaitTillMaruHasPeers
+import java.io.File
+import java.math.BigInteger
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 @Disabled("flaky and we don't need it anymore")
 class CliqueToPosTest {
@@ -120,14 +120,13 @@ class CliqueToPosTest {
       cancunTimestamp = forksTimestamps["cancunTime"]!!
       pragueTimestamp = forksTimestamps["pragueTime"]!!
       ttd = forksTimestamps["terminalTotalDifficulty"]!!
-      maruFactory =
-        MaruFactory(
-          validatorPrivateKey = VALIDATOR_PRIVATE_KEY_WITH_PREFIX.fromHexToByteArray(),
-          shanghaiTimestamp = shanghaiTimestamp,
-          cancunTimestamp = cancunTimestamp,
-          pragueTimestamp = pragueTimestamp,
-          ttd = ttd,
-        )
+      maruFactory = MaruFactory(
+        validatorPrivateKey = VALIDATOR_PRIVATE_KEY_WITH_PREFIX.fromHexToByteArray(),
+        shanghaiTimestamp = shanghaiTimestamp,
+        cancunTimestamp = cancunTimestamp,
+        pragueTimestamp = pragueTimestamp,
+        ttd = ttd,
+      )
     }
 
     @AfterAll
@@ -168,27 +167,26 @@ class CliqueToPosTest {
         ethereumJsonRpcUrl = "http://localhost:8545",
         engineApiRpc = "http://localhost:8550",
         dataDir = sequencerMaruTmpDir.toPath(),
-        followers =
-          FollowersConfig(
-            mapOf(
-              "follower-besu" to ApiEndpointConfig(URI.create("http://localhost:9550").toURL()),
-              "follower-erigon" to
-                ApiEndpointConfig(
-                  URI.create("http://localhost:11551").toURL(),
-                  jwtSecretPath = TestEnvironment.JWT_CONFIG_PATH,
-                ),
-              "follower-nethermind" to
-                ApiEndpointConfig(
-                  URI.create("http://localhost:10550").toURL(),
-                  jwtSecretPath = TestEnvironment.JWT_CONFIG_PATH,
-                ),
-              "follower-geth" to
-                ApiEndpointConfig(
-                  URI.create("http://localhost:8561").toURL(),
-                  jwtSecretPath = TestEnvironment.JWT_CONFIG_PATH,
-                ),
-            ),
+        followers = FollowersConfig(
+          mapOf(
+            "follower-besu" to ApiEndpointConfig(URI.create("http://localhost:9550").toURL()),
+            "follower-erigon" to
+              ApiEndpointConfig(
+                URI.create("http://localhost:11551").toURL(),
+                jwtSecretPath = TestEnvironment.JWT_CONFIG_PATH,
+              ),
+            "follower-nethermind" to
+              ApiEndpointConfig(
+                URI.create("http://localhost:10550").toURL(),
+                jwtSecretPath = TestEnvironment.JWT_CONFIG_PATH,
+              ),
+            "follower-geth" to
+              ApiEndpointConfig(
+                URI.create("http://localhost:8561").toURL(),
+                jwtSecretPath = TestEnvironment.JWT_CONFIG_PATH,
+              ),
           ),
+        ),
       )
 
     private var runCounter = 0u
@@ -314,14 +312,13 @@ class CliqueToPosTest {
 
     val followerDataDir = Files.createTempDirectory("maru-$nodeName")
     followerDataDir.toFile().deleteOnExit()
-    maruFollower =
-      maruFactory.buildTestMaruFollowerWithConsensusSwitch(
-        engineApiConfig = engineApiConfig,
-        ethereumApiConfig = engineApiConfig,
-        dataDir = followerDataDir,
-        validatorPortForStaticPeering = maruSequencer.p2pPort(),
-        desyncTolerance = 0UL,
-      )
+    maruFollower = maruFactory.buildTestMaruFollowerWithConsensusSwitch(
+      engineApiConfig = engineApiConfig,
+      ethereumApiConfig = engineApiConfig,
+      dataDir = followerDataDir,
+      validatorPortForStaticPeering = maruSequencer.p2pPort(),
+      desyncTolerance = 0UL,
+    )
 
     maruFollower!!.start()
 

--- a/e2e/src/acceptanceTest/kotlin/maru/e2e/TestEnvironment.kt
+++ b/e2e/src/acceptanceTest/kotlin/maru/e2e/TestEnvironment.kt
@@ -9,12 +9,6 @@
 package maru.e2e
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
-import java.net.URI
-import java.util.Optional
-import java.util.UUID
-import kotlin.io.path.Path
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
 import maru.config.ApiEndpointConfig
 import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
 import org.web3j.protocol.Web3j
@@ -22,6 +16,12 @@ import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3jClientBuilder
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider
+import java.net.URI
+import java.util.Optional
+import java.util.UUID
+import kotlin.io.path.Path
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 object TestEnvironment {
   const val JWT_CONFIG_PATH = "../docker/jwt"
@@ -85,7 +85,7 @@ object TestEnvironment {
     (
       mapOf("follower-geth" to geth1ExecutionEngineClient) +
         (followerExecutionEngineClients - "follower-geth-2" - "follower-nethermind")
-    )
+      )
 
   private fun buildWeb3Client(
     rpcUrl: String,

--- a/executionlayer/src/main/kotlin/maru/executionlayer/ExecutionLayerFactory.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/ExecutionLayerFactory.kt
@@ -27,12 +27,11 @@ object ExecutionLayerFactory {
     metricsFacade: MetricsFacade,
   ): ExecutionLayerManager =
     JsonRpcExecutionLayerManager(
-      executionLayerEngineApiClient =
-        buildExecutionEngineClient(
-          web3JEngineApiClient = web3JEngineApiClient,
-          elFork = elFork,
-          metricsFacade = metricsFacade,
-        ),
+      executionLayerEngineApiClient = buildExecutionEngineClient(
+        web3JEngineApiClient = web3JEngineApiClient,
+        elFork = elFork,
+        metricsFacade = metricsFacade,
+      ),
     )
 
   fun buildExecutionEngineClient(

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/BaseWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/BaseWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -30,12 +30,11 @@ abstract class BaseWeb3JJsonRpcExecutionLayerEngineApiClient(
       category = MaruMetricsCategory.ENGINE_API,
       name = "request.latency",
       description = "Execution Engine API request latency",
-      commonTags =
-        listOf(
-          Tag("fork", getFork().name),
-          Tag("endpoint", web3jClient.getEndpoint()),
-          Tag("method", method),
-        ),
+      commonTags = listOf(
+        Tag("fork", getFork().name),
+        Tag("endpoint", web3jClient.getEndpoint()),
+        Tag("method", method),
+      ),
       tagValueExtractor = {
         when {
           it.payload != null -> listOf(Tag("status", "success"))

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/CancunWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/CancunWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -8,7 +8,6 @@
  */
 package maru.executionlayer.client
 
-import java.util.Optional
 import maru.consensus.ElFork
 import maru.core.ExecutionPayload
 import maru.extensions.captureTimeSafeFuture
@@ -25,6 +24,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
+import java.util.Optional
 
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md
 class CancunWeb3JJsonRpcExecutionLayerEngineApiClient(
@@ -53,9 +53,12 @@ class CancunWeb3JJsonRpcExecutionLayerEngineApiClient(
     createRequestTimer<PayloadStatusV1>(method = "newPayload").captureTimeSafeFuture(
       web3jEngineClient
         .newPayloadV3(
-          /* executionPayload = */ executionPayload.toExecutionPayloadV3(),
-          /* blobVersionedHashes = */ emptyList(),
-          /* parentBeaconBlockRoot = */ Bytes32.ZERO,
+          /* executionPayload = */
+          executionPayload.toExecutionPayloadV3(),
+          /* blobVersionedHashes = */
+          emptyList(),
+          /* parentBeaconBlockRoot = */
+          Bytes32.ZERO,
         ).thenApply {
           if (it.payload != null) {
             Response.fromPayloadReceivedAsJson(it.payload)
@@ -77,10 +80,15 @@ class CancunWeb3JJsonRpcExecutionLayerEngineApiClient(
 
   private fun PayloadAttributesV1.toV3(): PayloadAttributesV3 =
     PayloadAttributesV3(
-      /* timestamp = */ this.timestamp,
-      /* prevRandao = */ this.prevRandao,
-      /* suggestedFeeRecipient = */ this.suggestedFeeRecipient,
-      /* withdrawals = */ emptyList(),
-      /* parentBeaconBlockRoot = */ Bytes32.ZERO,
+      /* timestamp = */
+      this.timestamp,
+      /* prevRandao = */
+      this.prevRandao,
+      /* suggestedFeeRecipient = */
+      this.suggestedFeeRecipient,
+      /* withdrawals = */
+      emptyList(),
+      /* parentBeaconBlockRoot = */
+      Bytes32.ZERO,
     )
 }

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/ParisWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/ParisWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -8,7 +8,6 @@
  */
 package maru.executionlayer.client
 
-import java.util.Optional
 import maru.consensus.ElFork
 import maru.core.ExecutionPayload
 import maru.extensions.captureTimeSafeFuture
@@ -23,6 +22,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
+import java.util.Optional
 
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md
 class ParisWeb3JJsonRpcExecutionLayerEngineApiClient(

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/PragueWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/PragueWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -8,7 +8,6 @@
  */
 package maru.executionlayer.client
 
-import java.util.Optional
 import maru.consensus.ElFork
 import maru.core.ExecutionPayload
 import maru.extensions.captureTimeSafeFuture
@@ -25,6 +24,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
+import java.util.Optional
 
 open class PragueWeb3JJsonRpcExecutionLayerEngineApiClient(
   web3jClient: Web3JClient,

--- a/executionlayer/src/main/kotlin/maru/executionlayer/client/ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/client/ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient.kt
@@ -8,7 +8,6 @@
  */
 package maru.executionlayer.client
 
-import java.util.Optional
 import maru.consensus.ElFork
 import maru.core.ExecutionPayload
 import maru.extensions.captureTimeSafeFuture
@@ -24,6 +23,7 @@ import tech.pegasys.teku.ethereum.executionclient.schema.Response
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
+import java.util.Optional
 
 // https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md
 class ShanghaiWeb3JJsonRpcExecutionLayerEngineApiClient(

--- a/executionlayer/src/main/kotlin/maru/executionlayer/manager/JsonRpcExecutionLayerManager.kt
+++ b/executionlayer/src/main/kotlin/maru/executionlayer/manager/JsonRpcExecutionLayerManager.kt
@@ -8,7 +8,6 @@
  */
 package maru.executionlayer.manager
 
-import java.util.concurrent.atomic.AtomicReference
 import maru.core.ExecutionPayload
 import maru.executionlayer.client.ExecutionLayerEngineApiClient
 import maru.mappers.Mappers.toDomain
@@ -19,6 +18,7 @@ import org.apache.tuweni.bytes.Bytes32
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceStateV1
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
+import java.util.concurrent.atomic.AtomicReference
 
 class JsonRpcExecutionLayerManager(
   private val executionLayerEngineApiClient: ExecutionLayerEngineApiClient,

--- a/executionlayer/src/test/kotlin/maru/executionlayer/manager/JsonRpcExecutionLayerManagerTest.kt
+++ b/executionlayer/src/test/kotlin/maru/executionlayer/manager/JsonRpcExecutionLayerManagerTest.kt
@@ -8,9 +8,6 @@
  */
 package maru.executionlayer.manager
 
-import java.util.concurrent.ExecutionException
-import kotlin.random.Random
-import kotlin.random.nextULong
 import maru.core.ExecutionPayload
 import maru.core.ext.DataGenerators
 import maru.executionlayer.client.ExecutionLayerEngineApiClient
@@ -41,6 +38,9 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.bytes.Bytes20
 import tech.pegasys.teku.infrastructure.bytes.Bytes8
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
+import java.util.concurrent.ExecutionException
+import kotlin.random.Random
+import kotlin.random.nextULong
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult as TekuForkChoiceUpdatedResult
 import tech.pegasys.teku.spec.executionlayer.ExecutionPayloadStatus as TekuExecutionPayloadStatus
 
@@ -126,12 +126,11 @@ class JsonRpcExecutionLayerManagerTest {
     val expectedPayloadStatus =
       PayloadStatus(
         ExecutionPayloadStatus.VALID,
-        latestValidHash =
-          payloadStatus
-            .asInternalExecutionPayload()
-            .latestValidHash
-            .get()
-            .toArray(),
+        latestValidHash = payloadStatus
+          .asInternalExecutionPayload()
+          .latestValidHash
+          .get()
+          .toArray(),
         validationError = null,
       )
     val expectedResult = ForkChoiceUpdatedResult(expectedPayloadStatus, payloadId.wrappedBytes.toArray())
@@ -168,12 +167,11 @@ class JsonRpcExecutionLayerManagerTest {
     val expectedPayloadStatus =
       PayloadStatus(
         ExecutionPayloadStatus.VALID,
-        latestValidHash =
-          payloadStatus
-            .asInternalExecutionPayload()
-            .latestValidHash
-            .get()
-            .toArray(),
+        latestValidHash = payloadStatus
+          .asInternalExecutionPayload()
+          .latestValidHash
+          .get()
+          .toArray(),
         validationError = null,
       )
     val expectedResult = ForkChoiceUpdatedResult(expectedPayloadStatus, payloadId.wrappedBytes.toArray())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,10 @@
 [plugins]
 spring-dependency-management = { id = "io.spring.dependency-management", version = "1.1.5" }
 errorprone = { id = "net.ltgt.errorprone", version = "4.0.1" }
-spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
+spotless = { id = "com.diffplug.spotless", version = "8.2.1" }
 
 [libraries]
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "2.3.0" }
+
+[versions]
+ktlint = "1.0.1"

--- a/jvm-libs/mappers/src/main/kotlin/maru/mappers/Mappers.kt
+++ b/jvm-libs/mappers/src/main/kotlin/maru/mappers/Mappers.kt
@@ -8,8 +8,6 @@
  */
 package maru.mappers
 
-import java.math.BigInteger
-import kotlin.jvm.optionals.getOrNull
 import maru.core.ExecutionPayload
 import maru.executionlayer.manager.ExecutionPayloadStatus
 import maru.executionlayer.manager.ForkChoiceUpdatedResult
@@ -34,6 +32,8 @@ import tech.pegasys.teku.ethereum.executionclient.schema.ExecutionPayloadV3
 import tech.pegasys.teku.ethereum.executionclient.schema.PayloadAttributesV1
 import tech.pegasys.teku.infrastructure.bytes.Bytes20
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
+import java.math.BigInteger
+import kotlin.jvm.optionals.getOrNull
 import tech.pegasys.teku.ethereum.executionclient.schema.ForkChoiceUpdatedResult as TekuForkChoiceUpdatedResult
 import tech.pegasys.teku.spec.executionlayer.PayloadStatus as TekuPayloadStatus
 
@@ -48,8 +48,7 @@ object Mappers {
       recId = v.subtract(Transaction.REPLAY_UNPROTECTED_V_BASE).byteValueExact()
     } else if (v > Transaction.REPLAY_PROTECTED_V_MIN) {
       chainId = v.subtract(Transaction.REPLAY_PROTECTED_V_BASE).divide(Transaction.TWO)
-      recId =
-        v.subtract(Transaction.TWO.multiply(chainId).add(Transaction.REPLAY_PROTECTED_V_BASE)).byteValueExact()
+      recId = v.subtract(Transaction.TWO.multiply(chainId).add(Transaction.REPLAY_PROTECTED_V_BASE)).byteValueExact()
     } else {
       throw RuntimeException("An unsupported encoded `v` value of $v was found")
     }
@@ -148,8 +147,7 @@ object Mappers {
       gasUsed = this.gasUsed.longValue().toULong(),
       timestamp = this.timestamp.longValue().toULong(),
       extraData = this.extraData.toArray(),
-      baseFeePerGas =
-        this.baseFeePerGas.toBigInteger(),
+      baseFeePerGas = this.baseFeePerGas.toBigInteger(),
       blockHash = this.blockHash.toArray(),
       transactions = this.transactions.map { it.toArray() },
     )
@@ -174,60 +172,106 @@ object Mappers {
 
   fun ExecutionPayload.toExecutionPayloadV3() =
     ExecutionPayloadV3(
-      /* parentHash */ Bytes32.wrap(this.parentHash),
-      /* feeRecipient */ Bytes20(Bytes.wrap(this.feeRecipient)),
-      /* stateRoot */ Bytes32.wrap(this.stateRoot),
-      /* receiptsRoot */ Bytes32.wrap(this.receiptsRoot),
-      /* logsBloom */ Bytes.wrap(this.logsBloom),
-      /* prevRandao */ Bytes32.wrap(this.prevRandao),
-      /* blockNumber */ UInt64.valueOf(this.blockNumber.toString()),
-      /* gasLimit */ UInt64.valueOf(this.gasLimit.toString()),
-      /* gasUsed */ UInt64.valueOf(this.gasUsed.toString()),
-      /* timestamp */ UInt64.valueOf(this.timestamp.toString()),
-      /* extraData */ Bytes.wrap(this.extraData),
-      /* baseFeePerGas */ UInt256.valueOf(this.baseFeePerGas),
-      /* blockHash */ Bytes32.wrap(this.blockHash),
-      /* transactions */ this.transactions.map { Bytes.wrap(it) },
-      /* withdrawals */ emptyList(),
-      /* blobGasUsed */ UInt64.ZERO,
-      /* excessBlobGas */ UInt64.ZERO,
+      /* parentHash */
+      Bytes32.wrap(this.parentHash),
+      /* feeRecipient */
+      Bytes20(Bytes.wrap(this.feeRecipient)),
+      /* stateRoot */
+      Bytes32.wrap(this.stateRoot),
+      /* receiptsRoot */
+      Bytes32.wrap(this.receiptsRoot),
+      /* logsBloom */
+      Bytes.wrap(this.logsBloom),
+      /* prevRandao */
+      Bytes32.wrap(this.prevRandao),
+      /* blockNumber */
+      UInt64.valueOf(this.blockNumber.toString()),
+      /* gasLimit */
+      UInt64.valueOf(this.gasLimit.toString()),
+      /* gasUsed */
+      UInt64.valueOf(this.gasUsed.toString()),
+      /* timestamp */
+      UInt64.valueOf(this.timestamp.toString()),
+      /* extraData */
+      Bytes.wrap(this.extraData),
+      /* baseFeePerGas */
+      UInt256.valueOf(this.baseFeePerGas),
+      /* blockHash */
+      Bytes32.wrap(this.blockHash),
+      /* transactions */
+      this.transactions.map { Bytes.wrap(it) },
+      /* withdrawals */
+      emptyList(),
+      /* blobGasUsed */
+      UInt64.ZERO,
+      /* excessBlobGas */
+      UInt64.ZERO,
     )
 
   fun ExecutionPayload.toExecutionPayloadV2() =
     ExecutionPayloadV2(
-      /* parentHash */ Bytes32.wrap(this.parentHash),
-      /* feeRecipient */ Bytes20(Bytes.wrap(this.feeRecipient)),
-      /* stateRoot */ Bytes32.wrap(this.stateRoot),
-      /* receiptsRoot */ Bytes32.wrap(this.receiptsRoot),
-      /* logsBloom */ Bytes.wrap(this.logsBloom),
-      /* prevRandao */ Bytes32.wrap(this.prevRandao),
-      /* blockNumber */ UInt64.valueOf(this.blockNumber.toString()),
-      /* gasLimit */ UInt64.valueOf(this.gasLimit.toString()),
-      /* gasUsed */ UInt64.valueOf(this.gasUsed.toString()),
-      /* timestamp */ UInt64.valueOf(this.timestamp.toString()),
-      /* extraData */ Bytes.wrap(this.extraData),
-      /* baseFeePerGas */ UInt256.valueOf(this.baseFeePerGas),
-      /* blockHash */ Bytes32.wrap(this.blockHash),
-      /* transactions */ this.transactions.map { Bytes.wrap(it) },
-      /* withdrawals */ emptyList(),
+      /* parentHash */
+      Bytes32.wrap(this.parentHash),
+      /* feeRecipient */
+      Bytes20(Bytes.wrap(this.feeRecipient)),
+      /* stateRoot */
+      Bytes32.wrap(this.stateRoot),
+      /* receiptsRoot */
+      Bytes32.wrap(this.receiptsRoot),
+      /* logsBloom */
+      Bytes.wrap(this.logsBloom),
+      /* prevRandao */
+      Bytes32.wrap(this.prevRandao),
+      /* blockNumber */
+      UInt64.valueOf(this.blockNumber.toString()),
+      /* gasLimit */
+      UInt64.valueOf(this.gasLimit.toString()),
+      /* gasUsed */
+      UInt64.valueOf(this.gasUsed.toString()),
+      /* timestamp */
+      UInt64.valueOf(this.timestamp.toString()),
+      /* extraData */
+      Bytes.wrap(this.extraData),
+      /* baseFeePerGas */
+      UInt256.valueOf(this.baseFeePerGas),
+      /* blockHash */
+      Bytes32.wrap(this.blockHash),
+      /* transactions */
+      this.transactions.map { Bytes.wrap(it) },
+      /* withdrawals */
+      emptyList(),
     )
 
   fun ExecutionPayload.toExecutionPayloadV1() =
     ExecutionPayloadV1(
-      /* parentHash */ Bytes32.wrap(this.parentHash),
-      /* feeRecipient */ Bytes20(Bytes.wrap(this.feeRecipient)),
-      /* stateRoot */ Bytes32.wrap(this.stateRoot),
-      /* receiptsRoot */ Bytes32.wrap(this.receiptsRoot),
-      /* logsBloom */ Bytes.wrap(this.logsBloom),
-      /* prevRandao */ Bytes32.wrap(this.prevRandao),
-      /* blockNumber */ UInt64.valueOf(this.blockNumber.toString()),
-      /* gasLimit */ UInt64.valueOf(this.gasLimit.toString()),
-      /* gasUsed */ UInt64.valueOf(this.gasUsed.toString()),
-      /* timestamp */ UInt64.valueOf(this.timestamp.toString()),
-      /* extraData */ Bytes.wrap(this.extraData),
-      /* baseFeePerGas */ UInt256.valueOf(this.baseFeePerGas),
-      /* blockHash */ Bytes32.wrap(this.blockHash),
-      /* transactions */ this.transactions.map { Bytes.wrap(it) },
+      /* parentHash */
+      Bytes32.wrap(this.parentHash),
+      /* feeRecipient */
+      Bytes20(Bytes.wrap(this.feeRecipient)),
+      /* stateRoot */
+      Bytes32.wrap(this.stateRoot),
+      /* receiptsRoot */
+      Bytes32.wrap(this.receiptsRoot),
+      /* logsBloom */
+      Bytes.wrap(this.logsBloom),
+      /* prevRandao */
+      Bytes32.wrap(this.prevRandao),
+      /* blockNumber */
+      UInt64.valueOf(this.blockNumber.toString()),
+      /* gasLimit */
+      UInt64.valueOf(this.gasLimit.toString()),
+      /* gasUsed */
+      UInt64.valueOf(this.gasUsed.toString()),
+      /* timestamp */
+      UInt64.valueOf(this.timestamp.toString()),
+      /* extraData */
+      Bytes.wrap(this.extraData),
+      /* baseFeePerGas */
+      UInt256.valueOf(this.baseFeePerGas),
+      /* blockHash */
+      Bytes32.wrap(this.blockHash),
+      /* transactions */
+      this.transactions.map { Bytes.wrap(it) },
     )
 
   fun PayloadAttributes.toPayloadAttributesV1(): PayloadAttributesV1 =

--- a/jvm-libs/teku-web3j/src/main/kotlin/maru/web3j/TekuWeb3JClientFactory.kt
+++ b/jvm-libs/teku-web3j/src/main/kotlin/maru/web3j/TekuWeb3JClientFactory.kt
@@ -8,13 +8,6 @@
  */
 package maru.web3j
 
-import java.net.URL
-import java.util.Optional
-import java.util.UUID
-import kotlin.io.path.Path
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.toJavaDuration
 import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -25,13 +18,21 @@ import tech.pegasys.teku.ethereum.executionclient.auth.JwtConfig
 import tech.pegasys.teku.ethereum.executionclient.web3j.Web3JClient
 import tech.pegasys.teku.infrastructure.logging.EventLogger
 import tech.pegasys.teku.infrastructure.time.SystemTimeProvider
+import java.net.URL
+import java.util.Optional
+import java.util.UUID
+import kotlin.io.path.Path
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 object JwtHelper {
   fun loadOrGenerate(jwtPath: String): JwtConfig {
     val jwtConfigPath = Optional.ofNullable(jwtPath)
     return JwtConfig
       .createIfNeeded(
-        /* needed = */ true,
+        /* needed = */
+        true,
         jwtConfigPath,
         Optional.of(UUID.randomUUID().toString()),
         Path("/dev/null"), // Teku's API limitation. Would be good to clean it
@@ -64,8 +65,10 @@ object TekuWeb3JClientFactory {
           jwtPath?.let {
             addInterceptor(
               JwtAuthHttpInterceptor(
-                /* jwtConfig = */ JwtHelper.loadOrGenerate(jwtPath),
-                /* timeProvider = */ SystemTimeProvider.SYSTEM_TIME_PROVIDER,
+                /* jwtConfig = */
+                JwtHelper.loadOrGenerate(jwtPath),
+                /* timeProvider = */
+                SystemTimeProvider.SYSTEM_TIME_PROVIDER,
               ),
             )
           }

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/BesuCluster.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/BesuCluster.kt
@@ -8,7 +8,6 @@
  */
 package maru.test.cluster
 
-import java.net.URI
 import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition
 import org.hyperledger.besu.tests.acceptance.dsl.condition.net.NetConditions
@@ -19,6 +18,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.ThreadBesuNodeRunner
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.ClusterConfiguration
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.ClusterConfigurationBuilder
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.net.NetTransactions
+import java.net.URI
 
 class BesuCluster(
   private val clusterConfiguration: ClusterConfiguration = ClusterConfigurationBuilder().build(),

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/MaruCluster.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/MaruCluster.kt
@@ -8,10 +8,6 @@
  */
 package maru.test.cluster
 
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlin.random.Random
-import kotlin.time.Instant
 import maru.app.MaruApp
 import maru.config.MaruConfig
 import maru.consensus.ChainFork
@@ -23,6 +19,10 @@ import maru.test.genesis.GenesisFactory
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.random.Random
+import kotlin.time.Instant
 
 enum class NodeRole {
   Sequencer,
@@ -258,10 +258,9 @@ class MaruCluster(
       createMaru(
         elNode = nodeStartingConfig.elNode,
         config = nodeStartingConfig.maruConfig,
-        bootnodes =
-          nodeStartingConfig.overridingBootnodesNodesLables
-            ?.let { nodesEnrs(it) }
-            ?: bootNodesEnrs,
+        bootnodes = nodeStartingConfig.overridingBootnodesNodesLables
+          ?.let { nodesEnrs(it) }
+          ?: bootNodesEnrs,
         staticpeers = nodesAddr(nodeStartingConfig.staticPeersNodesLables ?: emptyList()),
         nodeKeyData = nodeStartingConfig.nodeKey,
         nodeRole = nodeStartingConfig.nodeRole,

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/MaruConfigHelper.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/MaruConfigHelper.kt
@@ -8,11 +8,6 @@
  */
 package maru.test.cluster
 
-import java.net.URI
-import java.nio.file.Files
-import java.nio.file.Path
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import maru.config.ApiConfig
 import maru.config.ApiEndpointConfig
 import maru.config.FollowersConfig
@@ -28,6 +23,11 @@ import maru.config.SyncingConfig.SyncTargetSelection
 import maru.config.ValidatorElNode
 import maru.crypto.PrivateKeyGenerator
 import maru.extensions.encodeHex
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 val configTemplate: MaruConfig =
   MaruConfig(
@@ -37,30 +37,26 @@ val configTemplate: MaruConfig =
     validatorElNode = null,
     api = ApiConfig(port = 0u),
     qbft = null, // Followers by default
-    p2p =
-      P2PConfig(
-        port = 0u, // find a free port
-        discovery =
-          Discovery(
-            refreshInterval = 10.seconds,
-            port = 0u,
-            bootnodes = emptyList(),
-          ),
-      ),
-    followers = FollowersConfig(emptyMap()),
-    syncing =
-      SyncingConfig(
-        peerChainHeightPollingInterval = 1.seconds,
-        syncTargetSelection = SyncTargetSelection.Highest,
-        elSyncStatusRefreshInterval = 500.milliseconds,
-        desyncTolerance = 0UL,
-      ),
-    observability =
-      ObservabilityConfig(
+    p2p = P2PConfig(
+      port = 0u, // find a free port
+      discovery = Discovery(
+        refreshInterval = 10.seconds,
         port = 0u,
-        prometheusMetricsEnabled = false,
-        jvmMetricsEnabled = false,
+        bootnodes = emptyList(),
       ),
+    ),
+    followers = FollowersConfig(emptyMap()),
+    syncing = SyncingConfig(
+      peerChainHeightPollingInterval = 1.seconds,
+      syncTargetSelection = SyncTargetSelection.Highest,
+      elSyncStatusRefreshInterval = 500.milliseconds,
+      desyncTolerance = 0UL,
+    ),
+    observability = ObservabilityConfig(
+      port = 0u,
+      prometheusMetricsEnabled = false,
+      jvmMetricsEnabled = false,
+    ),
   )
 
 fun initPersistence(
@@ -78,13 +74,11 @@ internal fun setQbftConfigIfSequencer(
 ): MaruConfig {
   var newConfig = config
   if (isSequencer) {
-    newConfig =
-      config.copy(
-        qbft =
-          config.qbft
-            ?.copy(feeRecipient = nodeKeyData.address)
-            ?: QbftConfig(feeRecipient = nodeKeyData.address),
-      )
+    newConfig = config.copy(
+      qbft = config.qbft
+        ?.copy(feeRecipient = nodeKeyData.address)
+        ?: QbftConfig(feeRecipient = nodeKeyData.address),
+    )
   }
   return newConfig
 }
@@ -110,10 +104,9 @@ internal fun setP2pConfig(
     p2pConfig = p2pConfig.copy(discovery = updatedDiscovery)
   }
   if (staticpeers.isNotEmpty()) {
-    p2pConfig =
-      p2pConfig?.copy(
-        staticPeers = staticpeers,
-      )
+    p2pConfig = p2pConfig?.copy(
+      staticPeers = staticpeers,
+    )
   }
   return config.copy(p2p = p2pConfig)
 }
@@ -132,10 +125,9 @@ internal fun setValidatorConfig(
     )
   val updatedForkTransition =
     config.forkTransition.copy(
-      l2EthApiEndpoint =
-        config.forkTransition.l2EthApiEndpoint?.copy(
-          endpoint = URI.create(elNode.ethApiUrl()).toURL(),
-        ) ?: ApiEndpointConfig(URI.create(elNode.ethApiUrl()).toURL()),
+      l2EthApiEndpoint = config.forkTransition.l2EthApiEndpoint?.copy(
+        endpoint = URI.create(elNode.ethApiUrl()).toURL(),
+      ) ?: ApiEndpointConfig(URI.create(elNode.ethApiUrl()).toURL()),
     )
   return config.copy(validatorElNode = updatedValidatorConfig, forkTransition = updatedForkTransition)
 }

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/NodeBuilder.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/NodeBuilder.kt
@@ -8,10 +8,10 @@
  */
 package maru.test.cluster
 
-import java.nio.file.Path
 import maru.config.MaruConfig
 import maru.crypto.PrivateKeyGenerator
 import testutils.besu.BesuFactory
+import java.nio.file.Path
 
 class NodeBuilder(
   maruConfigTemplate: MaruConfig,
@@ -49,11 +49,10 @@ class NodeBuilder(
     prevConfig: MaruConfig,
   ): MaruConfig =
     prevConfig.copy(
-      persistence =
-        prevConfig.persistence.copy(
-          dataPath = clusterDataDir.resolve("$label-data"),
-          privateKeyPath = clusterDataDir.resolve("$label-private-key"),
-        ),
+      persistence = prevConfig.persistence.copy(
+        dataPath = clusterDataDir.resolve("$label-data"),
+        privateKeyPath = clusterDataDir.resolve("$label-private-key"),
+      ),
     )
 
   // fun withElBesu(besuBuilder: () -> BesuNode): NodeBuilder {

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/TestMaruAppFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/cluster/TestMaruAppFactory.kt
@@ -25,18 +25,16 @@ fun createMaru(
 ): MaruApp {
   initPersistence(config.persistence, nodeKeyData)
   var effectiveConfig = config
-  effectiveConfig =
-    setValidatorConfig(
-      config = effectiveConfig,
-      payloadValidationEnabled = nodeRole == NodeRole.Sequencer,
-      elNode = elNode,
-    )
-  effectiveConfig =
-    setQbftConfigIfSequencer(
-      config = effectiveConfig,
-      isSequencer = nodeRole == NodeRole.Sequencer,
-      nodeKeyData = nodeKeyData,
-    )
+  effectiveConfig = setValidatorConfig(
+    config = effectiveConfig,
+    payloadValidationEnabled = nodeRole == NodeRole.Sequencer,
+    elNode = elNode,
+  )
+  effectiveConfig = setQbftConfigIfSequencer(
+    config = effectiveConfig,
+    isSequencer = nodeRole == NodeRole.Sequencer,
+    nodeKeyData = nodeKeyData,
+  )
   effectiveConfig = setP2pConfig(config = effectiveConfig, bootnodes = bootnodes, staticpeers = staticpeers)
 
   return MaruAppFactory().create(

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/extensions/BesuNodeExtensions.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/extensions/BesuNodeExtensions.kt
@@ -22,13 +22,12 @@ fun BesuNode.latestBlock(includeTransactions: Boolean = false): EthBlock.Block {
   var block: EthBlock.Block? = null
   while (retries > 0 && block == null) {
     try {
-      block =
-        this
-          .nodeRequests()
-          .eth()
-          .ethGetBlockByNumber(DefaultBlockParameter.valueOf("latest"), includeTransactions)
-          .send()
-          .block
+      block = this
+        .nodeRequests()
+        .eth()
+        .ethGetBlockByNumber(DefaultBlockParameter.valueOf("latest"), includeTransactions)
+        .send()
+        .block
     } catch (e: Exception) {
       // ignore and retry
     }

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/GenesisFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/GenesisFactory.kt
@@ -8,11 +8,11 @@
  */
 package maru.test.genesis
 
-import kotlin.time.Instant
 import maru.consensus.ChainFork
 import maru.consensus.ForksSchedule
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import kotlin.time.Instant
 
 class GenesisFactory(
   val chainId: UInt,
@@ -28,15 +28,14 @@ class GenesisFactory(
     terminalTotalDifficulty: ULong? = null,
     chainForks: Map<Instant, ChainFork> = emptyMap(),
   ) {
-    forkSchedule =
-      beaconGenesisFactory
-        .create(
-          blockTimeSeconds = blockTimeSeconds,
-          chainId = chainId,
-          validators = sequencersAddresses,
-          terminalTotalDifficulty = terminalTotalDifficulty,
-          forks = chainForks,
-        )
+    forkSchedule = beaconGenesisFactory
+      .create(
+        blockTimeSeconds = blockTimeSeconds,
+        chainId = chainId,
+        validators = sequencersAddresses,
+        terminalTotalDifficulty = terminalTotalDifficulty,
+        forks = chainForks,
+      )
     besuGenesisFactory.setForkSchedule(forkSchedule)
     log.info("initialized fork schedule: $forkSchedule")
   }

--- a/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/MaruGenesisFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/maru/test/genesis/MaruGenesisFactory.kt
@@ -8,8 +8,6 @@
  */
 package maru.test.genesis
 
-import kotlin.time.Clock
-import kotlin.time.Instant
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.DifficultyAwareQbftConfig
@@ -18,6 +16,8 @@ import maru.consensus.ForkSpec
 import maru.consensus.ForksSchedule
 import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class MaruGenesisFactory(
   private val clock: Clock = Clock.System,
@@ -43,11 +43,10 @@ class MaruGenesisFactory(
       val initialForkConfig =
         if (terminalTotalDifficulty != null) {
           DifficultyAwareQbftConfig(
-            postTtdConfig =
-              QbftConsensusConfig(
-                validatorSet = validatorsSet,
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-              ),
+            postTtdConfig = QbftConsensusConfig(
+              validatorSet = validatorsSet,
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+            ),
             terminalTotalDifficulty = terminalTotalDifficulty,
           )
         } else {
@@ -89,11 +88,10 @@ class MaruGenesisFactory(
           val forkConsensusConfig =
             if (index == 0 && terminalTotalDifficulty != null) {
               DifficultyAwareQbftConfig(
-                postTtdConfig =
-                  QbftConsensusConfig(
-                    validatorSet = validatorsSet,
-                    fork = chainFork,
-                  ),
+                postTtdConfig = QbftConsensusConfig(
+                  validatorSet = validatorsSet,
+                  fork = chainFork,
+                ),
                 terminalTotalDifficulty = terminalTotalDifficulty,
               )
             } else {

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/Web3jTransactionsHelper.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/Web3jTransactionsHelper.kt
@@ -8,14 +8,14 @@
  */
 package testutils
 
-import java.math.BigInteger
-import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.web3j.crypto.Credentials
 import org.web3j.protocol.Web3j
 import org.web3j.protocol.core.methods.response.EthSendTransaction
 import org.web3j.tx.RawTransactionManager
+import java.math.BigInteger
+import java.util.concurrent.TimeUnit
 
 class Web3jTransactionsHelper(
   private val web3j: Web3j,

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/besu/BesuFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/besu/BesuFactory.kt
@@ -8,10 +8,6 @@
  */
 package testutils.besu
 
-import java.util.Collections.singletonList
-import java.util.Optional
-import kotlin.jvm.optionals.getOrDefault
-import kotlin.random.Random
 import linea.kotlin.encodeHex
 import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec
 import org.hyperledger.besu.crypto.KeyPairUtil
@@ -30,6 +26,10 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.BesuNodeConfigurationBuilder
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.BesuNodeFactory
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationFactory
+import java.util.Collections.singletonList
+import java.util.Optional
+import kotlin.jvm.optionals.getOrDefault
+import kotlin.random.Random
 
 object BesuFactory {
   private const val PRAGUE_GENESIS = "/el_prague.json"

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/besu/BesuNodeExtensions.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/besu/BesuNodeExtensions.kt
@@ -8,11 +8,11 @@
  */
 package testutils.besu
 
-import java.math.BigInteger
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster
 import org.web3j.protocol.core.DefaultBlockParameter
 import org.web3j.protocol.core.methods.response.EthBlock
+import java.math.BigInteger
 
 fun BesuNode.ethGetBlockByNumber(
   blockParameter: DefaultBlockParameter,

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruExtensions.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruExtensions.kt
@@ -8,12 +8,12 @@
  */
 package testutils.maru
 
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import maru.app.MaruApp
 import org.awaitility.Awaitility.await
 import org.awaitility.core.ConditionFactory
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 fun MaruApp.awaitTillMaruHasPeers(
   numberOfPeers: UInt,

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/MaruFactory.kt
@@ -13,13 +13,6 @@ import io.libp2p.core.crypto.KeyType
 import io.libp2p.core.crypto.generateKeyPair
 import io.libp2p.core.crypto.marshalPrivateKey
 import io.libp2p.core.crypto.unmarshalPrivateKey
-import java.net.URI
-import java.nio.file.Files
-import java.nio.file.Path
-import java.util.concurrent.CompletableFuture
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.kotlin.decodeHex
 import linea.kotlin.encodeHex
@@ -62,6 +55,13 @@ import maru.p2p.messages.StatusManager
 import maru.serialization.SerDe
 import maru.services.NoOpLongRunningService
 import net.consensys.linea.metrics.MetricsFacade
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import org.hyperledger.besu.plugin.services.MetricsSystem as BesuMetricsSystem
 
 /**
@@ -159,41 +159,37 @@ class MaruFactory(
           ForkSpec(
             timestampSeconds = 0UL,
             blockTimeSeconds = 1u,
-            configuration =
-              DifficultyAwareQbftConfig(
-                QbftConsensusConfig(
-                  validatorSet = setOf(Validator(validatorAddress.fromHexToByteArray())),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
-                ),
-                terminalTotalDifficulty = ttd!!,
+            configuration = DifficultyAwareQbftConfig(
+              QbftConsensusConfig(
+                validatorSet = setOf(Validator(validatorAddress.fromHexToByteArray())),
+                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
               ),
+              terminalTotalDifficulty = ttd!!,
+            ),
           ),
           ForkSpec(
             timestampSeconds = shanghaiTimestamp,
             blockTimeSeconds = 1u,
-            configuration =
-              QbftConsensusConfig(
-                validatorSet = setOf(Validator(validatorAddress.fromHexToByteArray())),
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
-              ),
+            configuration = QbftConsensusConfig(
+              validatorSet = setOf(Validator(validatorAddress.fromHexToByteArray())),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
+            ),
           ),
           ForkSpec(
             timestampSeconds = cancunTimestamp,
             blockTimeSeconds = 1u,
-            configuration =
-              QbftConsensusConfig(
-                validatorSet = setOf(Validator(validatorAddress.fromHexToByteArray())),
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
-              ),
+            configuration = QbftConsensusConfig(
+              validatorSet = setOf(Validator(validatorAddress.fromHexToByteArray())),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
+            ),
           ),
           ForkSpec(
             timestampSeconds = pragueTimestamp,
             blockTimeSeconds = 1u,
-            configuration =
-              QbftConsensusConfig(
-                validatorSet = validatorSet,
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-              ),
+            configuration = QbftConsensusConfig(
+              validatorSet = validatorSet,
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+            ),
           ),
         ),
       )
@@ -204,11 +200,10 @@ class MaruFactory(
           ForkSpec(
             timestampSeconds = 0UL,
             blockTimeSeconds = 1u,
-            configuration =
-              QbftConsensusConfig(
-                validatorSet = validatorSet,
-                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-              ),
+            configuration = QbftConsensusConfig(
+              validatorSet = validatorSet,
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+            ),
           ),
         ),
       )
@@ -343,11 +338,10 @@ class MaruFactory(
       persistence = Persistence(dataPath = dataDir),
       qbft = qbftOptions,
       p2p = p2pConfig,
-      validatorElNode =
-        ValidatorElNode(
-          engineApiEndpoint = engineApiEndpointConfig,
-          payloadValidationEnabled = enablePayloadValidation,
-        ),
+      validatorElNode = ValidatorElNode(
+        engineApiEndpoint = engineApiEndpointConfig,
+        payloadValidationEnabled = enablePayloadValidation,
+      ),
       followers = followers,
       observability = observabilityOptions,
       linea = lineaConfig,
@@ -388,29 +382,27 @@ class MaruFactory(
   ): MaruApp =
     MaruAppFactory().create(
       config = config,
-      beaconGenesisConfig =
-        buildForkSchedule(
-          pragueTimestamp,
-          cancunTimestamp,
-          shanghaiTimestamp,
-          ttd,
-          initialValidators,
-        ),
+      beaconGenesisConfig = buildForkSchedule(
+        pragueTimestamp,
+        cancunTimestamp,
+        shanghaiTimestamp,
+        ttd,
+        initialValidators,
+      ),
       overridingP2PNetwork = overridingP2PNetwork,
       overridingFinalizationProvider = overridingFinalizationProvider,
       overridingLineaContractClient = overridingLineaContractClient,
-      overridingApiServer =
-        if (startApiServer) {
-          null
-        } else {
-          object : ApiServer {
-            override fun start(): CompletableFuture<Unit> = NoOpLongRunningService.start()
+      overridingApiServer = if (startApiServer) {
+        null
+      } else {
+        object : ApiServer {
+          override fun start(): CompletableFuture<Unit> = NoOpLongRunningService.start()
 
-            override fun stop(): CompletableFuture<Unit> = NoOpLongRunningService.stop()
+          override fun stop(): CompletableFuture<Unit> = NoOpLongRunningService.stop()
 
-            override fun port(): Int = 0
-          }
-        },
+          override fun port(): Int = 0
+        }
+      },
       p2pNetworkFactory = p2pNetworkFactory,
     )
 

--- a/jvm-libs/test-utils/src/main/kotlin/testutils/maru/TestablePeriodicTimer.kt
+++ b/jvm-libs/test-utils/src/main/kotlin/testutils/maru/TestablePeriodicTimer.kt
@@ -8,11 +8,11 @@
  */
 package testutils.maru
 
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration
 import linea.timer.Timer
 import linea.timer.TimerFactory
 import linea.timer.TimerSchedule
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
 
 // Test implementation that allows controlling the timer execution. Supports only scheduleAtFixedRate
 class TestablePeriodicTimer(

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/BesuClusterTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/BesuClusterTest.kt
@@ -8,11 +8,6 @@
  */
 package maru.test
 
-import java.net.ConnectException
-import java.util.Optional
-import kotlin.random.Random
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.DifficultyAwareQbftConfig
@@ -34,37 +29,38 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import testutils.besu.BesuFactory
+import java.net.ConnectException
+import java.util.Optional
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class BesuClusterTest {
   private lateinit var genesis: String
 
   @BeforeEach
   fun beforeEach() {
-    genesis =
-      BesuGenesisFactory()
-        .apply {
-          setForkSchedule(
-            ForksSchedule(
-              chainId = Random.nextInt(1, Int.MAX_VALUE).toUInt(),
-              forks =
-                listOf(
-                  ForkSpec(
-                    timestampSeconds = 0UL,
-                    blockTimeSeconds = 1U,
-                    configuration =
-                      DifficultyAwareQbftConfig(
-                        terminalTotalDifficulty = UInt.MAX_VALUE.toULong(),
-                        postTtdConfig =
-                          QbftConsensusConfig(
-                            validatorSet = setOf(Validator(Random.nextBytes(20))),
-                            fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
-                          ),
-                      ),
+    genesis = BesuGenesisFactory()
+      .apply {
+        setForkSchedule(
+          ForksSchedule(
+            chainId = Random.nextInt(1, Int.MAX_VALUE).toUInt(),
+            forks = listOf(
+              ForkSpec(
+                timestampSeconds = 0UL,
+                blockTimeSeconds = 1U,
+                configuration = DifficultyAwareQbftConfig(
+                  terminalTotalDifficulty = UInt.MAX_VALUE.toULong(),
+                  postTtdConfig = QbftConsensusConfig(
+                    validatorSet = setOf(Validator(Random.nextBytes(20))),
+                    fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
                   ),
                 ),
+              ),
             ),
-          )
-        }.create()
+          ),
+        )
+      }.create()
   }
 
   fun createBesu(
@@ -90,14 +86,13 @@ class BesuClusterTest {
 
   @Test
   fun `should allow to add nodes to existing cluster and sync`() {
-    cluster =
-      BesuCluster()
-        .apply {
-          addNode(createBesu("besu-0"))
-          addNode(createBesu("besu-1", validator = true))
-          addNode(createBesu("besu-2"))
-          start(false)
-        }
+    cluster = BesuCluster()
+      .apply {
+        addNode(createBesu("besu-0"))
+        addNode(createBesu("besu-1", validator = true))
+        addNode(createBesu("besu-2"))
+        start(false)
+      }
 
     await
       .atMost(30.seconds.toJavaDuration())
@@ -121,13 +116,12 @@ class BesuClusterTest {
 
   @Test
   fun `should allow to start nodes 1 by 1 and sync`() {
-    cluster =
-      BesuCluster()
-        .apply {
-          addNodeAndStart(createBesu("besu-0"))
-          addNodeAndStart(createBesu("besu-1", validator = true))
-          addNodeAndStart(createBesu("besu-2"))
-        }
+    cluster = BesuCluster()
+      .apply {
+        addNodeAndStart(createBesu("besu-0"))
+        addNodeAndStart(createBesu("besu-1", validator = true))
+        addNodeAndStart(createBesu("besu-2"))
+      }
 
     await
       .atMost(120.seconds.toJavaDuration())
@@ -146,12 +140,11 @@ class BesuClusterTest {
 
   @Test
   fun `should remove,stop and add back nodes to the cluster`() {
-    cluster =
-      BesuCluster().apply {
-        addNode(createBesu("sequencer", validator = true))
-        addNode(createBesu("follower-1"))
-        start(false)
-      }
+    cluster = BesuCluster().apply {
+      addNode(createBesu("sequencer", validator = true))
+      addNode(createBesu("follower-1"))
+      start(false)
+    }
 
     await
       .atMost(120.seconds.toJavaDuration())

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/MaruClusterTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/MaruClusterTest.kt
@@ -8,11 +8,6 @@
  */
 package maru.test
 
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
-import kotlin.time.times
-import kotlin.time.toJavaDuration
 import linea.kotlin.toULong
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
@@ -30,6 +25,11 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.time.times
+import kotlin.time.toJavaDuration
 
 class MaruClusterTest {
   private lateinit var cluster: MaruCluster
@@ -38,11 +38,10 @@ class MaruClusterTest {
   fun beforeEach() {
     configureLoggers(
       rootLevel = Level.WARN,
-      logLevels =
-        listOf(
-          "maru" to Level.INFO,
-          "maru.clients" to Level.DEBUG,
-        ),
+      logLevels = listOf(
+        "maru" to Level.INFO,
+        "maru.clients" to Level.DEBUG,
+      ),
     )
   }
 
@@ -55,12 +54,11 @@ class MaruClusterTest {
 
   @Test
   fun `should allow to retrieve nodes by label`() {
-    cluster =
-      MaruCluster()
-        .addNode(NodeRole.Follower)
-        .addNode(NodeRole.Sequencer, withBesuEl = true)
-        .addNode("follower-special")
-        .start()
+    cluster = MaruCluster()
+      .addNode(NodeRole.Follower)
+      .addNode(NodeRole.Sequencer, withBesuEl = true)
+      .addNode("follower-special")
+      .start()
 
     assertThat(cluster.node("follower").nodeRole).isEqualTo(NodeRole.Follower)
     assertThat(cluster.node("follower-special").nodeRole).isEqualTo(NodeRole.Follower)
@@ -70,20 +68,18 @@ class MaruClusterTest {
   @Test
   @Order(2)
   fun `should create network starting at prague`() {
-    cluster =
-      MaruCluster(
-        chainForks =
-          mapOf(
-            // Genesis at Prague
-            Instant.fromEpochSeconds(0L) to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Prague,
-              ),
+    cluster = MaruCluster(
+      chainForks = mapOf(
+        // Genesis at Prague
+        Instant.fromEpochSeconds(0L) to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Prague,
           ),
-      ).addNode(NodeRole.Sequencer, withBesuEl = true) { nodeBuilder ->
-        nodeBuilder.withLabel("sequencer")
-      }.start()
+      ),
+    ).addNode(NodeRole.Sequencer, withBesuEl = true) { nodeBuilder ->
+      nodeBuilder.withLabel("sequencer")
+    }.start()
 
     await()
       .pollInterval(1.seconds.toJavaDuration())
@@ -99,34 +95,32 @@ class MaruClusterTest {
     val now = Clock.System.now()
     val terminalTotalDifficulty = 20UL
     val forkTimeGap = 10.seconds
-    cluster =
-      MaruCluster(
-        terminalTotalDifficulty = terminalTotalDifficulty,
-        chainForks =
-          mapOf(
-            Instant.fromEpochSeconds(0) to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Paris,
-              ),
-            now.plus(30.seconds) to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Shanghai,
-              ),
-            now.plus(30.seconds + forkTimeGap) to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Cancun,
-              ),
-            now.plus(30.seconds + 2 * forkTimeGap) to
-              ChainFork(
-                ClFork.QBFT_PHASE0,
-                ElFork.Prague,
-              ),
+    cluster = MaruCluster(
+      terminalTotalDifficulty = terminalTotalDifficulty,
+      chainForks = mapOf(
+        Instant.fromEpochSeconds(0) to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Paris,
           ),
-      ).addNode("sequencer", addBesu = true)
-        .start()
+        now.plus(30.seconds) to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Shanghai,
+          ),
+        now.plus(30.seconds + forkTimeGap) to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Cancun,
+          ),
+        now.plus(30.seconds + 2 * forkTimeGap) to
+          ChainFork(
+            ClFork.QBFT_PHASE0,
+            ElFork.Prague,
+          ),
+      ),
+    ).addNode("sequencer", addBesu = true)
+      .start()
 
     await()
       .atMost(120.seconds.toJavaDuration())
@@ -144,16 +138,15 @@ class MaruClusterTest {
   @Test
   @Order(4)
   fun `should instantiate multiple nodes in the cluster with static peering and sync`() {
-    cluster =
-      MaruCluster()
-        .addNode("sequencer", addBesu = true)
-        .addNode("follower-internal-0") { nodeBuilder ->
-          nodeBuilder
-            .staticPeers(listOf("sequencer"))
-        }.addNode("follower-internal-1") { nodeBuilder ->
-          nodeBuilder
-            .staticPeers(listOf("sequencer"))
-        }.start()
+    cluster = MaruCluster()
+      .addNode("sequencer", addBesu = true)
+      .addNode("follower-internal-0") { nodeBuilder ->
+        nodeBuilder
+          .staticPeers(listOf("sequencer"))
+      }.addNode("follower-internal-1") { nodeBuilder ->
+        nodeBuilder
+          .staticPeers(listOf("sequencer"))
+      }.start()
 
     await()
       .apply { }
@@ -167,12 +160,11 @@ class MaruClusterTest {
   @Test
   @Order(5)
   fun `should instantiate multiple nodes in the cluster with discovery`() {
-    cluster =
-      MaruCluster()
-        .addNode("bootnode-1")
-        .addNode("sequencer", addBesu = true)
-        .addNode("follower-internal-0")
-        .start()
+    cluster = MaruCluster()
+      .addNode("bootnode-1")
+      .addNode("sequencer", addBesu = true)
+      .addNode("follower-internal-0")
+      .start()
     val followers = cluster.nodes(NodeRole.Follower)
 
     await()
@@ -194,12 +186,11 @@ class MaruClusterTest {
   @Test
   @Order(6)
   fun `should allow to add nodes after cluster is has started`() {
-    cluster =
-      MaruCluster()
-        .addNode("bootnode-0")
-        .addNode("sequencer", addBesu = true)
-        .addNode("follower-internal-0")
-        .start()
+    cluster = MaruCluster()
+      .addNode("bootnode-0")
+      .addNode("sequencer", addBesu = true)
+      .addNode("follower-internal-0")
+      .start()
 
     await()
       .pollInterval(1.seconds.toJavaDuration())
@@ -223,10 +214,9 @@ class MaruClusterTest {
   @Test
   @Order(7)
   fun `should fail when nodes with duplicated labels are added`() {
-    cluster =
-      MaruCluster()
-        .addNode("node-1")
-        .addNode("node-2")
+    cluster = MaruCluster()
+      .addNode("node-1")
+      .addNode("node-2")
 
     try {
       cluster.addNode("node-1")

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/BeaconGenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/BeaconGenesisFactoryTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.test.genesis
 
-import kotlin.time.Instant
 import linea.kotlin.decodeHex
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
@@ -23,6 +22,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.time.Instant
 
 class BeaconGenesisFactoryTest {
   private val validatorAddresses =
@@ -50,18 +50,16 @@ class BeaconGenesisFactoryTest {
     assertThat(result).isEqualTo(
       ForksSchedule(
         chainId = chainId,
-        forks =
-          listOf(
-            ForkSpec(
-              timestampSeconds = 0UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-                ),
+        forks = listOf(
+          ForkSpec(
+            timestampSeconds = 0UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
             ),
           ),
+        ),
       ),
     )
   }
@@ -92,18 +90,16 @@ class BeaconGenesisFactoryTest {
     assertThat(result).isEqualTo(
       ForksSchedule(
         chainId = 1337U,
-        forks =
-          listOf(
-            ForkSpec(
-              timestampSeconds = 0UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
-                ),
+        forks = listOf(
+          ForkSpec(
+            timestampSeconds = 0UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
             ),
           ),
+        ),
       ),
     )
   }
@@ -123,22 +119,19 @@ class BeaconGenesisFactoryTest {
     assertThat(result).isEqualTo(
       ForksSchedule(
         chainId = 1337U,
-        forks =
-          listOf(
-            ForkSpec(
-              timestampSeconds = 0UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                DifficultyAwareQbftConfig(
-                  terminalTotalDifficulty = 50UL,
-                  postTtdConfig =
-                    QbftConsensusConfig(
-                      validatorSet = validators.toSet(),
-                      fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
-                    ),
-                ),
+        forks = listOf(
+          ForkSpec(
+            timestampSeconds = 0UL,
+            blockTimeSeconds = 1U,
+            configuration = DifficultyAwareQbftConfig(
+              terminalTotalDifficulty = 50UL,
+              postTtdConfig = QbftConsensusConfig(
+                validatorSet = validators.toSet(),
+                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
+              ),
             ),
           ),
+        ),
       ),
     )
   }
@@ -167,67 +160,59 @@ class BeaconGenesisFactoryTest {
     assertThat(result).isEqualTo(
       ForksSchedule(
         chainId = 1337U,
-        forks =
-          listOf(
-            ForkSpec(
-              timestampSeconds = 0UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                DifficultyAwareQbftConfig(
-                  terminalTotalDifficulty = 50UL,
-                  postTtdConfig =
-                    QbftConsensusConfig(
-                      validatorSet = validators.toSet(),
-                      fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
-                    ),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 1000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 2000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 3000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 4000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 5000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
-                ),
+        forks = listOf(
+          ForkSpec(
+            timestampSeconds = 0UL,
+            blockTimeSeconds = 1U,
+            configuration = DifficultyAwareQbftConfig(
+              terminalTotalDifficulty = 50UL,
+              postTtdConfig = QbftConsensusConfig(
+                validatorSet = validators.toSet(),
+                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
+              ),
             ),
           ),
+          ForkSpec(
+            timestampSeconds = 1000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Shanghai),
+            ),
+          ),
+          ForkSpec(
+            timestampSeconds = 2000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
+            ),
+          ),
+          ForkSpec(
+            timestampSeconds = 3000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
+            ),
+          ),
+          ForkSpec(
+            timestampSeconds = 4000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+            ),
+          ),
+          ForkSpec(
+            timestampSeconds = 5000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
+            ),
+          ),
+        ),
       ),
     )
   }
@@ -252,31 +237,27 @@ class BeaconGenesisFactoryTest {
     assertThat(result).isEqualTo(
       ForksSchedule(
         chainId = 1337U,
-        forks =
-          listOf(
-            ForkSpec(
-              timestampSeconds = 0UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                DifficultyAwareQbftConfig(
-                  terminalTotalDifficulty = 50UL,
-                  postTtdConfig =
-                    QbftConsensusConfig(
-                      validatorSet = validators.toSet(),
-                      fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
-                    ),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 100_000_000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
-                ),
+        forks = listOf(
+          ForkSpec(
+            timestampSeconds = 0UL,
+            blockTimeSeconds = 1U,
+            configuration = DifficultyAwareQbftConfig(
+              terminalTotalDifficulty = 50UL,
+              postTtdConfig = QbftConsensusConfig(
+                validatorSet = validators.toSet(),
+                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
+              ),
             ),
           ),
+          ForkSpec(
+            timestampSeconds = 100_000_000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
+            ),
+          ),
+        ),
       ),
     )
   }
@@ -300,27 +281,24 @@ class BeaconGenesisFactoryTest {
     assertThat(result).isEqualTo(
       ForksSchedule(
         chainId = 1337U,
-        forks =
-          listOf(
-            ForkSpec(
-              timestampSeconds = 0UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
-                ),
-            ),
-            ForkSpec(
-              timestampSeconds = 100_000_000UL,
-              blockTimeSeconds = 1U,
-              configuration =
-                QbftConsensusConfig(
-                  validatorSet = validators.toSet(),
-                  fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
-                ),
+        forks = listOf(
+          ForkSpec(
+            timestampSeconds = 0UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Paris),
             ),
           ),
+          ForkSpec(
+            timestampSeconds = 100_000_000UL,
+            blockTimeSeconds = 1U,
+            configuration = QbftConsensusConfig(
+              validatorSet = validators.toSet(),
+              fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Cancun),
+            ),
+          ),
+        ),
       ),
     )
   }
@@ -346,7 +324,8 @@ class BeaconGenesisFactoryTest {
         )
       }.isInstanceOf(java.lang.IllegalArgumentException::class.java)
         .hasMessageContaining(
-          "EL forks don't follow the correct order: found [Shanghai, Paris, Cancun, Prague], expected [Paris, Shanghai, Cancun, Prague]",
+          "EL forks don't follow the correct order: found [Shanghai, Paris, Cancun, Prague], " +
+            "expected [Paris, Shanghai, Cancun, Prague]",
         )
     }
 

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/BesuGenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/BesuGenesisFactoryTest.kt
@@ -9,8 +9,6 @@
 package maru.test.genesis
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import kotlin.random.Random
-import kotlin.time.Instant
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.DifficultyAwareQbftConfig
@@ -23,6 +21,8 @@ import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.time.Instant
 
 class BesuGenesisFactoryTest {
   val objectMapper = jacksonObjectMapper()
@@ -103,72 +103,62 @@ class BesuGenesisFactoryTest {
         ForkSpec(
           timestampSeconds = 0UL,
           blockTimeSeconds = 2U,
-          configuration =
-            DifficultyAwareQbftConfig(
-              terminalTotalDifficulty = 2000UL,
-              postTtdConfig =
-                QbftConsensusConfig(
-                  validatorSet = validators,
-                  fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Paris),
-                ),
+          configuration = DifficultyAwareQbftConfig(
+            terminalTotalDifficulty = 2000UL,
+            postTtdConfig = QbftConsensusConfig(
+              validatorSet = validators,
+              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Paris),
             ),
+          ),
         )
       val shanghaiForkSpec =
         ForkSpec(
-          timestampSeconds =
-            Instant.Companion
-              .parse("2025-10-20T00:00:00Z")
-              .epochSeconds
-              .toULong(),
+          timestampSeconds = Instant.Companion
+            .parse("2025-10-20T00:00:00Z")
+            .epochSeconds
+            .toULong(),
           blockTimeSeconds = 2U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Shanghai),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Shanghai),
+          ),
         )
       val cancunForkSpec =
         ForkSpec(
-          timestampSeconds =
-            Instant.Companion
-              .parse("2025-10-21T00:00:00Z")
-              .epochSeconds
-              .toULong(),
+          timestampSeconds = Instant.Companion
+            .parse("2025-10-21T00:00:00Z")
+            .epochSeconds
+            .toULong(),
           blockTimeSeconds = 2U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Cancun),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Cancun),
+          ),
         )
       val pragueForkSpec =
         ForkSpec(
-          timestampSeconds =
-            Instant.Companion
-              .parse("2025-10-22T00:00:00Z")
-              .epochSeconds
-              .toULong(),
+          timestampSeconds = Instant.Companion
+            .parse("2025-10-22T00:00:00Z")
+            .epochSeconds
+            .toULong(),
           blockTimeSeconds = 2U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
+          ),
         )
 
       val osakaForkSpec =
         ForkSpec(
-          timestampSeconds =
-            Instant.Companion
-              .parse("2025-10-23T00:00:00Z")
-              .epochSeconds
-              .toULong(),
+          timestampSeconds = Instant.Companion
+            .parse("2025-10-23T00:00:00Z")
+            .epochSeconds
+            .toULong(),
           blockTimeSeconds = 2U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
+          ),
         )
 
       val forksSchedule =
@@ -202,21 +192,19 @@ class BesuGenesisFactoryTest {
         ForkSpec(
           timestampSeconds = 1000UL,
           blockTimeSeconds = 5U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Prague),
+          ),
         )
       val osakaForkSpec =
         ForkSpec(
           timestampSeconds = 2000UL,
           blockTimeSeconds = 5U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
+          ),
         )
       val forksSchedule = ForksSchedule(13U, listOf(pragueForkSpec, osakaForkSpec))
       val result =
@@ -244,21 +232,19 @@ class BesuGenesisFactoryTest {
         ForkSpec(
           timestampSeconds = 0UL,
           blockTimeSeconds = 5U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Cancun),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Cancun),
+          ),
         )
       val osakaForkSpec =
         ForkSpec(
           timestampSeconds = 2000UL,
           blockTimeSeconds = 5U,
-          configuration =
-            QbftConsensusConfig(
-              validatorSet = validators,
-              fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
-            ),
+          configuration = QbftConsensusConfig(
+            validatorSet = validators,
+            fork = ChainFork(ClFork.QBFT_PHASE1, ElFork.Osaka),
+          ),
         )
       val forksSchedule = ForksSchedule(13U, listOf(cancunForkSpec, osakaForkSpec))
       val result =

--- a/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
+++ b/jvm-libs/test-utils/src/test/kotlin/maru/test/genesis/GenesisFactoryTest.kt
@@ -9,8 +9,6 @@
 package maru.test.genesis
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import kotlin.random.Random
-import kotlin.time.Instant
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.ElFork
@@ -21,6 +19,8 @@ import maru.core.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.time.Instant
 
 class GenesisFactoryTest {
   val objectMapper = jacksonObjectMapper()
@@ -29,11 +29,10 @@ class GenesisFactoryTest {
 
   @BeforeEach
   fun setup() {
-    genesisFactory =
-      GenesisFactory(
-        chainId = 13U,
-        blockTimeSeconds = 1U,
-      )
+    genesisFactory = GenesisFactory(
+      chainId = 13U,
+      blockTimeSeconds = 1U,
+    )
   }
 
   @Test
@@ -102,27 +101,24 @@ class GenesisFactoryTest {
       val expected =
         ForksSchedule(
           chainId = 13U,
-          forks =
-            listOf(
-              ForkSpec(
-                timestampSeconds = epochTimestamp.epochSeconds.toULong(),
-                blockTimeSeconds = 1U,
-                configuration =
-                  QbftConsensusConfig(
-                    validatorSet = validators.map { Validator(it) }.toSet(),
-                    fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
-                  ),
-              ),
-              ForkSpec(
-                timestampSeconds = osakaTimestamp.epochSeconds.toULong(),
-                blockTimeSeconds = 1U,
-                configuration =
-                  QbftConsensusConfig(
-                    validatorSet = validators.map { Validator(it) }.toSet(),
-                    fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
-                  ),
+          forks = listOf(
+            ForkSpec(
+              timestampSeconds = epochTimestamp.epochSeconds.toULong(),
+              blockTimeSeconds = 1U,
+              configuration = QbftConsensusConfig(
+                validatorSet = validators.map { Validator(it) }.toSet(),
+                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Prague),
               ),
             ),
+            ForkSpec(
+              timestampSeconds = osakaTimestamp.epochSeconds.toULong(),
+              blockTimeSeconds = 1U,
+              configuration = QbftConsensusConfig(
+                validatorSet = validators.map { Validator(it) }.toSet(),
+                fork = ChainFork(ClFork.QBFT_PHASE0, ElFork.Osaka),
+              ),
+            ),
+          ),
         )
 
       assertThat(forksSchedule).isEqualTo(expected)

--- a/jvm-libs/utils/src/main/kotlin/linea/maru/KeyTool.kt
+++ b/jvm-libs/utils/src/main/kotlin/linea/maru/KeyTool.kt
@@ -8,13 +8,13 @@
  */
 package linea.maru
 
-import kotlin.system.exitProcess
 import linea.kotlin.decodeHex
 import maru.crypto.PrivateKeyGenerator
 import maru.crypto.PrivateKeyGenerator.getKeyData
 import maru.crypto.PrivateKeyGenerator.getKeyDataByPrefixedKey
 import maru.crypto.PrivateKeyGenerator.logKeyData
 import picocli.CommandLine
+import kotlin.system.exitProcess
 
 @CommandLine.Command(
   name = "keytool",

--- a/linea-finalization-provider/src/main/kotlin/maru/finalization/LineaFinalizationProvider.kt
+++ b/linea-finalization-provider/src/main/kotlin/maru/finalization/LineaFinalizationProvider.kt
@@ -8,8 +8,6 @@
  */
 package maru.finalization
 
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration
 import linea.contract.l1.LineaRollupSmartContractClientReadOnly
 import linea.domain.BlockData
 import linea.domain.BlockParameter
@@ -25,6 +23,8 @@ import maru.extensions.encodeHex
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
 
 class LineaFinalizationProvider(
   private val lineaContract: LineaRollupSmartContractClientReadOnly,
@@ -34,12 +34,12 @@ class LineaFinalizationProvider(
   timerFactory: TimerFactory,
   private val log: Logger = LogManager.getLogger(LineaFinalizationProvider::class.java),
 ) : PeriodicPollingService(
-    name = "l1-finalization-poller",
-    timerFactory = timerFactory,
-    timerSchedule = TimerSchedule.FIXED_RATE,
-    pollingInterval = pollingUpdateInterval,
-    log = log,
-  ),
+  name = "l1-finalization-poller",
+  timerFactory = timerFactory,
+  timerSchedule = TimerSchedule.FIXED_RATE,
+  pollingInterval = pollingUpdateInterval,
+  log = log,
+),
   FinalizationProvider {
   private data class BlockHeader(
     val blockNumber: ULong,
@@ -75,13 +75,12 @@ class LineaFinalizationProvider(
         l2EthApi.ethGetBlockByNumberTxHashes(BlockParameter.Tag.EARLIEST)
       }.get()
       .also { block ->
-        lastFinalizedBlock =
-          AtomicReference(
-            BlockHeader(
-              blockNumber = block.number,
-              hash = block.hash,
-            ),
-          )
+        lastFinalizedBlock = AtomicReference(
+          BlockHeader(
+            blockNumber = block.number,
+            hash = block.hash,
+          ),
+        )
       }
   }
 

--- a/observability/src/main/kotlin/maru/metrics/BesuMetricsCategoryAdapter.kt
+++ b/observability/src/main/kotlin/maru/metrics/BesuMetricsCategoryAdapter.kt
@@ -8,8 +8,8 @@
  */
 package maru.metrics
 
-import java.util.Optional
 import org.apache.logging.log4j.LogManager
+import java.util.Optional
 import net.consensys.linea.metrics.MetricsCategory as LineaMetricsCategory
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory as BesuMetricsCategory
 

--- a/observability/src/main/kotlin/maru/metrics/LabelledSuppliedCounterAdapter.kt
+++ b/observability/src/main/kotlin/maru/metrics/LabelledSuppliedCounterAdapter.kt
@@ -9,11 +9,11 @@
 package maru.metrics
 
 import io.vertx.core.Vertx
-import java.util.function.DoubleSupplier
-import kotlin.time.DurationUnit
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric
+import java.util.function.DoubleSupplier
+import kotlin.time.DurationUnit
 import net.consensys.linea.metrics.MetricsCategory as LineaMetricsCategory
 
 class LabelledSuppliedCounterAdapter(

--- a/observability/src/main/kotlin/maru/metrics/LabelledSuppliedGaugeAdapter.kt
+++ b/observability/src/main/kotlin/maru/metrics/LabelledSuppliedGaugeAdapter.kt
@@ -8,10 +8,10 @@
  */
 package maru.metrics
 
-import java.util.function.DoubleSupplier
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric
+import java.util.function.DoubleSupplier
 import net.consensys.linea.metrics.MetricsCategory as LineaMetricsCategory
 
 class LabelledSuppliedGaugeAdapter(

--- a/observability/src/main/kotlin/maru/metrics/LabelledSuppliedSummaryAdapter.kt
+++ b/observability/src/main/kotlin/maru/metrics/LabelledSuppliedSummaryAdapter.kt
@@ -9,12 +9,12 @@
 package maru.metrics
 
 import io.vertx.core.Vertx
-import java.util.function.Supplier
-import kotlin.time.DurationUnit
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import org.hyperledger.besu.plugin.services.metrics.ExternalSummary
 import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedSummary
+import java.util.function.Supplier
+import kotlin.time.DurationUnit
 import net.consensys.linea.metrics.MetricsCategory as LineaMetricsCategory
 
 class LabelledSuppliedSummaryAdapter(

--- a/observability/src/main/kotlin/maru/metrics/LabelledTimerAdapter.kt
+++ b/observability/src/main/kotlin/maru/metrics/LabelledTimerAdapter.kt
@@ -9,10 +9,10 @@
 package maru.metrics
 
 import io.micrometer.core.instrument.Clock
-import java.util.concurrent.CompletableFuture
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric
+import java.util.concurrent.CompletableFuture
 import net.consensys.linea.metrics.MetricsCategory as LineaMetricsCategory
 import net.consensys.linea.metrics.Timer as LineaTimer
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer as BesuTimer

--- a/observability/src/test/kotlin/maru/metrics/BesuMetricsSystemAdapterTest.kt
+++ b/observability/src/test/kotlin/maru/metrics/BesuMetricsSystemAdapterTest.kt
@@ -12,10 +12,6 @@ import io.micrometer.core.instrument.ImmutableTag
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.vertx.core.Vertx
-import java.util.Optional
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import net.consensys.linea.metrics.MetricsFacade
 import net.consensys.linea.metrics.Tag
 import net.consensys.linea.metrics.micrometer.MicrometerMetricsFacade
@@ -25,6 +21,10 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 import net.consensys.linea.metrics.MetricsCategory as LineaMetricsCategory
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory as BesuMetricsCategory
 
@@ -50,17 +50,15 @@ class BesuMetricsSystemAdapterTest {
   fun beforeEach() {
     vertx = Vertx.vertx()
     meterRegistry = SimpleMeterRegistry()
-    metricsFacade =
-      MicrometerMetricsFacade(
-        meterRegistry,
-        metricsPrefix = "linea.test",
-        allMetricsCommonTags = listOf(Tag("version", "1.0.1")),
-      )
-    besuMetricsSystemAdapter =
-      BesuMetricsSystemAdapter(
-        vertx = vertx,
-        metricsFacade = metricsFacade,
-      )
+    metricsFacade = MicrometerMetricsFacade(
+      meterRegistry,
+      metricsPrefix = "linea.test",
+      allMetricsCommonTags = listOf(Tag("version", "1.0.1")),
+    )
+    besuMetricsSystemAdapter = BesuMetricsSystemAdapter(
+      vertx = vertx,
+      metricsFacade = metricsFacade,
+    )
   }
 
   @Test

--- a/p2p/src/main/kotlin/maru/p2p/Extensions.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Extensions.kt
@@ -14,10 +14,9 @@ fun MaruPeer.toPeerInfo(): PeerInfo =
     enr = null,
     address = address.toExternalForm(),
     status = if (isConnected) PeerInfo.PeerStatus.CONNECTED else PeerInfo.PeerStatus.DISCONNECTED,
-    direction =
-      if (connectionInitiatedLocally()) {
-        PeerInfo.PeerDirection.OUTBOUND
-      } else {
-        PeerInfo.PeerDirection.INBOUND
-      },
+    direction = if (connectionInitiatedLocally()) {
+      PeerInfo.PeerDirection.OUTBOUND
+    } else {
+      PeerInfo.PeerDirection.INBOUND
+    },
   )

--- a/p2p/src/main/kotlin/maru/p2p/Libp2pNetworkFactory.kt
+++ b/p2p/src/main/kotlin/maru/p2p/Libp2pNetworkFactory.kt
@@ -24,9 +24,6 @@ import io.libp2p.pubsub.gossip.builders.GossipParamsBuilder
 import io.libp2p.pubsub.gossip.builders.GossipRouterBuilder
 import io.libp2p.security.secio.SecIoSecureChannel
 import io.libp2p.transport.tcp.TcpTransport
-import java.util.Optional
-import kotlin.random.Random
-import kotlin.time.toJavaDuration
 import maru.config.P2PConfig
 import maru.core.SealedBeaconBlock
 import maru.p2p.topics.ImmediateTopicHandler
@@ -48,6 +45,9 @@ import tech.pegasys.teku.networking.p2p.network.PeerHandler
 import tech.pegasys.teku.networking.p2p.peer.Peer
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod
+import java.util.Optional
+import kotlin.random.Random
+import kotlin.time.toJavaDuration
 import org.hyperledger.besu.plugin.services.MetricsSystem as BesuMetricsSystem
 
 data class TekuLibP2PNetwork(
@@ -105,11 +105,10 @@ class Libp2pNetworkFactory(
       GossipRouterBuilder()
         .apply {
           params = gossipParams
-          scoreParams =
-            GossipScoreParams(
-              GossipPeerScoreParams(isDirect = { _ -> gossipingConfig.considerPeersAsDirect }),
-              GossipTopicsScoreParams(),
-            )
+          scoreParams = GossipScoreParams(
+            GossipPeerScoreParams(isDirect = { _ -> gossipingConfig.considerPeersAsDirect }),
+            GossipTopicsScoreParams(),
+          )
           messageFactory = { getMessageFactory(it, gossipTopicHandlers) }
         }
     val gossipRouter = gossipRouterBuilder.build()
@@ -149,13 +148,20 @@ class Libp2pNetworkFactory(
 
     val p2pNetwork =
       LibP2PNetwork(
-        /* privKey = */ privateKey,
-        /* nodeId = */ libP2PNodeId,
-        /* host = */ host,
-        /* peerManager = */ peerManager,
-        /* advertisedAddresses = */ advertisedAddresses,
-        /* gossipNetwork = */ gossipNetwork,
-        /* listenPorts = */ listOf(port.toInt()),
+        /* privKey = */
+        privateKey,
+        /* nodeId = */
+        libP2PNodeId,
+        /* host = */
+        host,
+        /* peerManager = */
+        peerManager,
+        /* advertisedAddresses = */
+        advertisedAddresses,
+        /* gossipNetwork = */
+        gossipNetwork,
+        /* listenPorts = */
+        listOf(port.toInt()),
       )
     return TekuLibP2PNetwork(p2pNetwork, host, maruPeerManager)
   }

--- a/p2p/src/main/kotlin/maru/p2p/MaruIncomingRpcRequestHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruIncomingRpcRequestHandler.kt
@@ -19,7 +19,7 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcStream
 class MaruIncomingRpcRequestHandler<
   TRequest : RequestMessageAdapter<*, RpcMessageType>,
   TResponse : Message<*, RpcMessageType>,
->(
+  >(
   private val rpcMessageHandler: RpcMessageHandler<TRequest, TResponse>,
   private val requestMessageSerDe: SerDe<TRequest>,
   private val responseMessageSerDe: SerDe<TResponse>,
@@ -45,11 +45,10 @@ class MaruIncomingRpcRequestHandler<
       rpcMessageHandler.handleIncomingMessage(
         peer = peer,
         message = message,
-        callback =
-          MaruRpcResponseCallback(
-            rpcStream = rpcStream,
-            messageSerializer = responseMessageSerDe,
-          ),
+        callback = MaruRpcResponseCallback(
+          rpcStream = rpcStream,
+          messageSerializer = responseMessageSerDe,
+        ),
       )
     } ?: { log.trace("Ignoring message of type {} because peer has been disconnected", message.type) }
   }

--- a/p2p/src/main/kotlin/maru/p2p/MaruPeer.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPeer.kt
@@ -8,13 +8,6 @@
  */
 package maru.p2p
 
-import java.util.Optional
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
-import kotlin.time.Duration
 import maru.config.P2PConfig
 import maru.p2p.messages.BeaconBlocksByRangeRequest
 import maru.p2p.messages.BeaconBlocksByRangeResponse
@@ -36,6 +29,13 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.RpcRequest
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.bodyselector.RpcRequestBodySelector
+import java.util.Optional
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
 
 interface MaruPeer : Peer {
   fun getStatus(): Status?
@@ -155,17 +155,16 @@ class DefaultMaruPeer(
     scheduledDisconnect.ifPresent { it.cancel(false) }
     if (!scheduler.isShutdown) {
       try {
-        scheduledDisconnect =
-          Optional.of(
-            scheduler.schedule(
-              {
-                log.debug("Disconnecting from peerId={} by timeout", this.id)
-                disconnectCleanly(DisconnectReason.UNRESPONSIVE)
-              },
-              delay.inWholeMilliseconds,
-              TimeUnit.MILLISECONDS,
-            ),
-          )
+        scheduledDisconnect = Optional.of(
+          scheduler.schedule(
+            {
+              log.debug("Disconnecting from peerId={} by timeout", this.id)
+              disconnectCleanly(DisconnectReason.UNRESPONSIVE)
+            },
+            delay.inWholeMilliseconds,
+            TimeUnit.MILLISECONDS,
+          ),
+        )
       } catch (e: Exception) {
         log.trace("Failed to schedule disconnect for peerId={}", this.id, e)
       }
@@ -231,7 +230,7 @@ class DefaultMaruPeer(
     TOutgoingHandler : RpcRequestHandler,
     TRequest : RpcRequest,
     RespHandler : RpcResponseHandler<*>,
-  > sendRequest(
+    > sendRequest(
     rpcMethod: RpcMethod<TOutgoingHandler, TRequest, RespHandler>,
     request: TRequest,
     responseHandler: RespHandler,
@@ -241,7 +240,7 @@ class DefaultMaruPeer(
     TOutgoingHandler : RpcRequestHandler,
     TRequest : RpcRequest,
     RespHandler : RpcResponseHandler<*>,
-  > sendRequest(
+    > sendRequest(
     rpcMethod: RpcMethod<TOutgoingHandler, TRequest, RespHandler>,
     rpcRequestBodySelector: RpcRequestBodySelector<TRequest>,
     responseHandler: RespHandler,

--- a/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPeerManager.kt
@@ -8,11 +8,6 @@
  */
 package maru.p2p
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 import maru.config.P2PConfig
 import maru.p2p.discovery.MaruDiscoveryService
 import org.apache.logging.log4j.LogManager
@@ -22,6 +17,11 @@ import tech.pegasys.teku.networking.p2p.network.PeerHandler
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.peer.NodeId
 import tech.pegasys.teku.networking.p2p.peer.Peer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 class MaruPeerManager(
   private val maruPeerFactory: MaruPeerFactory,
@@ -61,15 +61,14 @@ class MaruPeerManager(
       logConnectedPeers()
     }, 20000, 20000, TimeUnit.MILLISECONDS)
     if (discoveryService != null) {
-      discoveryTask =
-        PeerDiscoveryTask(
-          discoveryService = discoveryService,
-          p2pNetwork = p2pNetwork,
-          reputationManager = reputationManager,
-          maxPeers = maxPeers,
-          getPeerCount = { peerCount },
-          discoveryConfig = p2pConfig.discovery!!,
-        )
+      discoveryTask = PeerDiscoveryTask(
+        discoveryService = discoveryService,
+        p2pNetwork = p2pNetwork,
+        reputationManager = reputationManager,
+        maxPeers = maxPeers,
+        getPeerCount = { peerCount },
+        discoveryConfig = p2pConfig.discovery!!,
+      )
       discoveryTask!!.start()
     }
   }

--- a/p2p/src/main/kotlin/maru/p2p/MaruPreparedGossipMessage.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruPreparedGossipMessage.kt
@@ -8,12 +8,12 @@
  */
 package maru.p2p
 
-import java.util.Optional
 import maru.crypto.Hashing
 import org.apache.tuweni.bytes.Bytes
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage
 import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers
+import java.util.Optional
 
 class MaruPreparedGossipMessage(
   private val origMessage: Bytes,

--- a/p2p/src/main/kotlin/maru/p2p/MaruReputationManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruReputationManager.kt
@@ -9,13 +9,6 @@
 package maru.p2p
 
 import com.google.common.base.MoreObjects
-import java.util.EnumSet
-import java.util.Optional
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.concurrent.Volatile
-import kotlin.jvm.optionals.getOrNull
-import kotlin.math.min
-import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import maru.config.P2PConfig
@@ -33,6 +26,13 @@ import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.peer.NodeId
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager
+import java.util.EnumSet
+import java.util.Optional
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.Volatile
+import kotlin.jvm.optionals.getOrNull
+import kotlin.math.min
+import kotlin.time.Instant
 
 class MaruReputationManager(
   metricsSystem: MetricsSystem,

--- a/p2p/src/main/kotlin/maru/p2p/MaruRpcResponseCallback.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruRpcResponseCallback.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p
 
-import java.nio.channels.ClosedChannelException
 import maru.p2p.messages.RpcExceptionSerDe
 import maru.serialization.Serializer
 import org.apache.logging.log4j.LogManager
@@ -21,6 +20,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus.SUCCESS_RESP
 import tech.pegasys.teku.networking.p2p.peer.PeerDisconnectedException
 import tech.pegasys.teku.networking.p2p.rpc.RpcStream
 import tech.pegasys.teku.networking.p2p.rpc.StreamClosedException
+import java.nio.channels.ClosedChannelException
 
 class MaruRpcResponseCallback<TResponse : Message<*, *>>(
   private val rpcStream: RpcStream,

--- a/p2p/src/main/kotlin/maru/p2p/MaruRpcResponseHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/MaruRpcResponseHandler.kt
@@ -8,9 +8,9 @@
  */
 package maru.p2p
 
-import java.util.Optional
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler
+import java.util.Optional
 
 class MaruRpcResponseHandler<TResponse> : RpcResponseHandler<TResponse> {
   val future = SafeFuture<TResponse>()

--- a/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
+++ b/p2p/src/main/kotlin/maru/p2p/NoOpP2PNetwork.kt
@@ -8,12 +8,12 @@
  */
 package maru.p2p
 
-import java.util.UUID
 import maru.consensus.ForkSpec
 import org.apache.logging.log4j.LogManager
 import org.ethereum.beacon.discovery.schema.NodeRecord
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.networking.p2p.peer.NodeId
+import java.util.UUID
 
 object NoOpP2PNetwork : P2PNetwork {
   private val log = LogManager.getLogger(this.javaClass)

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetwork.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetwork.kt
@@ -11,7 +11,6 @@ package maru.p2p
 import io.libp2p.core.pubsub.ValidationResult.Ignore
 import io.libp2p.core.pubsub.ValidationResult.Invalid
 import io.libp2p.core.pubsub.ValidationResult.Valid
-import java.io.Closeable
 import maru.consensus.ForkSpec
 import maru.core.SealedBeaconBlock
 import maru.executionlayer.manager.ExecutionPayloadStatus
@@ -20,6 +19,7 @@ import org.ethereum.beacon.discovery.schema.NodeRecord
 import org.hyperledger.besu.consensus.qbft.core.types.QbftMessage
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.networking.p2p.peer.NodeId
+import java.io.Closeable
 
 const val LINEA_DOMAIN = "linea"
 

--- a/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
+++ b/p2p/src/main/kotlin/maru/p2p/P2PNetworkImpl.kt
@@ -10,13 +10,6 @@ package maru.p2p
 
 import io.libp2p.core.PeerId
 import io.libp2p.core.crypto.unmarshalPrivateKey
-import java.util.Optional
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import kotlin.jvm.optionals.getOrElse
-import kotlin.jvm.optionals.getOrNull
 import linea.timer.TimerFactory
 import maru.config.P2PConfig
 import maru.consensus.ForkSpec
@@ -53,6 +46,13 @@ import tech.pegasys.teku.networking.p2p.network.PeerAddress
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.peer.NodeId
 import tech.pegasys.teku.networking.p2p.peer.Peer
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import kotlin.jvm.optionals.getOrElse
+import kotlin.jvm.optionals.getOrNull
 import org.hyperledger.besu.plugin.services.MetricsSystem as BesuMetricsSystem
 
 class P2PNetworkImpl(
@@ -131,18 +131,16 @@ class P2PNetworkImpl(
       MaruReputationManager(besuMetricsSystem, SystemTimeProvider(), this::isStaticPeer, p2pConfig.reputation)
 
     val rpcMethods = rpcMethodsFactory(statusManager, rpcIdGenerator, { maruPeerManager }, beaconChain)
-    maruPeerManager =
-      MaruPeerManager(
-        maruPeerFactory =
-          DefaultMaruPeerFactory(
-            rpcMethods = rpcMethods,
-            statusManager = statusManager,
-            p2pConfig = p2pConfig,
-          ),
+    maruPeerManager = MaruPeerManager(
+      maruPeerFactory = DefaultMaruPeerFactory(
+        rpcMethods = rpcMethods,
+        statusManager = statusManager,
         p2pConfig = p2pConfig,
-        reputationManager = reputationManager,
-        isStaticPeer = this::isStaticPeer,
-      )
+      ),
+      p2pConfig = p2pConfig,
+      reputationManager = reputationManager,
+      isStaticPeer = this::isStaticPeer,
+    )
 
     return Libp2pNetworkFactory(LINEA_DOMAIN).build(
       privateKey = privateKey,
@@ -208,20 +206,18 @@ class P2PNetworkImpl(
             .createPeerAddress(peer)
             ?.let { address -> addStaticPeer(address as MultiaddrPeerAddress) }
         }
-        discoveryService =
-          p2pConfig.discovery?.let { discoveryConfig ->
-            MaruDiscoveryService(
-              privateKeyBytes = privateKeyBytesWithoutPrefix(privateKeyBytes),
-              p2pConfig =
-                p2pConfig.copy(
-                  port = port, // use actual listening port
-                  discovery = if (discoveryConfig.port == 0u) discoveryConfig.copy(port = port) else discoveryConfig,
-                ),
-              forkIdHashManager = forkIdHashManager,
-              p2PState = p2PState,
-              timerFactory = timerFactory,
-            )
-          }
+        discoveryService = p2pConfig.discovery?.let { discoveryConfig ->
+          MaruDiscoveryService(
+            privateKeyBytes = privateKeyBytesWithoutPrefix(privateKeyBytes),
+            p2pConfig = p2pConfig.copy(
+              port = port, // use actual listening port
+              discovery = if (discoveryConfig.port == 0u) discoveryConfig.copy(port = port) else discoveryConfig,
+            ),
+            forkIdHashManager = forkIdHashManager,
+            p2PState = p2PState,
+            timerFactory = timerFactory,
+          )
+        }
         discoveryService?.start()
         maruPeerManager.start(discoveryService, p2pNetwork)
         metricsFacade.createGauge(

--- a/p2p/src/main/kotlin/maru/p2p/PeerDiscoveryTask.kt
+++ b/p2p/src/main/kotlin/maru/p2p/PeerDiscoveryTask.kt
@@ -8,11 +8,6 @@
  */
 package maru.p2p
 
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.toJavaDuration
 import maru.config.P2PConfig
 import maru.p2p.discovery.MaruDiscoveryService
 import org.apache.logging.log4j.LogManager
@@ -23,6 +18,11 @@ import tech.pegasys.teku.networking.p2p.libp2p.PeerAlreadyConnectedException
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork
 import tech.pegasys.teku.networking.p2p.peer.Peer
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.toJavaDuration
 
 class PeerDiscoveryTask(
   private val discoveryService: MaruDiscoveryService,
@@ -46,13 +46,12 @@ class PeerDiscoveryTask(
       log.warn("Trying to start already started PeerDiscoveryTask")
       return
     }
-    discoveryTaskFuture =
-      scheduler.scheduleWithFixedDelay(
-        { runSearchTask(discoveryService) },
-        0,
-        discoveryConfig.searchInterval.inWholeMilliseconds,
-        TimeUnit.MILLISECONDS,
-      )
+    discoveryTaskFuture = scheduler.scheduleWithFixedDelay(
+      { runSearchTask(discoveryService) },
+      0,
+      discoveryConfig.searchInterval.inWholeMilliseconds,
+      TimeUnit.MILLISECONDS,
+    )
   }
 
   fun stop() {

--- a/p2p/src/main/kotlin/maru/p2p/RpcMethods.kt
+++ b/p2p/src/main/kotlin/maru/p2p/RpcMethods.kt
@@ -47,17 +47,15 @@ open class RpcMethods(
 
   val beaconBlocksByRangeRequestMessageSerDe =
     BeaconBlocksByRangeRequestMessageSerDe(
-      beaconBlocksByRangeRequestSerDe =
-        MaruCompressorRLPSerDe(
-          serDe = BeaconBlocksByRangeRequestSerDe(),
-        ),
+      beaconBlocksByRangeRequestSerDe = MaruCompressorRLPSerDe(
+        serDe = BeaconBlocksByRangeRequestSerDe(),
+      ),
     )
   val beaconBlocksByRangeResponseMessageSerDe =
     BeaconBlocksByRangeResponseMessageSerDe(
-      beaconBlocksByRangeResponseSerDe =
-        MaruCompressorRLPSerDe(
-          serDe = BeaconBlocksByRangeResponseSerDe(RLPSerializers.SealedBeaconBlockSerializer),
-        ),
+      beaconBlocksByRangeResponseSerDe = MaruCompressorRLPSerDe(
+        serDe = BeaconBlocksByRangeResponseSerDe(RLPSerializers.SealedBeaconBlockSerializer),
+      ),
     )
 
   val beaconBlocksByRangeRpcMethod =

--- a/p2p/src/main/kotlin/maru/p2p/SubscriptionManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/SubscriptionManager.kt
@@ -8,10 +8,10 @@
  */
 package maru.p2p
 
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.function.Supplier
 import org.apache.logging.log4j.LogManager
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.Supplier
 
 class SubscriptionManager<E> {
   private val log = LogManager.getLogger(this.javaClass)

--- a/p2p/src/main/kotlin/maru/p2p/discovery/MaruDiscoveryService.kt
+++ b/p2p/src/main/kotlin/maru/p2p/discovery/MaruDiscoveryService.kt
@@ -8,11 +8,6 @@
  */
 package maru.p2p.discovery
 
-import java.util.Optional
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import linea.kotlin.encodeHex
 import linea.kotlin.toBigInteger
 import linea.kotlin.toULong
@@ -39,6 +34,11 @@ import org.ethereum.beacon.discovery.schema.NodeRecordFactory
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer
 import tech.pegasys.teku.networking.p2p.discovery.discv5.SecretKeyParser
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 class MaruDiscoveryService(
   privateKeyBytes: ByteArray,
@@ -152,15 +152,14 @@ class MaruDiscoveryService(
     return discoverySystem
       .start()
       .thenRun {
-        poller =
-          timerFactory.createTimer(
-            name = "boot-node-refresher",
-            initialDelay = if (timerFactory is VertxTimerFactory) 1.milliseconds else Duration.ZERO,
-            period = p2pConfig.discovery!!.refreshInterval,
-            timerSchedule = TimerSchedule.FIXED_RATE,
-            errorHandler = { e -> log.warn("Failed to ping bootnodes", e) },
-            task = Runnable { pingBootnodes() },
-          )
+        poller = timerFactory.createTimer(
+          name = "boot-node-refresher",
+          initialDelay = if (timerFactory is VertxTimerFactory) 1.milliseconds else Duration.ZERO,
+          period = p2pConfig.discovery!!.refreshInterval,
+          timerSchedule = TimerSchedule.FIXED_RATE,
+          errorHandler = { e -> log.warn("Failed to ping bootnodes", e) },
+          task = Runnable { pingBootnodes() },
+        )
         poller!!.start()
       }.thenApply {}
   }
@@ -220,9 +219,12 @@ class MaruDiscoveryService(
         .signer(signer)
         .seq(UInt64.valueOf(sequenceNumber.toBigInteger()))
         .address(
-          /* ipAddress = */ p2pConfig.discovery!!.advertisedIp ?: p2pConfig.ipAddress,
-          /* udpPort = */ p2pConfig.discovery!!.port.toInt(),
-          /* tcpPort = */ p2pConfig.port.toInt(),
+          /* ipAddress = */
+          p2pConfig.discovery!!.advertisedIp ?: p2pConfig.ipAddress,
+          /* udpPort = */
+          p2pConfig.discovery!!.port.toInt(),
+          /* tcpPort = */
+          p2pConfig.port.toInt(),
         ).customField(FORK_ID_HASH_FIELD_NAME, Bytes.wrap(forkIdHashManager.currentForkHash()))
     // TODO: do we want more custom fields to identify version/topics/role/something else?
 

--- a/p2p/src/main/kotlin/maru/p2p/fork/ForkId.kt
+++ b/p2p/src/main/kotlin/maru/p2p/fork/ForkId.kt
@@ -8,12 +8,12 @@
  */
 package maru.p2p.fork
 
-import java.nio.ByteBuffer
 import linea.kotlin.encodeHex
 import maru.core.Hasher
 import maru.core.ObjHasher
 import maru.crypto.Keccak256Hasher
 import maru.serialization.Serializer
+import java.nio.ByteBuffer
 
 data class ForkId(
   val prevForkIdDigest: ByteArray,

--- a/p2p/src/main/kotlin/maru/p2p/fork/ForkPeeringManager.kt
+++ b/p2p/src/main/kotlin/maru/p2p/fork/ForkPeeringManager.kt
@@ -8,17 +8,17 @@
  */
 package maru.p2p.fork
 
-import java.time.Clock
-import kotlin.time.Duration
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
-import kotlin.time.toKotlinInstant
 import linea.kotlin.encodeHex
 import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ForkSpec
 import maru.database.BeaconChain
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.time.Clock
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlin.time.toKotlinInstant
 
 data class ForkInfo(
   val forkSpec: ForkSpec,

--- a/p2p/src/main/kotlin/maru/p2p/fork/ForkSpecDigester.kt
+++ b/p2p/src/main/kotlin/maru/p2p/fork/ForkSpecDigester.kt
@@ -8,12 +8,12 @@
  */
 package maru.p2p.fork
 
-import java.nio.ByteBuffer
 import linea.kotlin.encodeHex
 import maru.consensus.DifficultyAwareQbftConfig
 import maru.consensus.ForkSpec
 import maru.consensus.QbftConsensusConfig
 import maru.serialization.Serializer
+import java.nio.ByteBuffer
 
 object QbftConsensusConfigDigester : Serializer<QbftConsensusConfig> {
   override fun serialize(value: QbftConsensusConfig): ByteArray {

--- a/p2p/src/main/kotlin/maru/p2p/fork/RollingForwardForkIdDigestCalculator.kt
+++ b/p2p/src/main/kotlin/maru/p2p/fork/RollingForwardForkIdDigestCalculator.kt
@@ -8,12 +8,12 @@
  */
 package maru.p2p.fork
 
-import java.nio.ByteBuffer
 import maru.consensus.ForkSpec
 import maru.core.Hasher
 import maru.core.ObjHasher
 import maru.crypto.Keccak256Hasher
 import maru.database.BeaconChain
+import java.nio.ByteBuffer
 
 internal fun interface ForkDigestCalculator {
   fun calculateForkDigests(forks: List<ForkSpec>): List<ForkInfo>

--- a/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandler.kt
@@ -28,8 +28,8 @@ class BeaconBlocksByRangeHandler(
   private val beaconChain: BeaconChain,
   private val blockRetrievalStrategy: BlockRetrievalStrategy = DefaultBlockRetrievalStrategy(),
 ) : RpcMessageHandler<
-    RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>,
-    Message<BeaconBlocksByRangeResponse, RpcMessageType>,
+  RequestMessageAdapter<BeaconBlocksByRangeRequest, RpcMessageType>,
+  Message<BeaconBlocksByRangeResponse, RpcMessageType>,
   > {
   private val log = LogManager.getLogger(this.javaClass)
 

--- a/p2p/src/main/kotlin/maru/p2p/messages/RpcExceptionSerDe.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/RpcExceptionSerDe.kt
@@ -8,13 +8,13 @@
  */
 package maru.p2p.messages
 
-import java.nio.charset.StandardCharsets
 import maru.serialization.SerDe
 import org.apache.tuweni.bytes.Bytes
 import org.hyperledger.besu.ethereum.rlp.RLP
 import org.hyperledger.besu.ethereum.rlp.RLPInput
 import org.hyperledger.besu.ethereum.rlp.RLPOutput
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException
+import java.nio.charset.StandardCharsets
 
 class RpcExceptionSerDe : SerDe<RpcException> {
   override fun serialize(value: RpcException): ByteArray =

--- a/p2p/src/main/kotlin/maru/p2p/messages/Status.kt
+++ b/p2p/src/main/kotlin/maru/p2p/messages/Status.kt
@@ -34,5 +34,8 @@ data class Status(
   }
 
   override fun toString(): String =
-    "Status(latestBlockNumber=$latestBlockNumber, forkIdHash=${forkIdHash.encodeHex()}, latestStateRoot=${latestStateRoot.encodeHex()})"
+    "Status(" +
+      "latestBlockNumber=$latestBlockNumber, " +
+      "forkIdHash=${forkIdHash.encodeHex()}, " +
+      "latestStateRoot=${latestStateRoot.encodeHex()})"
 }

--- a/p2p/src/main/kotlin/maru/p2p/topics/ImmediateTopicHandler.kt
+++ b/p2p/src/main/kotlin/maru/p2p/topics/ImmediateTopicHandler.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p.topics
 
-import java.util.Optional
 import maru.p2p.LINEA_DOMAIN
 import maru.p2p.MaruPreparedGossipMessage
 import maru.p2p.SubscriptionManager
@@ -22,6 +21,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler
+import java.util.Optional
 import io.libp2p.core.pubsub.ValidationResult as Libp2pValidationResult
 
 /**

--- a/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
+++ b/p2p/src/main/kotlin/maru/p2p/topics/TopicHandlerWithInOrderDelivering.kt
@@ -8,8 +8,6 @@
  */
 package maru.p2p.topics
 
-import java.util.Optional
-import java.util.PriorityQueue
 import maru.p2p.LINEA_DOMAIN
 import maru.p2p.MaruPreparedGossipMessage
 import maru.p2p.SubscriptionManager
@@ -23,6 +21,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage
 import tech.pegasys.teku.networking.p2p.gossip.TopicHandler
+import java.util.Optional
+import java.util.PriorityQueue
 import io.libp2p.core.pubsub.ValidationResult as Libp2pValidationResult
 
 fun interface SequenceNumberExtractor<T> {

--- a/p2p/src/test/kotlin/maru/p2p/DefaultMaruPeerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/DefaultMaruPeerTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.p2p
 
-import java.util.Optional
-import kotlin.time.Duration.Companion.seconds
 import maru.config.P2PConfig
 import maru.p2p.messages.Status
 import maru.p2p.messages.StatusManager
@@ -30,6 +28,8 @@ import tech.pegasys.teku.networking.p2p.rpc.RpcMethod
 import tech.pegasys.teku.networking.p2p.rpc.RpcRequestHandler
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseHandler
 import tech.pegasys.teku.networking.p2p.rpc.RpcStreamController
+import java.util.Optional
+import kotlin.time.Duration.Companion.seconds
 
 class DefaultMaruPeerTest {
   private val delegatePeer = mock<Peer>()

--- a/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/MaruPeerManagerTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p
 
-import java.util.concurrent.ConcurrentHashMap
 import maru.config.P2PConfig
 import maru.config.SyncingConfig
 import maru.syncing.CLSyncStatus
@@ -30,6 +29,7 @@ import tech.pegasys.teku.networking.p2p.network.PeerAddress
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.peer.NodeId
 import tech.pegasys.teku.networking.p2p.peer.Peer
+import java.util.concurrent.ConcurrentHashMap
 import tech.pegasys.teku.networking.p2p.network.P2PNetwork as TekuP2PNetwork
 
 class MaruPeerManagerTest {

--- a/p2p/src/test/kotlin/maru/p2p/MaruReputationManagerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/MaruReputationManagerTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p
 
-import java.util.Optional
 import maru.config.P2PConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem
@@ -21,6 +20,7 @@ import tech.pegasys.teku.networking.p2p.network.PeerAddress
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.peer.NodeId
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
+import java.util.Optional
 
 class MaruReputationManagerTest {
   private val nodeId = mock<NodeId>()

--- a/p2p/src/test/kotlin/maru/p2p/NetworkHelperTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/NetworkHelperTest.kt
@@ -8,11 +8,11 @@
  */
 package maru.p2p
 
-import java.net.Inet4Address
-import java.net.InetAddress
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.net.Inet4Address
+import java.net.InetAddress
 
 class NetworkHelperTest {
   @Test

--- a/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/P2PTest.kt
@@ -10,14 +10,6 @@ package maru.p2p
 
 import io.libp2p.core.PeerId
 import io.libp2p.etc.types.fromHex
-import java.lang.Thread.sleep
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeUnit
-import java.util.stream.Stream
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import linea.timer.JvmTimerFactory
 import maru.config.P2PConfig
 import maru.consensus.ForkIdManagerFactory.createForkIdHashManager
@@ -60,6 +52,14 @@ import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus
 import tech.pegasys.teku.networking.p2p.libp2p.LibP2PNodeId
 import tech.pegasys.teku.networking.p2p.libp2p.MultiaddrPeerAddress
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
+import java.lang.Thread.sleep
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.stream.Stream
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import maru.p2p.ext.DataGenerators as P2P2DataGenerators
 
 @Execution(ExecutionMode.SAME_THREAD)
@@ -115,16 +115,15 @@ class P2PTest {
     ): P2PNetworkImpl =
       P2PNetworkImpl(
         privateKeyBytes = privateKey,
-        p2pConfig =
-          P2PConfig(
-            ipAddress = IPV4,
-            port = port,
-            staticPeers = staticPeers,
-            reconnectDelay = reconnectDelay,
-            statusUpdate = statusUpdate,
-            discovery = discovery,
-            reputation = reputationConfig,
-          ),
+        p2pConfig = P2PConfig(
+          ipAddress = IPV4,
+          port = port,
+          staticPeers = staticPeers,
+          reconnectDelay = reconnectDelay,
+          statusUpdate = statusUpdate,
+          discovery = discovery,
+          reputation = reputationConfig,
+        ),
         chainId = chainId,
         serDe = RLPSerializers.SealedBeaconBlockCompressorSerializer,
         metricsFacade = TestMetrics.TestMetricsFacade,
@@ -316,11 +315,10 @@ class P2PTest {
     val p2pNetworkImpl2 =
       createAndStartP2PNetwork(
         privateKey = key2,
-        staticPeers =
-          listOf(
-            createPeerAddress(p2pNetworkImpl1.port, PEER_ID_NODE_1),
-            createPeerAddress(p2pNetworkImpl3.port, PEER_ID_NODE_3),
-          ),
+        staticPeers = listOf(
+          createPeerAddress(p2pNetworkImpl1.port, PEER_ID_NODE_1),
+          createPeerAddress(p2pNetworkImpl3.port, PEER_ID_NODE_3),
+        ),
         beaconChain = beaconChain2,
       )
     p2pNetworkImpl2.subscribeToBlocks {
@@ -343,7 +341,8 @@ class P2PTest {
     assertNetworkHasPeers(network = p2pNetworkImpl3, peers = 1)
 
     sleep(1100L) // to make sure that the peers have communicated that they have subscribed to the topic
-    // This sleep can be decreased if the heartbeat is decreased (set to 1s for now, see P2PNetworkFactory) in the GossipRouter
+    // This sleep can be decreased if the heartbeat is decreased in the GossipRouter.
+    // It is set to 1s for now; see P2PNetworkFactory.
 
     val randomBlockMessage = P2P2DataGenerators.randomBlockMessage()
     p2pNetworkImpl1.broadcastMessage(message = randomBlockMessage)
@@ -360,10 +359,9 @@ class P2PTest {
     beaconChain
       .newBeaconChainUpdater()
       .putBeaconState(
-        beaconState =
-          beaconChain.getLatestBeaconState().copy(
-            beaconBlockHeader = beaconBlockHeader,
-          ),
+        beaconState = beaconChain.getLatestBeaconState().copy(
+          beaconBlockHeader = beaconBlockHeader,
+        ),
       ).commit()
   }
 
@@ -441,8 +439,7 @@ class P2PTest {
     val expectedBlocks =
       storedBlocks.subList(
         fromIndex = startBlockNumber.toInt(),
-        toIndex =
-          startBlockNumber.toInt() + count.toInt(),
+        toIndex = startBlockNumber.toInt() + count.toInt(),
       )
     assertThat(response.blocks).hasSize(5)
     assertThat(response.blocks).isEqualTo(expectedBlocks)
@@ -505,11 +502,10 @@ class P2PTest {
     val p2pNetworkImpl1 =
       createAndStartP2PNetwork(
         privateKey = key1,
-        discovery =
-          P2PConfig.Discovery(
-            port = discoveryPort,
-            refreshInterval = 1.seconds,
-          ),
+        discovery = P2PConfig.Discovery(
+          port = discoveryPort,
+          refreshInterval = 1.seconds,
+        ),
       )
     val enr = ENR.factory.fromEnr(p2pNetworkImpl1.enr)
     assertThat(enr.tcpAddress.get().port).isEqualTo(p2pNetworkImpl1.port.toInt())
@@ -534,16 +530,14 @@ class P2PTest {
       createP2PNetwork(
         privateKey = key1,
         port = p2pPort1.toUInt(),
-        discovery =
-          P2PConfig.Discovery(
-            port = findFreePort(),
-            refreshInterval = refreshInterval,
-          ),
-        reputationConfig =
-          P2PConfig.Reputation(
-            cooldownPeriod = 1.seconds,
-            banPeriod = 2.seconds,
-          ),
+        discovery = P2PConfig.Discovery(
+          port = findFreePort(),
+          refreshInterval = refreshInterval,
+        ),
+        reputationConfig = P2PConfig.Reputation(
+          cooldownPeriod = 1.seconds,
+          banPeriod = 2.seconds,
+        ),
       )
 
     var p2pNetworkImpl2: P2PNetworkImpl? = null
@@ -551,47 +545,39 @@ class P2PTest {
     try {
       p2pNetworkImpl1.start().get()
 
-      p2pNetworkImpl2 =
-        createP2PNetwork(
-          privateKey = key2,
-          port = p2pPort2.toUInt(),
-          beaconChain =
-            InMemoryBeaconChain(
-              initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
-            ),
-          discovery =
-            P2PConfig.Discovery(
-              port = findFreePort(),
-              bootnodes = listOf(p2pNetworkImpl1.enr!!),
-              refreshInterval = refreshInterval,
-            ),
-          reputationConfig =
-            P2PConfig.Reputation(
-              cooldownPeriod = 1.seconds,
-              banPeriod = 2.minutes,
-            ),
-        )
+      p2pNetworkImpl2 = createP2PNetwork(
+        privateKey = key2,
+        port = p2pPort2.toUInt(),
+        beaconChain = InMemoryBeaconChain(
+          initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
+        ),
+        discovery = P2PConfig.Discovery(
+          port = findFreePort(),
+          bootnodes = listOf(p2pNetworkImpl1.enr!!),
+          refreshInterval = refreshInterval,
+        ),
+        reputationConfig = P2PConfig.Reputation(
+          cooldownPeriod = 1.seconds,
+          banPeriod = 2.minutes,
+        ),
+      )
 
-      p2pNetworkImpl3 =
-        createP2PNetwork(
-          privateKey = key3,
-          port = p2pPort3.toUInt(),
-          beaconChain =
-            InMemoryBeaconChain(
-              initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
-            ),
-          discovery =
-            P2PConfig.Discovery(
-              port = findFreePort(),
-              bootnodes = listOf(p2pNetworkImpl1.enr!!),
-              refreshInterval = refreshInterval,
-            ),
-          reputationConfig =
-            P2PConfig.Reputation(
-              cooldownPeriod = 1.seconds,
-              banPeriod = 2.minutes,
-            ),
-        )
+      p2pNetworkImpl3 = createP2PNetwork(
+        privateKey = key3,
+        port = p2pPort3.toUInt(),
+        beaconChain = InMemoryBeaconChain(
+          initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
+        ),
+        discovery = P2PConfig.Discovery(
+          port = findFreePort(),
+          bootnodes = listOf(p2pNetworkImpl1.enr!!),
+          refreshInterval = refreshInterval,
+        ),
+        reputationConfig = P2PConfig.Reputation(
+          cooldownPeriod = 1.seconds,
+          banPeriod = 2.minutes,
+        ),
+      )
 
       p2pNetworkImpl2.start().get()
       p2pNetworkImpl3.start().get()
@@ -649,29 +635,26 @@ class P2PTest {
     val p2pNetworkImpl1 =
       createAndStartP2PNetwork(
         privateKey = key1,
-        statusUpdate =
-          P2PConfig.StatusUpdate(
-            refreshInterval = 1.seconds,
-            refreshIntervalLeeway = 1.seconds,
-            timeout = 1.seconds,
-          ),
+        statusUpdate = P2PConfig.StatusUpdate(
+          refreshInterval = 1.seconds,
+          refreshIntervalLeeway = 1.seconds,
+          timeout = 1.seconds,
+        ),
         statusManager = getMockedStatusMessageFactory(),
       )
 
     val p2pNetworkImpl2 =
       createAndStartP2PNetwork(
         privateKey = key2,
-        beaconChain =
-          InMemoryBeaconChain(
-            initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
-          ),
+        beaconChain = InMemoryBeaconChain(
+          initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
+        ),
         staticPeers = listOf(createPeerAddress(p2pNetworkImpl1.port, PEER_ID_NODE_1)),
-        statusUpdate =
-          P2PConfig.StatusUpdate(
-            refreshInterval = 1.seconds,
-            refreshIntervalLeeway = 1.seconds,
-            timeout = 1.seconds,
-          ),
+        statusUpdate = P2PConfig.StatusUpdate(
+          refreshInterval = 1.seconds,
+          refreshIntervalLeeway = 1.seconds,
+          timeout = 1.seconds,
+        ),
         statusManager = getMockedStatusMessageFactory(),
       )
 
@@ -706,16 +689,14 @@ class P2PTest {
     val p2pNetworkImpl1 =
       createAndStartP2PNetwork(
         privateKey = key1,
-        statusUpdate =
-          P2PConfig.StatusUpdate(
-            refreshInterval = 1.seconds,
-            refreshIntervalLeeway = 0.seconds,
-            timeout = 1.seconds,
-          ),
-        reputationConfig =
-          P2PConfig.Reputation(
-            cooldownPeriod = 50.milliseconds,
-          ),
+        statusUpdate = P2PConfig.StatusUpdate(
+          refreshInterval = 1.seconds,
+          refreshIntervalLeeway = 0.seconds,
+          timeout = 1.seconds,
+        ),
+        reputationConfig = P2PConfig.Reputation(
+          cooldownPeriod = 50.milliseconds,
+        ),
       )
 
     // Node 2 is initiating the connection and is only sending status updates after 2 seconds.
@@ -725,17 +706,15 @@ class P2PTest {
       createAndStartP2PNetwork(
         privateKey = key2,
         staticPeers = listOf(createPeerAddress(p2pNetworkImpl1.port, PEER_ID_NODE_1)),
-        beaconChain =
-          InMemoryBeaconChain(
-            initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
-          ),
+        beaconChain = InMemoryBeaconChain(
+          initialBeaconState = DataGenerators.randomBeaconState(number = 0u, timestamp = 0u),
+        ),
         reconnectDelay = 100.milliseconds,
-        statusUpdate =
-          P2PConfig.StatusUpdate(
-            refreshInterval = 2.seconds,
-            refreshIntervalLeeway = 1.seconds,
-            timeout = 1.seconds,
-          ),
+        statusUpdate = P2PConfig.StatusUpdate(
+          refreshInterval = 2.seconds,
+          refreshIntervalLeeway = 1.seconds,
+          timeout = 1.seconds,
+        ),
       )
 
     val awaitTimeoutInSeconds = 30L

--- a/p2p/src/test/kotlin/maru/p2p/discovery/MaruDiscoveryServiceTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/discovery/MaruDiscoveryServiceTest.kt
@@ -8,13 +8,6 @@
  */
 package maru.p2p.discovery
 
-import java.net.InetAddress
-import java.net.InetSocketAddress
-import java.util.Optional
-import kotlin.random.Random
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 import linea.kotlin.decodeHex
 import linea.kotlin.toULong
 import linea.timer.JvmTimerFactory
@@ -40,6 +33,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryPeer
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.util.Optional
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 class MaruDiscoveryServiceTest {
   companion object {
@@ -100,22 +100,20 @@ class MaruDiscoveryServiceTest {
       P2PConfig(
         ipAddress = "127.0.0.1",
         port = 9001u,
-        discovery =
-          P2PConfig.Discovery(
-            port = 9000u,
-            bootnodes = listOf(),
-            refreshInterval = 10.seconds,
-          ),
+        discovery = P2PConfig.Discovery(
+          port = 9000u,
+          bootnodes = listOf(),
+          refreshInterval = 10.seconds,
+        ),
       )
     p2PState = InMemoryP2PState()
-    service =
-      MaruDiscoveryService(
-        privateKeyBytes = keyPair.secretKey().bytesArray(),
-        p2pConfig = p2pConfig,
-        forkIdHashManager = forkIdHashProvider,
-        p2PState = p2PState,
-        timerFactory = JvmTimerFactory(),
-      )
+    service = MaruDiscoveryService(
+      privateKeyBytes = keyPair.secretKey().bytesArray(),
+      p2pConfig = p2pConfig,
+      forkIdHashManager = forkIdHashProvider,
+      p2PState = p2PState,
+      timerFactory = JvmTimerFactory(),
+    )
   }
 
   @Test
@@ -168,17 +166,15 @@ class MaruDiscoveryServiceTest {
     val bootnode =
       MaruDiscoveryService(
         privateKeyBytes = key1,
-        p2pConfig =
-          P2PConfig(
-            ipAddress = IPV4,
-            port = PORT1,
-            discovery =
-              P2PConfig.Discovery(
-                port = PORT2,
-                bootnodes = emptyList(),
-                refreshInterval = 5.seconds,
-              ),
+        p2pConfig = P2PConfig(
+          ipAddress = IPV4,
+          port = PORT1,
+          discovery = P2PConfig.Discovery(
+            port = PORT2,
+            bootnodes = emptyList(),
+            refreshInterval = 5.seconds,
           ),
+        ),
         forkIdHashManager = forkIdHashProvider,
         p2PState = InMemoryP2PState(),
         timerFactory = JvmTimerFactory(),
@@ -187,17 +183,15 @@ class MaruDiscoveryServiceTest {
     val discoveryService2 =
       MaruDiscoveryService(
         privateKeyBytes = key2,
-        p2pConfig =
-          P2PConfig(
-            ipAddress = IPV4,
-            port = PORT3,
-            discovery =
-              P2PConfig.Discovery(
-                port = PORT4,
-                bootnodes = listOf(bootnode.getLocalNodeRecord().asEnr()),
-                refreshInterval = 500.milliseconds,
-              ),
+        p2pConfig = P2PConfig(
+          ipAddress = IPV4,
+          port = PORT3,
+          discovery = P2PConfig.Discovery(
+            port = PORT4,
+            bootnodes = listOf(bootnode.getLocalNodeRecord().asEnr()),
+            refreshInterval = 500.milliseconds,
           ),
+        ),
         forkIdHashManager = forkIdHashProvider,
         p2PState = InMemoryP2PState(),
         timerFactory = JvmTimerFactory(),
@@ -206,17 +200,15 @@ class MaruDiscoveryServiceTest {
     val discoveryService3 =
       MaruDiscoveryService(
         privateKeyBytes = key3,
-        p2pConfig =
-          P2PConfig(
-            ipAddress = IPV4,
-            port = PORT5,
-            discovery =
-              P2PConfig.Discovery(
-                port = PORT6,
-                bootnodes = listOf(bootnode.getLocalNodeRecord().asEnr()),
-                refreshInterval = 500.milliseconds,
-              ),
+        p2pConfig = P2PConfig(
+          ipAddress = IPV4,
+          port = PORT5,
+          discovery = P2PConfig.Discovery(
+            port = PORT6,
+            bootnodes = listOf(bootnode.getLocalNodeRecord().asEnr()),
+            refreshInterval = 500.milliseconds,
           ),
+        ),
         forkIdHashManager = forkIdHashProvider,
         p2PState = InMemoryP2PState(),
         timerFactory = JvmTimerFactory(),
@@ -299,13 +291,12 @@ class MaruDiscoveryServiceTest {
       P2PConfig(
         ipAddress = ipAddress,
         port = port,
-        discovery =
-          P2PConfig.Discovery(
-            port = discoveryPort,
-            bootnodes = listOf(),
-            refreshInterval = 10.seconds,
-            advertisedIp = advertisedIp,
-          ),
+        discovery = P2PConfig.Discovery(
+          port = discoveryPort,
+          bootnodes = listOf(),
+          refreshInterval = 10.seconds,
+          advertisedIp = advertisedIp,
+        ),
       )
 
     val discoveryService =

--- a/p2p/src/test/kotlin/maru/p2p/fork/DifficultyAwareQbftConfigDigesterTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/fork/DifficultyAwareQbftConfigDigesterTest.kt
@@ -23,11 +23,10 @@ class DifficultyAwareQbftConfigDigesterTest {
     DifficultyAwareQbftConfig(
       QbftConsensusConfig(
         validatorSet = setOf(Validator("0x0000000000000000000000000000000000000001".decodeHex())),
-        fork =
-          ChainFork(
-            clFork = ClFork.QBFT_PHASE0,
-            elFork = ElFork.Paris,
-          ),
+        fork = ChainFork(
+          clFork = ClFork.QBFT_PHASE0,
+          elFork = ElFork.Paris,
+        ),
       ),
       terminalTotalDifficulty = 1000uL,
     )

--- a/p2p/src/test/kotlin/maru/p2p/fork/ForkSpecDigesterTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/fork/ForkSpecDigesterTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p.fork
 
-import kotlin.random.Random
 import linea.kotlin.decodeHex
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
@@ -19,16 +18,16 @@ import maru.consensus.QbftConsensusConfig
 import maru.core.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class ForkSpecDigesterTest {
   private val qbftConfig =
     QbftConsensusConfig(
       validatorSet = setOf(Validator("0x0000000000000000000000000000000000000001".decodeHex())),
-      fork =
-        ChainFork(
-          clFork = ClFork.QBFT_PHASE0,
-          elFork = ElFork.Paris,
-        ),
+      fork = ChainFork(
+        clFork = ClFork.QBFT_PHASE0,
+        elFork = ElFork.Paris,
+      ),
     )
   private val qbftTtdAwareConfig =
     DifficultyAwareQbftConfig(
@@ -80,11 +79,9 @@ class ForkSpecDigesterTest {
     val forkSpecQbftA = forkSpec.copy(configuration = qbftTtdAwareConfig)
     val forkSpecQbftB =
       forkSpec.copy(
-        configuration =
-          qbftTtdAwareConfig.copy(
-            terminalTotalDifficulty =
-              qbftTtdAwareConfig.terminalTotalDifficulty + 1uL,
-          ),
+        configuration = qbftTtdAwareConfig.copy(
+          terminalTotalDifficulty = qbftTtdAwareConfig.terminalTotalDifficulty + 1uL,
+        ),
       )
     assertThat(digest(forkSpecQbftA))
       .isNotEqualTo(digest(forkSpecQbftB))

--- a/p2p/src/test/kotlin/maru/p2p/fork/LenientForkPeeringManagerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/fork/LenientForkPeeringManagerTest.kt
@@ -8,15 +8,6 @@
  */
 package maru.p2p.fork
 
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZoneOffset
-import kotlin.random.Random
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
-import kotlin.time.toJavaInstant
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.ElFork
@@ -28,6 +19,15 @@ import maru.database.InMemoryBeaconChain
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.toJavaInstant
 
 class LenientForkPeeringManagerTest {
   private lateinit var clock: MutableClock
@@ -58,15 +58,14 @@ class LenientForkPeeringManagerTest {
   @BeforeEach
   fun setup() {
     beaconChain = InMemoryBeaconChain.Companion.fromGenesis(genesisTimestampSeconds = 100u)
-    forks =
-      listOf(
-        forkSpec(0UL, ElFork.Paris),
-        forkSpec(1_000UL, ElFork.Shanghai),
-        forkSpec(2_000UL, ElFork.Cancun),
-        forkSpec(3_000UL, ElFork.Prague),
-      ).mapIndexed { index, forkSpec ->
-        ForkInfo(forkSpec, forkIdDigest = ByteArray(1) { index.toByte() })
-      }.associateBy { (it.forkSpec.configuration as QbftConsensusConfig).elFork }
+    forks = listOf(
+      forkSpec(0UL, ElFork.Paris),
+      forkSpec(1_000UL, ElFork.Shanghai),
+      forkSpec(2_000UL, ElFork.Cancun),
+      forkSpec(3_000UL, ElFork.Prague),
+    ).mapIndexed { index, forkSpec ->
+      ForkInfo(forkSpec, forkIdDigest = ByteArray(1) { index.toByte() })
+    }.associateBy { (it.forkSpec.configuration as QbftConsensusConfig).elFork }
     clock = MutableClock(Instant.ofEpochSecond((forks[ElFork.Paris]!!.forkSpec.timestampSeconds + 100UL).toLong()))
   }
 

--- a/p2p/src/test/kotlin/maru/p2p/fork/QbftConsensusConfigDigesterTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/fork/QbftConsensusConfigDigesterTest.kt
@@ -21,11 +21,10 @@ class QbftConsensusConfigDigesterTest {
   private val config =
     QbftConsensusConfig(
       validatorSet = setOf(Validator("0x0000000000000000000000000000000000000001".decodeHex())),
-      fork =
-        ChainFork(
-          clFork = ClFork.QBFT_PHASE0,
-          elFork = ElFork.Paris,
-        ),
+      fork = ChainFork(
+        clFork = ClFork.QBFT_PHASE0,
+        elFork = ElFork.Paris,
+      ),
     )
 
   private fun digest(config: QbftConsensusConfig): ByteArray = QbftConsensusConfigDigester.serialize(config)

--- a/p2p/src/test/kotlin/maru/p2p/fork/RollingForwardForkIdDigestCalculatorTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/fork/RollingForwardForkIdDigestCalculatorTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p.fork
 
-import kotlin.random.Random
 import maru.consensus.ChainFork
 import maru.consensus.ClFork
 import maru.consensus.ElFork
@@ -19,6 +18,7 @@ import maru.database.BeaconChain
 import maru.database.InMemoryBeaconChain
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class RollingForwardForkIdDigestCalculatorTest {
   private fun createCalculator(

--- a/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandlerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeHandlerTest.kt
@@ -135,11 +135,10 @@ class BeaconBlocksByRangeHandlerTest {
 
   @Test
   fun `handles and returns subset of requested blocks for request with blocks that would exceed the size limit`() {
-    handler =
-      BeaconBlocksByRangeHandler(
-        beaconChain = beaconChain,
-        blockRetrievalStrategy = SizeLimitBlockRetrievalStrategy(sizeLimit = 9000),
-      )
+    handler = BeaconBlocksByRangeHandler(
+      beaconChain = beaconChain,
+      blockRetrievalStrategy = SizeLimitBlockRetrievalStrategy(sizeLimit = 9000),
+    )
 
     val request = BeaconBlocksByRangeRequest(startBlockNumber = 0UL, count = 10UL)
     val message =

--- a/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeResponseMessageSerDeTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/BeaconBlocksByRangeResponseMessageSerDeTest.kt
@@ -21,8 +21,7 @@ class BeaconBlocksByRangeResponseMessageSerDeTest {
   fun `response message serDe serializes and deserializes correctly`() {
     val messageSerDe =
       BeaconBlocksByRangeResponseMessageSerDe(
-        beaconBlocksByRangeResponseSerDe =
-          BeaconBlocksByRangeResponseSerDe(RLPSerializers.SealedBeaconBlockSerializer),
+        beaconBlocksByRangeResponseSerDe = BeaconBlocksByRangeResponseSerDe(RLPSerializers.SealedBeaconBlockSerializer),
       )
 
     val response =

--- a/p2p/src/test/kotlin/maru/p2p/messages/RpcExceptionSerDeTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/RpcExceptionSerDeTest.kt
@@ -8,11 +8,11 @@
  */
 package maru.p2p.messages
 
-import kotlin.random.Random
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus
+import kotlin.random.Random
 
 class RpcExceptionSerDeTest {
   private val serDe = RpcExceptionSerDe()

--- a/p2p/src/test/kotlin/maru/p2p/messages/StatusHandlerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/StatusHandlerTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p.messages
 
-import kotlin.random.Random
 import maru.core.ext.DataGenerators
 import maru.p2p.MaruPeer
 import maru.p2p.Message
@@ -25,6 +24,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.ResponseCallback
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcResponseStatus
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
+import kotlin.random.Random
 
 class StatusHandlerTest {
   @Test

--- a/p2p/src/test/kotlin/maru/p2p/messages/StatusSerDeTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/messages/StatusSerDeTest.kt
@@ -8,10 +8,10 @@
  */
 package maru.p2p.messages
 
-import kotlin.random.Random
-import kotlin.random.nextULong
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.random.nextULong
 
 class StatusSerDeTest {
   private val serDe = StatusSerDe()

--- a/p2p/src/test/kotlin/maru/p2p/topics/ImmediateTopicHandlerTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/topics/ImmediateTopicHandlerTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.p2p.topics
 
-import java.util.Optional
 import maru.p2p.LINEA_DOMAIN
 import maru.p2p.MaruPreparedGossipMessage
 import maru.p2p.SubscriptionManager
@@ -27,6 +26,7 @@ import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage
+import java.util.Optional
 import io.libp2p.core.pubsub.ValidationResult as Libp2pValidationResult
 
 class ImmediateTopicHandlerTest {
@@ -38,12 +38,11 @@ class ImmediateTopicHandlerTest {
   @BeforeEach
   fun setUp() {
     deserializer = TestDeserializer()
-    handler =
-      ImmediateTopicHandler(
-        subscriptionManager = mockSubscriptionManager,
-        deserializer = deserializer,
-        topicId = topicId,
-      )
+    handler = ImmediateTopicHandler(
+      subscriptionManager = mockSubscriptionManager,
+      deserializer = deserializer,
+      topicId = topicId,
+    )
   }
 
   private class TestDeserializer : Deserializer<String> {

--- a/p2p/src/test/kotlin/maru/p2p/topics/TopicHanlderWithInOrderDeliveringTest.kt
+++ b/p2p/src/test/kotlin/maru/p2p/topics/TopicHanlderWithInOrderDeliveringTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.p2p.topics
 
-import java.util.Optional
-import java.util.concurrent.TimeUnit
 import maru.p2p.MaruPreparedGossipMessage
 import maru.p2p.SubscriptionManager
 import maru.p2p.ValidationResult
@@ -20,6 +18,8 @@ import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.unsigned.UInt64
 import tech.pegasys.teku.networking.p2p.gossip.PreparedGossipMessage
+import java.util.Optional
+import java.util.concurrent.TimeUnit
 import io.libp2p.core.pubsub.ValidationResult as Libp2pValidationResult
 
 class TopicHanlderWithInOrderDeliveringTest {

--- a/p2p/src/testFixtures/kotlin/maru/consensus/ForkIdManagerFactory.kt
+++ b/p2p/src/testFixtures/kotlin/maru/consensus/ForkIdManagerFactory.kt
@@ -8,13 +8,13 @@
  */
 package maru.consensus
 
-import java.time.Clock
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 import maru.core.ext.DataGenerators
 import maru.database.BeaconChain
 import maru.p2p.fork.ForkPeeringManager
 import maru.p2p.fork.LenientForkPeeringManager
+import java.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 object ForkIdManagerFactory {
   fun createForkIdHashManager(
@@ -23,11 +23,10 @@ object ForkIdManagerFactory {
     elFork: ElFork = ElFork.Prague,
     consensusConfig: ConsensusConfig =
       QbftConsensusConfig(
-        validatorSet =
-          setOf(
-            DataGenerators.randomValidator(),
-            DataGenerators.randomValidator(),
-          ),
+        validatorSet = setOf(
+          DataGenerators.randomValidator(),
+          DataGenerators.randomValidator(),
+        ),
         fork = ChainFork(ClFork.QBFT_PHASE0, elFork = elFork),
       ),
     forks: List<ForkSpec> = listOf(ForkSpec(0UL, 1u, consensusConfig)),

--- a/serialization/src/main/kotlin/maru/serialization/compression/MaruSnappyFramedCompressor.kt
+++ b/serialization/src/main/kotlin/maru/serialization/compression/MaruSnappyFramedCompressor.kt
@@ -12,7 +12,6 @@ import io.libp2p.etc.types.readUvarint
 import io.libp2p.etc.types.toByteArray
 import io.libp2p.etc.types.toByteBuf
 import io.netty.buffer.ByteBuf
-import java.util.Optional
 import maru.compression.MaruCompressor
 import maru.serialization.MAX_MESSAGE_SIZE
 import org.apache.tuweni.bytes.Bytes
@@ -26,6 +25,7 @@ import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptio
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptions.PayloadLargerThanExpectedException
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.exceptions.PayloadSmallerThanExpectedException
 import tech.pegasys.teku.networking.eth2.rpc.core.encodings.compression.snappy.SnappyFramedCompressor
+import java.util.Optional
 
 class MaruSnappyFramedCompressor : MaruCompressor {
   private val compressor: Compressor = SnappyFramedCompressor()
@@ -93,8 +93,7 @@ class MaruSnappyFramedCompressor : MaruCompressor {
     val compressedByteBuf = payload.toByteBuf()
     var decompressedByteBuf: ByteBuf? = null
     try {
-      decompressedByteBuf =
-        decompress(compressedByteBuf)
+      decompressedByteBuf = decompress(compressedByteBuf)
 
       if (decompressedByteBuf == null) {
         throw DecompressFailedException()

--- a/serialization/src/main/kotlin/maru/serialization/rlp/ExecutionPayloadSerDe.kt
+++ b/serialization/src/main/kotlin/maru/serialization/rlp/ExecutionPayloadSerDe.kt
@@ -8,11 +8,11 @@
  */
 package maru.serialization.rlp
 
-import java.math.BigInteger
 import maru.core.ExecutionPayload
 import org.apache.tuweni.bytes.Bytes
 import org.hyperledger.besu.ethereum.rlp.RLPInput
 import org.hyperledger.besu.ethereum.rlp.RLPOutput
+import java.math.BigInteger
 
 class ExecutionPayloadSerDe : RLPSerDe<ExecutionPayload> {
   override fun writeTo(

--- a/serialization/src/test/kotlin/maru/compression/MaruNoOpCompressorTest.kt
+++ b/serialization/src/test/kotlin/maru/compression/MaruNoOpCompressorTest.kt
@@ -8,10 +8,10 @@
  */
 package maru.compression
 
-import kotlin.random.Random
 import maru.serialization.compression.MaruNoOpCompressor
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class MaruNoOpCompressorTest {
   private val compressor = MaruNoOpCompressor()

--- a/serialization/src/test/kotlin/maru/compression/MaruSnappyCompressorTest.kt
+++ b/serialization/src/test/kotlin/maru/compression/MaruSnappyCompressorTest.kt
@@ -8,10 +8,10 @@
  */
 package maru.compression
 
-import kotlin.random.Random
 import maru.serialization.compression.MaruSnappyCompressor
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class MaruSnappyCompressorTest {
   private val compressor = MaruSnappyCompressor()

--- a/serialization/src/test/kotlin/maru/compression/MaruSnappyFramedCompressorTest.kt
+++ b/serialization/src/test/kotlin/maru/compression/MaruSnappyFramedCompressorTest.kt
@@ -8,13 +8,13 @@
  */
 package maru.compression
 
-import kotlin.random.Random
 import maru.serialization.MAX_MESSAGE_SIZE
 import maru.serialization.compression.MaruSnappyFramedCompressor
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException.ChunkTooLongException
+import kotlin.random.Random
 
 class MaruSnappyFramedCompressorTest {
   private val compressor = MaruSnappyFramedCompressor()

--- a/serialization/src/test/kotlin/maru/serialization/rlp/BeaconBlockBodySerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/BeaconBlockBodySerializerTest.kt
@@ -8,12 +8,12 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
 import maru.core.BeaconBlockBody
 import maru.core.Seal
 import maru.core.ext.DataGenerators.randomExecutionPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class BeaconBlockBodySerializerTest {
   private val serializer =
@@ -26,12 +26,10 @@ class BeaconBlockBodySerializerTest {
   fun `can serialize and deserialize same value`() {
     val testValue =
       BeaconBlockBody(
-        prevCommitSeals =
-          buildSet(3) {
-            add(Seal(Random.nextBytes(96)))
-          },
-        executionPayload =
-          randomExecutionPayload(),
+        prevCommitSeals = buildSet(3) {
+          add(Seal(Random.nextBytes(96)))
+        },
+        executionPayload = randomExecutionPayload(),
       )
     val serializedData = serializer.serialize(testValue)
     val deserializedValue = serializer.deserialize(serializedData)

--- a/serialization/src/test/kotlin/maru/serialization/rlp/BeaconBlockHeaderSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/BeaconBlockHeaderSerializerTest.kt
@@ -8,13 +8,13 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
-import kotlin.random.nextULong
 import maru.core.HashUtil
 import maru.core.ext.DataGenerators
 import maru.crypto.Hashing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.random.nextULong
 
 class BeaconBlockHeaderSerializerTest {
   private val serializer =

--- a/serialization/src/test/kotlin/maru/serialization/rlp/BeaconBlockSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/BeaconBlockSerializerTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
-import kotlin.random.nextULong
 import maru.core.BeaconBlock
 import maru.core.BeaconBlockBody
 import maru.core.HashUtil
@@ -19,6 +17,8 @@ import maru.core.ext.DataGenerators.randomExecutionPayload
 import maru.crypto.Hashing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.random.nextULong
 
 class BeaconBlockSerializerTest {
   private val blockHeaderSerializer =
@@ -29,13 +29,11 @@ class BeaconBlockSerializerTest {
     )
   private val blockBodySerializer =
     BeaconBlockSerDe(
-      beaconBlockHeaderSerializer =
-      blockHeaderSerializer,
-      beaconBlockBodySerializer =
-        BeaconBlockBodySerDe(
-          sealSerializer = SealSerDe(),
-          executionPayloadSerializer = ExecutionPayloadSerDe(),
-        ),
+      beaconBlockHeaderSerializer = blockHeaderSerializer,
+      beaconBlockBodySerializer = BeaconBlockBodySerDe(
+        sealSerializer = SealSerDe(),
+        executionPayloadSerializer = ExecutionPayloadSerDe(),
+      ),
     )
 
   @Test

--- a/serialization/src/test/kotlin/maru/serialization/rlp/BeaconStateSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/BeaconStateSerializerTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
-import kotlin.random.nextULong
 import maru.core.BeaconState
 import maru.core.HashUtil
 import maru.core.Validator
@@ -17,6 +15,8 @@ import maru.core.ext.DataGenerators
 import maru.crypto.Hashing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.random.nextULong
 
 class BeaconStateSerializerTest {
   private val validatorSerializer = ValidatorSerDe()

--- a/serialization/src/test/kotlin/maru/serialization/rlp/MaruCompressorRLPSerDeTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/MaruCompressorRLPSerDeTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
-import kotlin.random.nextULong
 import maru.core.BeaconBlock
 import maru.core.BeaconBlockBody
 import maru.core.Seal
@@ -18,6 +16,8 @@ import maru.core.ext.DataGenerators
 import maru.core.ext.DataGenerators.randomExecutionPayload
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.random.nextULong
 
 class MaruCompressorRLPSerDeTest {
   private val compressorRLPSerDe =
@@ -35,11 +35,10 @@ class MaruCompressorRLPSerDeTest {
       )
     val sealedBlock =
       SealedBeaconBlock(
-        beaconBlock =
-          BeaconBlock(
-            beaconBlockHeader = beaconBlockHeader,
-            beaconBlockBody = beaconBlockBody,
-          ),
+        beaconBlock = BeaconBlock(
+          beaconBlockHeader = beaconBlockHeader,
+          beaconBlockBody = beaconBlockBody,
+        ),
         commitSeals = buildSet(3) { add(Seal(Random.nextBytes(96))) },
       )
     val serializedData = compressorRLPSerDe.serialize(sealedBlock)

--- a/serialization/src/test/kotlin/maru/serialization/rlp/SealSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/SealSerializerTest.kt
@@ -8,10 +8,10 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
 import maru.core.Seal
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class SealSerializerTest {
   private val serializer = SealSerDe()

--- a/serialization/src/test/kotlin/maru/serialization/rlp/SealedBeaconBlockSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/SealedBeaconBlockSerializerTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
-import kotlin.random.nextULong
 import maru.core.BeaconBlock
 import maru.core.BeaconBlockBody
 import maru.core.HashUtil
@@ -20,6 +18,8 @@ import maru.core.ext.DataGenerators.randomExecutionPayload
 import maru.crypto.Hashing
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.random.nextULong
 
 class SealedBeaconBlockSerializerTest {
   private val blockHeaderSerializer =
@@ -31,13 +31,11 @@ class SealedBeaconBlockSerializerTest {
   private val sealSerializer = SealSerDe()
   private val blockSerializer =
     BeaconBlockSerDe(
-      beaconBlockHeaderSerializer =
-      blockHeaderSerializer,
-      beaconBlockBodySerializer =
-        BeaconBlockBodySerDe(
-          sealSerializer = sealSerializer,
-          executionPayloadSerializer = ExecutionPayloadSerDe(),
-        ),
+      beaconBlockHeaderSerializer = blockHeaderSerializer,
+      beaconBlockBodySerializer = BeaconBlockBodySerDe(
+        sealSerializer = sealSerializer,
+        executionPayloadSerializer = ExecutionPayloadSerDe(),
+      ),
     )
   private val sealedBlockSerializer =
     SealedBeaconBlockSerDe(
@@ -55,11 +53,10 @@ class SealedBeaconBlockSerializerTest {
       )
     val sealedBlock =
       SealedBeaconBlock(
-        beaconBlock =
-          BeaconBlock(
-            beaconBlockHeader = beaconBlockHeader,
-            beaconBlockBody = beaconBlockBody,
-          ),
+        beaconBlock = BeaconBlock(
+          beaconBlockHeader = beaconBlockHeader,
+          beaconBlockBody = beaconBlockBody,
+        ),
         commitSeals = buildSet(3) { add(Seal(Random.nextBytes(96))) },
       )
     val serializedData = sealedBlockSerializer.serialize(sealedBlock)

--- a/serialization/src/test/kotlin/maru/serialization/rlp/ValidatorSerializerTest.kt
+++ b/serialization/src/test/kotlin/maru/serialization/rlp/ValidatorSerializerTest.kt
@@ -8,10 +8,10 @@
  */
 package maru.serialization.rlp
 
-import kotlin.random.Random
 import maru.core.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class ValidatorSerializerTest {
   private val serializer = ValidatorSerDe()

--- a/storage/src/main/kotlin/maru/database/kv/KvDatabase.kt
+++ b/storage/src/main/kotlin/maru/database/kv/KvDatabase.kt
@@ -8,8 +8,6 @@
  */
 package maru.database.kv
 
-import kotlin.jvm.optionals.getOrDefault
-import kotlin.jvm.optionals.getOrNull
 import maru.core.BeaconState
 import maru.core.SealedBeaconBlock
 import maru.database.BeaconChain
@@ -18,6 +16,8 @@ import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor
 import tech.pegasys.teku.storage.server.kvstore.KvStoreAccessor.KvStoreTransaction
 import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreColumn
 import tech.pegasys.teku.storage.server.kvstore.schema.KvStoreVariable
+import kotlin.jvm.optionals.getOrDefault
+import kotlin.jvm.optionals.getOrNull
 
 class KvDatabase(
   private val kvStoreAccessor: KvStoreAccessor,

--- a/storage/src/main/kotlin/maru/database/kv/KvDatabaseFactory.kt
+++ b/storage/src/main/kotlin/maru/database/kv/KvDatabaseFactory.kt
@@ -8,12 +8,12 @@
  */
 package maru.database.kv
 
-import java.nio.file.Path
 import org.apache.tuweni.bytes.Bytes
 import org.hyperledger.besu.plugin.services.MetricsSystem
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory
 import tech.pegasys.teku.storage.server.kvstore.KvStoreConfiguration
 import tech.pegasys.teku.storage.server.rocksdb.RocksDbInstanceFactory
+import java.nio.file.Path
 
 object KvDatabaseFactory {
   fun createRocksDbDatabase(

--- a/storage/src/main/kotlin/maru/database/kv/ULongSerializer.kt
+++ b/storage/src/main/kotlin/maru/database/kv/ULongSerializer.kt
@@ -8,8 +8,8 @@
  */
 package maru.database.kv
 
-import java.math.BigInteger
 import tech.pegasys.teku.storage.server.kvstore.serialization.KvStoreSerializer
+import java.math.BigInteger
 
 class ULongSerializer : KvStoreSerializer<ULong> {
   override fun serialize(value: ULong): ByteArray = BigInteger.valueOf(value.toLong()).toByteArray()

--- a/storage/src/test/kotlin/maru/database/kv/KvDatabaseTest.kt
+++ b/storage/src/test/kotlin/maru/database/kv/KvDatabaseTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.database.kv
 
-import java.nio.file.Path
-import kotlin.random.Random
 import maru.core.BeaconState
 import maru.core.ext.DataGenerators
 import maru.core.ext.metrics.TestMetrics
@@ -19,6 +17,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.random.Random
 
 class KvDatabaseTest {
   private fun createDatabase(databasePath: Path): KvDatabase =

--- a/syncing/src/main/kotlin/maru/syncing/ELSyncService.kt
+++ b/syncing/src/main/kotlin/maru/syncing/ELSyncService.kt
@@ -8,7 +8,6 @@
  */
 package maru.syncing
 
-import kotlin.time.Duration
 import linea.timer.PeriodicPollingService
 import linea.timer.TimerFactory
 import linea.timer.TimerSchedule
@@ -21,6 +20,7 @@ import maru.extensions.encodeHex
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Duration
 
 data class ElBlockInfo(
   val blockNumber: ULong,
@@ -62,12 +62,12 @@ class ELSyncService(
   timerFactory: TimerFactory,
   private val log: Logger = LogManager.getLogger(ELSyncService::class.java),
 ) : PeriodicPollingService(
-    name = "ELSyncPoller",
-    timerFactory = timerFactory,
-    timerSchedule = TimerSchedule.FIXED_RATE,
-    pollingInterval = config.pollingInterval,
-    log = log,
-  ) {
+  name = "ELSyncPoller",
+  timerFactory = timerFactory,
+  timerSchedule = TimerSchedule.FIXED_RATE,
+  pollingInterval = config.pollingInterval,
+  log = log,
+) {
   data class Config(
     val pollingInterval: Duration,
   )

--- a/syncing/src/main/kotlin/maru/syncing/PeerChainTracker.kt
+++ b/syncing/src/main/kotlin/maru/syncing/PeerChainTracker.kt
@@ -8,7 +8,6 @@
  */
 package maru.syncing
 
-import kotlin.time.Duration
 import linea.timer.PeriodicPollingService
 import linea.timer.TimerFactory
 import linea.timer.TimerSchedule
@@ -17,6 +16,7 @@ import maru.p2p.PeersHeadBlockProvider
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import kotlin.time.Duration
 
 /**
  * polls periodically peers chain head
@@ -35,12 +35,12 @@ class PeerChainTracker(
   private val beaconChain: BeaconChain,
   private val log: Logger = LogManager.getLogger(PeerChainTracker::class.java),
 ) : PeriodicPollingService(
-    name = "peer-chain-tracker",
-    timerFactory = timerFactory,
-    timerSchedule = TimerSchedule.FIXED_RATE,
-    pollingInterval = config.pollingUpdateInterval,
-    log = log,
-  ) {
+  name = "peer-chain-tracker",
+  timerFactory = timerFactory,
+  timerSchedule = TimerSchedule.FIXED_RATE,
+  pollingInterval = config.pollingUpdateInterval,
+  log = log,
+) {
   data class Config(
     val pollingUpdateInterval: Duration,
   )

--- a/syncing/src/main/kotlin/maru/syncing/SyncController.kt
+++ b/syncing/src/main/kotlin/maru/syncing/SyncController.kt
@@ -8,11 +8,6 @@
  */
 package maru.syncing
 
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Executors
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.read
-import kotlin.concurrent.write
 import linea.kotlin.minusCoercingUnderflow
 import linea.timer.TimerFactory
 import maru.consensus.ValidatorProvider
@@ -26,6 +21,11 @@ import maru.syncing.beaconchain.pipeline.BeaconChainDownloadPipelineFactory
 import net.consensys.linea.metrics.MetricsFacade
 import org.apache.logging.log4j.LogManager
 import org.hyperledger.besu.plugin.services.MetricsSystem
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 internal data class SyncState(
   val clStatus: CLSyncStatus,
@@ -94,12 +94,11 @@ class BeaconSyncControllerImpl(
 
         if (previousState.clStatus == newStatus) return@write emptyList()
 
-        currentState =
-          if (newStatus == CLSyncStatus.SYNCING && elSyncEnabled) {
-            previousState.copy(clStatus = newStatus, elStatus = ELSyncStatus.SYNCING)
-          } else {
-            previousState.copy(clStatus = newStatus)
-          }
+        currentState = if (newStatus == CLSyncStatus.SYNCING && elSyncEnabled) {
+          previousState.copy(clStatus = newStatus, elStatus = ELSyncStatus.SYNCING)
+        } else {
+          previousState.copy(clStatus = newStatus)
+        }
 
         buildList {
           if (previousState.elStatus == ELSyncStatus.SYNCED && currentState.elStatus == ELSyncStatus.SYNCING) {
@@ -135,12 +134,11 @@ class BeaconSyncControllerImpl(
         }
 
         // Enforce invariant: EL cannot be SYNCED when CL is SYNCING
-        currentState =
-          if (previousState.clStatus == CLSyncStatus.SYNCING) {
-            previousState
-          } else {
-            previousState.copy(elStatus = newStatus)
-          }
+        currentState = if (previousState.clStatus == CLSyncStatus.SYNCING) {
+          previousState
+        } else {
+          previousState.copy(elStatus = newStatus)
+        }
 
         buildList {
           add { elSyncHandlers.notifySubscribers(currentState.elStatus) }
@@ -216,8 +214,7 @@ class BeaconSyncControllerImpl(
           beaconChain = beaconChain,
           validatorProvider = validatorProvider,
           allowEmptyBlocks = allowEmptyBlocks,
-          executorService =
-            Executors.newCachedThreadPool(Thread.ofPlatform().daemon().factory()),
+          executorService = Executors.newCachedThreadPool(Thread.ofPlatform().daemon().factory()),
           pipelineConfig = pipelineConfig,
           peerLookup = peerLookup,
           besuMetrics = besuMetrics,

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/CLSyncServiceImpl.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/CLSyncServiceImpl.kt
@@ -8,11 +8,6 @@
  */
 package maru.syncing.beaconchain
 
-import java.util.concurrent.CancellationException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 import linea.kotlin.minusCoercingUnderflow
 import maru.consensus.ValidatorProvider
 import maru.database.BeaconChain
@@ -28,6 +23,11 @@ import net.consensys.linea.metrics.MetricsFacade
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.plugin.services.MetricsSystem
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 class CLSyncServiceImpl(
   private val beaconChain: BeaconChain,

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/SyncSealedBlockImporterFactory.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/SyncSealedBlockImporterFactory.kt
@@ -78,17 +78,16 @@ class SyncSealedBlockImporterFactory {
       val parentHeader = parentBlock.beaconBlock.beaconBlockHeader
 
       CompositeBlockValidator(
-        blockValidators =
-          listOfNotNull(
-            StateRootValidator(StateTransitionImpl(validatorProvider)),
-            BlockNumberValidator(parentHeader),
-            TimestampValidator(parentHeader),
-            ProposerValidator(ProposerSelectorImpl, beaconChain),
-            ParentRootValidator(parentHeader),
-            BodyRootValidator(),
-            ExecutionPayloadBlockNumberValidator(parentBlock.beaconBlock.beaconBlockBody.executionPayload),
-            if (!allowEmptyBlocks) EmptyBlockValidator else null,
-          ),
+        blockValidators = listOfNotNull(
+          StateRootValidator(StateTransitionImpl(validatorProvider)),
+          BlockNumberValidator(parentHeader),
+          TimestampValidator(parentHeader),
+          ProposerValidator(ProposerSelectorImpl, beaconChain),
+          ParentRootValidator(parentHeader),
+          BodyRootValidator(),
+          ExecutionPayloadBlockNumberValidator(parentBlock.beaconBlock.beaconBlockBody.executionPayload),
+          if (!allowEmptyBlocks) EmptyBlockValidator else null,
+        ),
       )
     }
   }

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactory.kt
@@ -8,7 +8,6 @@
  */
 package maru.syncing.beaconchain.pipeline
 
-import kotlin.time.Duration
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import maru.extensions.clampedAdd
 import maru.p2p.PeerLookup
@@ -18,6 +17,7 @@ import org.hyperledger.besu.metrics.BesuMetricCategory
 import org.hyperledger.besu.plugin.services.MetricsSystem
 import org.hyperledger.besu.services.pipeline.Pipeline
 import org.hyperledger.besu.services.pipeline.PipelineBuilder
+import kotlin.time.Duration
 
 data class BeaconChainPipeline(
   val pipeline: Pipeline<SyncTargetRange>,
@@ -71,17 +71,15 @@ class BeaconChainDownloadPipelineFactory(
 
     val downloadBlocksStep =
       DownloadBlocksStep(
-        downloadPeerProvider =
-          DownloadPeerProviderImpl(
-            peerLookup = peerLookup,
-            useUnconditionalRandomSelection = config.useUnconditionalRandomDownloadPeer,
-          ),
-        config =
-          DownloadBlocksStep.Config(
-            maxRetries = config.maxRetries,
-            blockRangeRequestTimeout = config.blockRangeRequestTimeout,
-            backoffDelay = config.backoffDelay,
-          ),
+        downloadPeerProvider = DownloadPeerProviderImpl(
+          peerLookup = peerLookup,
+          useUnconditionalRandomSelection = config.useUnconditionalRandomDownloadPeer,
+        ),
+        config = DownloadBlocksStep.Config(
+          maxRetries = config.maxRetries,
+          blockRangeRequestTimeout = config.blockRangeRequestTimeout,
+          backoffDelay = config.backoffDelay,
+        ),
       )
     val importBlocksStep = ImportBlocksStep(blockImporter)
 

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksStep.kt
@@ -8,13 +8,6 @@
  */
 package maru.syncing.beaconchain.pipeline
 
-import java.lang.Thread.sleep
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.function.Function
-import kotlin.time.Duration
 import maru.core.SealedBeaconBlock
 import maru.p2p.MaruPeer
 import maru.p2p.PeerLookup
@@ -24,6 +17,13 @@ import org.hyperledger.besu.util.log.LogUtil
 import tech.pegasys.teku.networking.eth2.rpc.core.RpcException
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
+import java.lang.Thread.sleep
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Function
+import kotlin.time.Duration
 
 interface DownloadPeerProvider {
   fun getDownloadingPeer(downloadRangeEndBlockNumber: ULong): MaruPeer?
@@ -40,7 +40,7 @@ class DownloadPeerProviderImpl(
           peers
         } else {
           peers.filter { peer ->
-            // TODO: consider to reduce the downloadRangeEndBlockNumber, because the status of the peers is up to "time between status updates" old
+            // TODO: consider reducing the downloadRangeEndBlockNumber because peer status is only periodically updated.
             peer.getStatus()?.latestBlockNumber?.let { it >= downloadRangeEndBlockNumber } == true
           }
         }
@@ -94,15 +94,14 @@ class DownloadBlocksStep(
     )
 
     while (state.downloadedBlocks.size.toULong() < totalCount) {
-      state =
-        when (val peer = downloadPeerProvider.getDownloadingPeer(targetRange.endBlock)) {
-          null -> {
-            sleep(config.backoffDelay.inWholeMilliseconds)
-            state.copy(retries = state.retries + 1u)
-          }
-
-          else -> downloadFromPeer(peer, state)
+      state = when (val peer = downloadPeerProvider.getDownloadingPeer(targetRange.endBlock)) {
+        null -> {
+          sleep(config.backoffDelay.inWholeMilliseconds)
+          state.copy(retries = state.retries + 1u)
         }
+
+        else -> downloadFromPeer(peer, state)
+      }
       checkMaxRetries(state.retries)
     }
 

--- a/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/ImportBlocksStep.kt
+++ b/syncing/src/main/kotlin/maru/syncing/beaconchain/pipeline/ImportBlocksStep.kt
@@ -8,8 +8,6 @@
  */
 package maru.syncing.beaconchain.pipeline
 
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.function.Consumer
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import maru.extensions.encodeHex
 import maru.p2p.ValidationResult
@@ -20,6 +18,8 @@ import org.apache.logging.log4j.Logger
 import org.hyperledger.besu.util.log.LogUtil
 import tech.pegasys.teku.networking.p2p.peer.DisconnectReason
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Consumer
 
 class ImportBlocksStep(
   private val blockImporter: SealedBeaconBlockImporter<ValidationResult>,

--- a/syncing/src/test/kotlin/maru/syncing/ELSyncServiceTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/ELSyncServiceTest.kt
@@ -8,10 +8,6 @@
  */
 package maru.syncing
 
-import kotlin.concurrent.atomics.AtomicInt
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
-import kotlin.concurrent.atomics.incrementAndFetch
-import kotlin.time.Duration.Companion.seconds
 import maru.consensus.NewBlockHandler
 import maru.core.ext.DataGenerators
 import maru.database.InMemoryBeaconChain
@@ -21,6 +17,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import tech.pegasys.teku.infrastructure.async.SafeFuture
 import testutils.maru.TestablePeriodicTimerFactory
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalAtomicApi::class)
 class ELSyncServiceTest {
@@ -85,8 +85,7 @@ class ELSyncServiceTest {
       }
     var forkChoiceResultToReturn =
       DataGenerators.randomValidForkChoiceUpdatedResult().copy(
-        payloadStatus =
-          DataGenerators.randomValidPayloadStatus().copy(status = ExecutionPayloadStatus.SYNCING),
+        payloadStatus = DataGenerators.randomValidPayloadStatus().copy(status = ExecutionPayloadStatus.SYNCING),
       )
     val blockImportHandler =
       NewBlockHandler<Unit> { SafeFuture.completedFuture(Unit) }

--- a/syncing/src/test/kotlin/maru/syncing/PeerChainTrackerTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/PeerChainTrackerTest.kt
@@ -8,8 +8,6 @@
  */
 package maru.syncing
 
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import maru.core.ext.DataGenerators
 import maru.database.BeaconChain
 import maru.database.InMemoryBeaconChain
@@ -19,6 +17,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testutils.maru.TestablePeriodicTimerFactory
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class PeerChainTrackerTest {
   // Dummy implementation of PeersHeadBlockProvider for testing
@@ -67,21 +67,19 @@ class PeerChainTrackerTest {
     targetChainHeadCalculator = TestSyncTargetSelector()
     timerFactory = TestablePeriodicTimerFactory()
 
-    config =
-      PeerChainTracker.Config(
-        pollingUpdateInterval = 1.seconds,
-      )
+    config = PeerChainTracker.Config(
+      pollingUpdateInterval = 1.seconds,
+    )
 
     // Use the lambda to inject our testable timer
-    peerChainTracker =
-      PeerChainTracker(
-        peersHeadsProvider,
-        syncTargetUpdateHandler,
-        targetChainHeadCalculator,
-        config,
-        timerFactory = timerFactory,
-        beaconChain = beaconChain,
-      )
+    peerChainTracker = PeerChainTracker(
+      peersHeadsProvider,
+      syncTargetUpdateHandler,
+      targetChainHeadCalculator,
+      config,
+      timerFactory = timerFactory,
+      beaconChain = beaconChain,
+    )
   }
 
   @AfterEach

--- a/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/SyncControllerThreadSafetyTest.kt
@@ -8,18 +8,18 @@
  */
 package maru.syncing
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.CyclicBarrier
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.random.Random
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
 
 // These tests employ multiple threads on their own, so they could use some more CPU space than usual
 @Execution(ExecutionMode.SAME_THREAD)

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/CLSyncServiceImplTest.kt
@@ -8,12 +8,6 @@
  */
 package maru.syncing.beaconchain
 
-import java.util.SequencedSet
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration.Companion.seconds
 import linea.timer.JvmTimerFactory
 import linea.timer.TimerFactory
 import maru.config.P2PConfig
@@ -66,6 +60,12 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.networking.p2p.libp2p.MultiaddrPeerAddress
+import java.util.SequencedSet
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
 
 class CLSyncServiceImplTest {
   companion object {
@@ -84,11 +84,10 @@ class CLSyncServiceImplTest {
     fun createForkIdHashProvider(beaconChain: BeaconChain): ForkPeeringManager {
       val consensusConfig: ConsensusConfig =
         QbftConsensusConfig(
-          validatorSet =
-            setOf(
-              Validator(ByteArray(20) { 0 }),
-              Validator(ByteArray(20) { 1 }),
-            ),
+          validatorSet = setOf(
+            Validator(ByteArray(20) { 0 }),
+            Validator(ByteArray(20) { 1 }),
+          ),
           fork = ChainFork(ClFork.QBFT_PHASE0, elFork = ElFork.Prague),
         )
 
@@ -126,30 +125,27 @@ class CLSyncServiceImplTest {
   fun setUp() {
     signatureAlgorithm = SecpCrypto.signatureAlgorithm
     keypair = signatureAlgorithm.generateKeyPair()
-    validators =
-      sortedSetOf(Validator(Util.publicKeyToAddress(keypair.publicKey).bytes.toArray()))
+    validators = sortedSetOf(Validator(Util.publicKeyToAddress(keypair.publicKey).bytes.toArray()))
 
     val genesisTimestamp = DataGenerators.randomTimestamp()
     val (genesisBeaconState, genesisBeaconBlock) = DataGenerators.genesisState(genesisTimestamp, validators)
     targetBeaconChain = spy(InMemoryBeaconChain(genesisBeaconState, genesisBeaconBlock))
     sourceBeaconChain = spy(InMemoryBeaconChain(genesisBeaconState, genesisBeaconBlock))
 
-    targetP2pNetwork =
-      createNetwork(
-        targetBeaconChain,
-        targetNodeKey,
-        0u,
-        InMemoryP2PState(),
-        JvmTimerFactory(),
-      )
-    sourceP2pNetwork =
-      createNetwork(
-        sourceBeaconChain,
-        sourceNodeKey,
-        0u,
-        InMemoryP2PState(),
-        JvmTimerFactory(),
-      )
+    targetP2pNetwork = createNetwork(
+      targetBeaconChain,
+      targetNodeKey,
+      0u,
+      InMemoryP2PState(),
+      JvmTimerFactory(),
+    )
+    sourceP2pNetwork = createNetwork(
+      sourceBeaconChain,
+      sourceNodeKey,
+      0u,
+      InMemoryP2PState(),
+      JvmTimerFactory(),
+    )
 
     createBlocks(
       beaconChain = sourceBeaconChain,
@@ -161,17 +157,16 @@ class CLSyncServiceImplTest {
     )
     peerLookup = spy(targetP2pNetwork.getPeerLookup())
     executorService = Executors.newCachedThreadPool()
-    clSyncService =
-      CLSyncServiceImpl(
-        beaconChain = targetBeaconChain,
-        executorService = executorService,
-        validatorProvider = StaticValidatorProvider(validators),
-        allowEmptyBlocks = true,
-        peerLookup = peerLookup,
-        besuMetrics = TestMetricsSystemAdapter,
-        metricsFacade = TestMetricsFacade,
-        pipelineConfig = defaultPipelineConfig,
-      )
+    clSyncService = CLSyncServiceImpl(
+      beaconChain = targetBeaconChain,
+      executorService = executorService,
+      validatorProvider = StaticValidatorProvider(validators),
+      allowEmptyBlocks = true,
+      peerLookup = peerLookup,
+      besuMetrics = TestMetricsSystemAdapter,
+      metricsFacade = TestMetricsFacade,
+      pipelineConfig = defaultPipelineConfig,
+    )
 
     try {
       targetP2pNetwork.start().get()
@@ -419,12 +414,11 @@ class CLSyncServiceImplTest {
     val p2pNetworkImpl =
       P2PNetworkImpl(
         privateKeyBytes = key,
-        p2pConfig =
-          P2PConfig(
-            ipAddress = IPV4,
-            port = port,
-            staticPeers = emptyList(),
-          ),
+        p2pConfig = P2PConfig(
+          ipAddress = IPV4,
+          port = port,
+          staticPeers = emptyList(),
+        ),
         chainId = CHAIN_ID,
         serDe = RLPSerializers.SealedBeaconBlockSerializer,
         metricsFacade = TestMetricsFacade,

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactoryTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/BeaconChainDownloadPipelineFactoryTest.kt
@@ -8,10 +8,6 @@
  */
 package maru.syncing.beaconchain.pipeline
 
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.seconds
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators.randomSealedBeaconBlock
@@ -34,6 +30,10 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 class BeaconChainDownloadPipelineFactoryTest {
   private lateinit var blockImporter: SealedBeaconBlockImporter<ValidationResult>
@@ -58,14 +58,13 @@ class BeaconChainDownloadPipelineFactoryTest {
     peerLookup = mock()
     executorService = Executors.newCachedThreadPool()
     syncTargetProvider = mock()
-    factory =
-      BeaconChainDownloadPipelineFactory(
-        blockImporter = blockImporter,
-        metricsSystem = NoOpMetricsSystem(),
-        peerLookup = peerLookup,
-        config = defaultPipelineConfig,
-        syncTargetProvider = syncTargetProvider,
-      )
+    factory = BeaconChainDownloadPipelineFactory(
+      blockImporter = blockImporter,
+      metricsSystem = NoOpMetricsSystem(),
+      peerLookup = peerLookup,
+      config = defaultPipelineConfig,
+      syncTargetProvider = syncTargetProvider,
+    )
   }
 
   @AfterEach

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/DownloadBlocksTest.kt
@@ -8,10 +8,6 @@
  */
 package maru.syncing.beaconchain.pipeline
 
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeoutException
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators.randomSealedBeaconBlock
 import maru.core.ext.DataGenerators.randomStatus
@@ -32,6 +28,10 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture
 import tech.pegasys.teku.infrastructure.async.SafeFuture.completedFuture
 import tech.pegasys.teku.networking.p2p.peer.NodeId
 import tech.pegasys.teku.networking.p2p.reputation.ReputationAdjustment
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class DownloadBlocksTest {
   private val defaultEndBlock = 11UL

--- a/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/ImportBlocksStepTest.kt
+++ b/syncing/src/test/kotlin/maru/syncing/beaconchain/pipeline/ImportBlocksStepTest.kt
@@ -8,7 +8,6 @@
  */
 package maru.syncing.beaconchain.pipeline
 
-import java.util.concurrent.CompletionException
 import maru.consensus.blockimport.SealedBeaconBlockImporter
 import maru.core.SealedBeaconBlock
 import maru.core.ext.DataGenerators
@@ -28,6 +27,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.pegasys.teku.infrastructure.async.SafeFuture
+import java.util.concurrent.CompletionException
 
 class ImportBlocksStepTest {
   private lateinit var blockImporter: SealedBeaconBlockImporter<ValidationResult>


### PR DESCRIPTION
https://github.com/Consensys/linea-monorepo/issues/2540


⚠️ Please make sure PR Title conforms to https://www.conventionalcommits.org/en/v1.0.0/#specification.
During the merge squash please be mindful to stick to conventional commits as well ⚠️

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily formatting/linters and editor configuration updates, plus large-scale reformatting with no intended runtime behavior changes.
> 
> **Overview**
> Aligns **formatting/tooling** with Linea monorepo conventions by updating `.editorconfig` and reconfiguring Spotless to use an explicit `ktlint` version plus rule overrides, and pinning `greclipse` for `*.gradle` formatting.
> 
> Applies the new style rules across the codebase (Kotlin sources, tests, and Gradle files), resulting in widespread whitespace/indentation/import-order changes and a few comment/string wrap adjustments, without functional logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6913f533f76d0954a8429b75f7f130530d06c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->