### PR TITLE
Update README with archive notice and new repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> **This repository has been archived and is no longer actively maintained.**
+> The content has been moved to [**Consensys/linea-monorepo**](https://github.com/Consensys/linea-monorepo).
+> Please refer to that repository for the latest implementation of Maru.
+
 # Maru
 A consensus layer client implementing QBFT protocol adhering to Eth 2.0 CL / EL separation and API
 


### PR DESCRIPTION
Added a warning about repository archiving and migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds an archive notice and redirects readers to the new repository.
> 
> **Overview**
> Adds a prominent `WARNING` banner to `README.md` stating the repository is archived and directing users to `Consensys/linea-monorepo` for the maintained Maru implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0c0144e93fe928b546d5d82e07ba1ba03b80ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->